### PR TITLE
DD maintenance duration observability

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1721,6 +1721,7 @@ const KeyRangeRef monitorConfKeys("\xff\x02/monitorConf/"_sr, "\xff\x02/monitorC
 
 const KeyRef healthyZoneKey = "\xff\x02/healthyZone"_sr;
 const StringRef ignoreSSFailuresZoneString = "IgnoreSSFailures"_sr;
+const KeyRef healthyZoneStartVersionKey = "\xff\x02/healthyZoneStartVersion"_sr;
 const KeyRef rebalanceDDIgnoreKey = "\xff\x02/rebalanceDDIgnored"_sr;
 
 Value healthyZoneValue(StringRef const& zoneId, Version version) {

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -778,6 +778,12 @@ extern const KeyRangeRef monitorConfKeys;
 
 extern const KeyRef healthyZoneKey;
 extern const StringRef ignoreSSFailuresZoneString;
+// Stores the version at which the current healthyZoneKey window started. Written and read only by
+// the Data Distributor (fdbserver/datadistributor/DDTeamCollection.actor.cpp), so a DD recruited
+// mid-maintenance can recover the true start version. Without persisting this information the
+// true start time of the maintenance mode would be lost when a DD is recruited during maintenance
+// mode. To preserve the current semantics of healthyZoneKey this additional key was added.
+extern const KeyRef healthyZoneStartVersionKey;
 extern const KeyRef rebalanceDDIgnoreKey;
 namespace DDIgnore {
 enum IgnoreType : uint8_t { NONE = 0, REBALANCE_DISK = 1, REBALANCE_READ = 2, ALL = 3 };

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -2016,6 +2016,8 @@ public:
 						} else if (SERVER_KNOBS->DD_REMOVE_MAINTENANCE_ON_FAILURE &&
 						           self->clearHealthyZoneFuture.isReady()) {
 							self->clearHealthyZoneFuture = clearHealthyZone(self->dbContext());
+							// For now we are not logging the duration here, e.g. in cases where another storage
+							// server outside of the maintenance zone failed.
 							TraceEvent("MaintenanceZoneCleared", self->distributorId).log();
 							self->healthyZone.set(Optional<Key>());
 						}
@@ -2625,23 +2627,50 @@ public:
 		}
 	}
 
