### PR TITLE
Allow TxnTimeout transactions to drain

### DIFF
--- a/fdbserver/workloads/TxnTimeout.cpp
+++ b/fdbserver/workloads/TxnTimeout.cpp
@@ -68,7 +68,8 @@ struct TxnTimeout : TestWorkload {
 			return Void();
 		}
 
-		return timeout(reportErrors(workload(this, db), "TxnTimeoutError"), testDuration, Void());
+		// Let in-flight transactions drain so the final success count includes every attempted transaction.
+		return reportErrors(workload(this, db), "TxnTimeoutError");
 	}
 
 	Future<bool> check(const Database& db) override {


### PR DESCRIPTION
## Summary

`TxnTimeout` counts a transaction before it enters its retry loop, but its workload-level timeout can cancel that transaction before it commits and then report a count mismatch. Let in-flight transactions drain so the strict success/total check remains meaningful while recovery and fault-injection coverage are preserved.

## Validation

- Built `fdbserver` with clang.
- Passed a focused fault-free cancellation regression (`testDuration=4`, `txnMinDuration=7`, six clients): all transactions completed with zero severe events.
- Passed `tests/fast/TxnTimeout.toml` with the two-region, single-replica, RocksDB configuration and fault injection enabled, plus two adjacent seeds; zero check, unexpected, or severe failures.
