### PR TITLE
Fix BulkLoading storage-team starvation in simulation

### DIFF
--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -12,8 +12,11 @@ disableTss = true # TODO(BulkLoad): support TSS. finishMoveShard should wait for
 # would never complete, and the workload's checkSame assertion would fire.
 config = 'triple'
 
-# Pair the pinned redundancy with enough machines to guarantee a disjoint team.
+# Pair the pinned redundancy with storage-class capacity for a disjoint team. Ordinary
+# machines may be assigned a non-storage process class, leaving fewer than six storage
+# machines under triple replication.
 machineCount = 15
+extraStorageMachineCountPerDC = 5
 
 # Without datacenters=1 the simulator picks randomInt(1,4) DCs (SimulatedCluster.cpp
 # line ~1610). When it picks 2, the 15 machines get split ~7-8 per DC, the primary

--- a/tests/fast/BulkLoading.toml
+++ b/tests/fast/BulkLoading.toml
@@ -12,10 +12,11 @@ disableTss = true # TODO(BulkLoad): support TSS. finishMoveShard should wait for
 # would never complete, and the workload's checkSame assertion would fire.
 config = 'triple'
 
-# Pair the pinned redundancy with storage-class capacity for a disjoint team. Ordinary
-# machines may be assigned a non-storage process class, leaving fewer than six storage
-# machines under triple replication.
-machineCount = 15
+# Pair the pinned redundancy with storage-class capacity for a disjoint team. The
+# simulator adds the extra storage count to machineCount before creating ordinary
+# machines, then adds the dedicated storage machines separately. Start with ten so
+# the result is 15 ordinary machines and five dedicated storage machines.
+machineCount = 10
 extraStorageMachineCountPerDC = 5
 
 # Without datacenters=1 the simulator picks randomInt(1,4) DCs (SimulatedCluster.cpp


### PR DESCRIPTION
## Summary

Bulk loading requires a destination team that does not share a storage server with the source team. The fast BulkLoading simulation pins triple replication and 15 machines, but ordinary machines can be assigned non-storage process classes. With only five storage-capable machines, all ten possible triple teams overlap the source and the workload can remain stuck waiting for a valid destination.

Reserve five additional storage-class machines for this test, restoring the storage headroom the workload previously relied on while retaining buggify, fault injection, storage wiggle, and randomized processes per machine.

## Validation

- Built the simulator target with warnings treated as errors.
- Replayed the affected BulkLoading configuration with buggify and fault injection enabled: two disjoint destination teams were selected and the consistency check passed.
- Ran 40 focused buggified, fault-injected BulkLoading simulations across varied process and storage topologies: 40 passed, 0 failed, and 0 no-valid-team warnings.