+	// Persists the version at which the current maintenance mode was started, so that a DD
+	// recruited mid-maintenance (see getOrRecordMaintenanceStart) can recover the true start.
+	static Version recordNewMaintenanceStart(ReadYourWritesTransaction* tr) {
+		Version version = tr->getReadVersion().get();
+		BinaryWriter bw(Unversioned());
+		bw << version;
+		tr->set(healthyZoneStartVersionKey, bw.toValue());
+		return version;
+	}
+
+	// Adopts the start version persisted by whichever DD instance first observed the current
+	// maintenance mode, for the case where this DD was (re)recruited while the maintenance was active.
+	// Falls back to recording a fresh start now if the key was never written.
+	static Future<Version> getOrRecordMaintenanceStart(ReadYourWritesTransaction* tr) {
+		Optional<Value> startVal = co_await tr->get(healthyZoneStartVersionKey);
+		if (startVal.present()) {
+			co_return BinaryReader::fromStringRef<Version>(startVal.get(), Unversioned());
+		}
+		co_return recordNewMaintenanceStart(tr);
+	}
+
+	// -1.0 if the start version was never established (should only happen if this DD instance
+	// raced a commit failure with a window's start/end); otherwise the elapsed window duration.
+	static double maintenanceDurationSeconds(ReadYourWritesTransaction* tr, Version startVersion) {
+		if (startVersion == invalidVersion) {
+			return -1.0;
+		}
+		return (tr->getReadVersion().get() - startVersion) / (double)SERVER_KNOBS->VERSIONS_PER_SECOND;
+	}
+
 	static Future<Void> waitHealthyZoneChange(DDTeamCollection* self) {
 		auto* counters = waitHealthyZoneChangeCounters();
 		ReadYourWritesTransaction tr(self->dbContext());
-		// maintenanceStartTime tracks the start time when the maintenance mode was started.
-		// This information is used to report the duration of the maintenance mode when the
-		// maintenance zone is removed, either manually or by a timeout. If the DD gets
-		// restarted during the maintenance window the maintenanceStartTime will be reset.
-		// Right now the healthyZoneKey only stores (ZoneID, EndVersion). We could add the 
-		// StartVersion to the tuple, but that might break other clients. Another option would be to store the Start
-		// time in a second key.
-		auto maintenanceStartTime = self->healthyZone.get().present() ? now() : 0.0;
+		// maintenanceStartVersion tracks the version at which the current maintenance/disable-DD
+		// window began, durably persisted via healthyZoneStartVersionKey, so that
+		// MaintenanceZoneEnd*/DataDistributionDisabledForStorageServerFailuresEnd can report an
+		// accurate Duration even if this DD instance was recruited mid-window.
+		Version maintenanceStartVersion = invalidVersion;
 		while (true) {
 			counters->started->increment(1);
 			Error err;
 			bool hasErr = false;
 			try {
-				tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 				Optional<Value> val = co_await tr.get(healthyZoneKey);
 				Future<Void> healthyZoneTimeout = Never();
@@ -2652,7 +2681,9 @@ public:
 						if (self->healthyZone.get() != p.first) {
 							TraceEvent("DataDistributionDisabledForStorageServerFailuresStart", self->distributorId)
 							    .log();
-							maintenanceStartTime = now();
+							maintenanceStartVersion = recordNewMaintenanceStart(&tr);
+						} else if (maintenanceStartVersion == invalidVersion) {
+							maintenanceStartVersion = co_await getOrRecordMaintenanceStart(&tr);
 						}
 						healthyZoneTimeout = Never();
 						self->healthyZone.set(p.first);
@@ -2666,24 +2697,30 @@ public:
 							    .detail("EndVersion", p.second)
 							    .detail("Duration", timeoutSeconds);
 							self->healthyZone.set(p.first);
-							maintenanceStartTime = now();
+							maintenanceStartVersion = recordNewMaintenanceStart(&tr);
+						} else if (maintenanceStartVersion == invalidVersion) {
+							maintenanceStartVersion = co_await getOrRecordMaintenanceStart(&tr);
 						}
 					} else if (self->healthyZone.get().present()) {
 						// maintenance hits timeout
 						TraceEvent("MaintenanceZoneEndTimeout", self->distributorId)
-						    .detail("Duration", now() - maintenanceStartTime);
+						    .detail("Duration", maintenanceDurationSeconds(&tr, maintenanceStartVersion));
 						self->healthyZone.set(Optional<Key>());
+						tr.clear(healthyZoneStartVersionKey);
+						maintenanceStartVersion = invalidVersion;
 					}
 				} else if (self->healthyZone.get().present()) {
 					// `healthyZone` has been cleared
+					double duration = maintenanceDurationSeconds(&tr, maintenanceStartVersion);
 					if (self->healthyZone.get().get() == ignoreSSFailuresZoneString) {
 						TraceEvent("DataDistributionDisabledForStorageServerFailuresEnd", self->distributorId)
-						    .detail("Duration", now() - maintenanceStartTime);
+						    .detail("Duration", duration);
 					} else {
-						TraceEvent("MaintenanceZoneEndManualClear", self->distributorId)
-						    .detail("Duration", now() - maintenanceStartTime);
+						TraceEvent("MaintenanceZoneEndManualClear", self->distributorId).detail("Duration", duration);
 					}
 					self->healthyZone.set(Optional<Key>());
+					tr.clear(healthyZoneStartVersionKey);
+					maintenanceStartVersion = invalidVersion;
 				}
 
 				Future<Void> watchFuture = tr.watch(healthyZoneKey);

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -2628,6 +2628,14 @@ public:
 	static Future<Void> waitHealthyZoneChange(DDTeamCollection* self) {
 		auto* counters = waitHealthyZoneChangeCounters();
 		ReadYourWritesTransaction tr(self->dbContext());
+		// maintenanceStartTime tracks the start time when the maintenance mode was started.
+		// This information is used to report the duration of the maintenance mode when the
+		// maintenance zone is removed, either manually or by a timeout. If the DD gets
+		// restarted during the maintenance window the maintenanceStartTime will be reset.
+		// Right now the healthyZoneKey only stores (ZoneID, EndVersion). We could add the 
+		// StartVersion to the tuple, but that might break other clients. Another option would be to store the Start
+		// time in a second key.
+		auto maintenanceStartTime = self->healthyZone.get().present() ? now() : 0.0;
 		while (true) {
 			counters->started->increment(1);
 			Error err;
@@ -2641,7 +2649,11 @@ public:
 					auto p = decodeHealthyZoneValue(val.get());
 					if (p.first == ignoreSSFailuresZoneString) {
 						// healthyZone is now overloaded for DD disabling purpose, which does not timeout
-						TraceEvent("DataDistributionDisabledForStorageServerFailuresStart", self->distributorId).log();
+						if (self->healthyZone.get() != p.first) {
+							TraceEvent("DataDistributionDisabledForStorageServerFailuresStart", self->distributorId)
+							    .log();
+							maintenanceStartTime = now();
+						}
 						healthyZoneTimeout = Never();
 						self->healthyZone.set(p.first);
 					} else if (p.second > tr.getReadVersion().get()) {
@@ -2654,18 +2666,22 @@ public:
 							    .detail("EndVersion", p.second)
 							    .detail("Duration", timeoutSeconds);
 							self->healthyZone.set(p.first);
+							maintenanceStartTime = now();
 						}
 					} else if (self->healthyZone.get().present()) {
 						// maintenance hits timeout
-						TraceEvent("MaintenanceZoneEndTimeout", self->distributorId).log();
+						TraceEvent("MaintenanceZoneEndTimeout", self->distributorId)
+						    .detail("Duration", now() - maintenanceStartTime);
 						self->healthyZone.set(Optional<Key>());
 					}
 				} else if (self->healthyZone.get().present()) {
 					// `healthyZone` has been cleared
 					if (self->healthyZone.get().get() == ignoreSSFailuresZoneString) {
-						TraceEvent("DataDistributionDisabledForStorageServerFailuresEnd", self->distributorId).log();
+						TraceEvent("DataDistributionDisabledForStorageServerFailuresEnd", self->distributorId)
+						    .detail("Duration", now() - maintenanceStartTime);
 					} else {
-						TraceEvent("MaintenanceZoneEndManualClear", self->distributorId).log();
+						TraceEvent("MaintenanceZoneEndManualClear", self->distributorId)
+						    .detail("Duration", now() - maintenanceStartTime);
 					}
 					self->healthyZone.set(Optional<Key>());
 				}


### PR DESCRIPTION
Right now it's a bit hard to get the duration of the maintenance mode. Depending on the setup this requires querying multiple sources and/or combining the `MaintenanceZoneStart` trace event and the end events (`MaintenanceZoneEndTimeout` or `MaintenanceZoneEndManualClear`). Adding this information directly to the DD trace event makes it easier to observe trends in the maintenance mode duration, especially when the maintenance mode is automatically set and reset by infrastructure tooling like the operator.
