### PR TITLE
Align code probe rarity with simulation coverage

### DIFF
--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -6396,7 +6396,7 @@ struct StartFullRestoreTaskFunc : RestoreTaskFuncBase {
 				    .detail("RestoreVersion", restoreVersion)
 				    .detail("Dest", destVersion);
 				if (destVersion <= restoreVersion) {
-					CODE_PROBE(true, "Forcing restored cluster to higher version");
+					CODE_PROBE(true, "Forcing restored cluster to higher version", probe::decoration::rare);
 					tr->set(minRequiredCommitVersionKey, BinaryWriter::toValue(restoreVersion + 1, Unversioned()));
 					co_await tr->commit();
 					tr->reset();

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2893,7 +2893,7 @@ static Future<Void> tssStreamComparison(Request request,
 
 			// skip tss comparison if both are end of stream
 			if ((!ssEndOfStream || !tssEndOfStream) && !TSS_doCompare(ssReply.get(), tssReply.get())) {
-				CODE_PROBE(true, "TSS mismatch in stream comparison");
+				CODE_PROBE(true, "TSS mismatch in stream comparison", probe::decoration::rare);
 				TraceEvent mismatchEvent(
 				    (simulationPolicyHasCapability(ISimulationPolicy::Capability::WarnOnStorageMismatch))
 				        ? SevWarnAlways
@@ -2909,7 +2909,8 @@ static Future<Void> tssStreamComparison(Request request,
 					           "Tracing Full TSS Mismatch in stream comparison",
 					           probe::decoration::rare);
 					CODE_PROBE(!FLOW_KNOBS->LOAD_BALANCE_TSS_MISMATCH_TRACE_FULL,
-					           "Tracing Partial TSS Mismatch in stream comparison and storing the rest in FDB");
+					           "Tracing Partial TSS Mismatch in stream comparison and storing the rest in FDB",
+					           probe::decoration::rare);
 
 					if (!FLOW_KNOBS->LOAD_BALANCE_TSS_MISMATCH_TRACE_FULL) {
 						mismatchEvent.disable();

--- a/fdbclient/NativeCdc.cpp
+++ b/fdbclient/NativeCdc.cpp
@@ -380,10 +380,12 @@ Future<CDCStreamId> registerNativeCdcStream(Database cx, Key name, KeyRange keys
 					throw client_invalid_operation();
 				}
 				if (!(co_await getNativeCdcProxyAssignment(&tr, streamId)).present()) {
-					CODE_PROBE(true, "Native CDC registration restores missing stream owner");
+					CODE_PROBE(true, "Native CDC registration restores missing stream owner", probe::decoration::rare);
 					const Tag tag = co_await getNativeCdcCurrentTag(&tr, streamId);
 					Optional<UID> sharedTagProxy = co_await getNativeCdcProxyAssignmentForTag(&tr, tag);
-					CODE_PROBE(sharedTagProxy.present(), "Native CDC shared-tag streams use one owner");
+					CODE_PROBE(sharedTagProxy.present(),
+					           "Native CDC shared-tag streams use one owner",
+					           probe::decoration::rare);
 					const UID selectedProxy = sharedTagProxy.present() ? sharedTagProxy.get() : proxyId;
 					tr.set(cdcProxyKeyFor(streamId, selectedProxy), Value());
 					signalNativeCdcProxyAssignmentChange(&tr);
@@ -439,7 +441,9 @@ Future<bool> removeNativeCdcStream(Database cx, Key name, CDCStreamId streamId, 
 			const Key nameKey = cdcStreamNameKeyFor(name);
 			Optional<Value> currentId = co_await tr.get(nameKey);
 			if (!nativeCdcNameMatchesStream(currentId, streamId)) {
-				CODE_PROBE(currentId.present(), "Native CDC preserves a replacement stream during removal retry");
+				CODE_PROBE(currentId.present(),
+				           "Native CDC preserves a replacement stream during removal retry",
+				           probe::decoration::rare);
 				if (currentId.present()) {
 					TraceEvent("NativeCdcRemovalPreservesReplacement")
 					    .detail("RemovedStreamId", streamId)
@@ -450,7 +454,7 @@ Future<bool> removeNativeCdcStream(Database cx, Key name, CDCStreamId streamId, 
 
 			Optional<UID> assignedProxy = co_await getNativeCdcProxyAssignment(&tr, streamId);
 			if (!assignedProxy.present() || assignedProxy.get() != proxyId) {
-				CODE_PROBE(true, "Native CDC rejects removal through a stale owner");
+				CODE_PROBE(true, "Native CDC rejects removal through a stale owner", probe::decoration::rare);
 				throw wrong_shard_server();
 			}
 
@@ -669,9 +673,7 @@ Future<CDCStreamId> registerNativeCdcStreamClient(Database cx, Key name, KeyRang
 		if (!registrationEnabled) {
 			Optional<CDCStreamId> existingStream = co_await findNativeCdcStreamId(cx, name);
 			if (cx->clientInfo->get().id != clientInfoId) {
-				CODE_PROBE(true,
-				           "Native CDC registration retries after client info changes during existence check",
-				           probe::decoration::rare);
+				CODE_PROBE(true, "Native CDC registration retries after client info changes during existence check");
 				continue;
 			}
 			if (!existingStream.present()) {
@@ -762,9 +764,7 @@ Future<CDCConsumeReply> NativeCdcConsumer::consumeImpl(Reference<NativeCdcConsum
 			if (rewindUnacknowledgedCursorAfterProxyReplacement(
 			        &self->currentPosition, self->lastAcknowledgedVersion, &self->deliveryProxyId, proxy.id())) {
 				self->knownAvailableThrough = self->lastAcknowledgedVersion;
-				CODE_PROBE(true,
-				           "Native CDC consumer rewinds unacknowledged cursor after proxy replacement",
-				           probe::decoration::rare);
+				CODE_PROBE(true, "Native CDC consumer rewinds unacknowledged cursor after proxy replacement");
 			}
 			try {
 				CDCConsumeReply reply =
@@ -772,7 +772,7 @@ Future<CDCConsumeReply> NativeCdcConsumer::consumeImpl(Reference<NativeCdcConsum
 				if (reply.lastConsumedVersion == self->currentPosition.lastConsumedVersion && reply.mutations.empty()) {
 					// The server lease bounds abandoned long polls. Renew it transparently so the public consume
 					// operation remains a long poll without accumulating server actors after client cancellation.
-					CODE_PROBE(true, "Native CDC consume renews an idle server lease", probe::decoration::rare);
+					CODE_PROBE(true, "Native CDC consume renews an idle server lease");
 					continue;
 				}
 				self->knownAvailableThrough = reply.lastConsumedVersion;

--- a/fdbclient/ReadYourWrites.cpp
+++ b/fdbclient/ReadYourWrites.cpp
@@ -1769,7 +1769,7 @@ Future<MappedRangeResult> ReadYourWritesTransaction::getMappedRange(KeySelector 
 	if (getDatabase()->apiVersionAtLeast(630)) {
 		if (specialKeys.contains(begin.getKey()) && specialKeys.begin <= end.getKey() &&
 		    end.getKey() <= specialKeys.end) {
-			CODE_PROBE(true, "Special key space get range (getMappedRange)", probe::decoration::rare);
+			CODE_PROBE(true, "Special key space get range (getMappedRange)");
 			throw client_invalid_operation(); // Not support special keys.
 		}
 	} else {
@@ -1791,7 +1791,7 @@ Future<MappedRangeResult> ReadYourWritesTransaction::getMappedRange(KeySelector 
 
 	// This optimization prevents nullptr operations from being added to the conflict range
 	if (limits.isReached()) {
-		CODE_PROBE(true, "RYW range read limit 0 (getMappedRange)", probe::decoration::rare);
+		CODE_PROBE(true, "RYW range read limit 0 (getMappedRange)");
 		return MappedRangeResult();
 	}
 
@@ -1805,7 +1805,7 @@ Future<MappedRangeResult> ReadYourWritesTransaction::getMappedRange(KeySelector 
 		end.removeOrEqual(end.arena());
 
 	if (begin.offset >= end.offset && begin.getKey() >= end.getKey()) {
-		CODE_PROBE(true, "RYW range inverted (getMappedRange)", probe::decoration::rare);
+		CODE_PROBE(true, "RYW range inverted (getMappedRange)");
 		return MappedRangeResult();
 	}
 

--- a/fdbserver/cdcproxy/CDCProxy.cpp
+++ b/fdbserver/cdcproxy/CDCProxy.cpp
@@ -452,7 +452,7 @@ Future<CDCStreamReadState> readCDCStreamState(Database cx,
 
 			RangeResult assignedProxies = co_await tr.getRange(cdcProxyRangeFor(streamId), 2);
 			if (assignedProxies.size() != 1 || decodeCDCProxyKey(assignedProxies[0].key).second != expectedProxyId) {
-				CODE_PROBE(true, "CDC proxy rejects request for stream owned elsewhere");
+				CODE_PROBE(true, "CDC proxy rejects request for stream owned elsewhere", probe::decoration::rare);
 				throw wrong_shard_server();
 			}
 
@@ -928,7 +928,7 @@ CDCBufferSelection CDCProxy::selectBufferCandidatesForTag(Reference<CDCBufferedT
 		if (stream == streams.end() || !stream->second->active) {
 			continue;
 		}
-		CODE_PROBE(true, "CDC proxy rejects a version larger than its complete buffer budget");
+		CODE_PROBE(true, "CDC proxy rejects a version larger than its complete buffer budget", probe::decoration::rare);
 		TraceEvent(SevWarn, "CDCProxyVersionExceedsBufferLimit", id)
 		    .detail("Tag", tag->tag)
 		    .detail("StreamId", streamId)
@@ -1142,7 +1142,7 @@ Future<Void> CDCProxy::initializeStream(Reference<CDCBufferedStream> stream) {
 	try {
 		const CDCStreamReadState metadata = co_await readCDCStreamState(cx, stream->streamId, id, true);
 		if (!isCurrentStreamInitialization(streams, stream)) {
-			CODE_PROBE(true, "CDC proxy discards stale stream initialization", probe::decoration::rare);
+			CODE_PROBE(true, "CDC proxy discards stale stream initialization");
 			co_return;
 		}
 		stream->keys = metadata.keys;
@@ -1348,7 +1348,8 @@ Future<Void> CDCProxy::popAcknowledgedData() {
 			co_return;
 		}
 		if (!isCurrentCompletePopLogSystem(currentLogSystem, popLogSystemConfig, popLogSystemRecoveryCount)) {
-			CODE_PROBE(true, "CDC proxy retries retired pops after log system topology changes");
+			CODE_PROBE(
+			    true, "CDC proxy retries retired pops after log system topology changes", probe::decoration::rare);
 			requestAcknowledgedDataPop();
 			co_return;
 		}
@@ -1372,7 +1373,9 @@ Future<Void> CDCProxy::popAcknowledgedData() {
 		}
 	}
 	if (!isCurrentCompletePopLogSystem(currentLogSystem, popLogSystemConfig, popLogSystemRecoveryCount)) {
-		CODE_PROBE(true, "CDC proxy preserves retired pop metadata after log system topology changes");
+		CODE_PROBE(true,
+		           "CDC proxy preserves retired pop metadata after log system topology changes",
+		           probe::decoration::rare);
 		requestAcknowledgedDataPop();
 		co_return;
 	}
@@ -1506,7 +1509,7 @@ Future<Void> CDCProxy::consume(CDCConsumeRequest request) {
 		auto buffered =
 		    co_await race(waitForBufferedVersion(stream, begin), delay(SERVER_KNOBS->CDC_PROXY_CONSUME_POLL_TIMEOUT));
 		if (buffered.index() == 1) {
-			CODE_PROBE(true, "CDC proxy expires an idle consume lease", probe::decoration::rare);
+			CODE_PROBE(true, "CDC proxy expires an idle consume lease");
 			CDCConsumeReply reply;
 			reply.lastConsumedVersion = request.cursor.lastConsumedVersion;
 			request.reply.send(reply);

--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -1677,7 +1677,7 @@ void registerWorker(RegisterWorkerRequest req, ClusterControllerData* self) {
 		self->updateDBInfo.trigger();
 		checkOutstandingRequests(self);
 	} else {
-		CODE_PROBE(true, "Received an old worker registration request.", probe::decoration::rare);
+		CODE_PROBE(true, "Received an old worker registration request.");
 	}
 
 	// For each singleton
@@ -2263,7 +2263,7 @@ Future<Void> monitorCDCProxyAssignmentsPass(ClusterControllerData* self) {
 					tr.clear(cdcProxyRangeFor(streamId));
 					tr.set(cdcProxyKeyFor(streamId, resolvedProxyId), Value());
 					repairedAssignment = true;
-					CODE_PROBE(true, "CDC stream assignment is repaired after missing owner");
+					CODE_PROBE(true, "CDC stream assignment is repaired after missing owner", probe::decoration::rare);
 					TraceEvent("CDCProxyAssignmentMissingRepaired")
 					    .detail("StreamId", streamId)
 					    .detail("CDCProxyID", resolvedProxyId)

--- a/fdbserver/clustercontroller/ClusterHealthIFactor.cpp
+++ b/fdbserver/clustercontroller/ClusterHealthIFactor.cpp
@@ -249,7 +249,9 @@ Future<Level> ProcessErrorsFactor::fetchLevel(Reference<IWorkerEventProvider con
 		CODE_PROBE(trackCodeProbes && hadSuccessfulRequest, "ClusterHealth ProcessErrorsFactor returns HEALTHY");
 		co_return hadSuccessfulRequest ? Level::HEALTHY : Level::METRICS_MISSING;
 	}
-	CODE_PROBE(trackCodeProbes, "ClusterHealth ProcessErrorsFactor returns CRITICAL_INTERVENTION_REQUIRED");
+	CODE_PROBE(trackCodeProbes,
+	           "ClusterHealth ProcessErrorsFactor returns CRITICAL_INTERVENTION_REQUIRED",
+	           probe::decoration::rare);
 	co_return Level::CRITICAL_INTERVENTION_REQUIRED;
 }
 

--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -1006,7 +1006,7 @@ Future<Void> updateRegistration(Reference<ClusterRecoveryData> self, Reference<L
 			                       std::vector<UID>());
 		} else {
 			// The cluster should enter the accepting commits phase soon, and then we will register again
-			CODE_PROBE(true, "cstate is updated but we aren't accepting commits yet", probe::decoration::rare);
+			CODE_PROBE(true, "cstate is updated but we aren't accepting commits yet");
 		}
 	}
 }

--- a/fdbserver/consistencyscan/ConsistencyScan.cpp
+++ b/fdbserver/consistencyscan/ConsistencyScan.cpp
@@ -516,9 +516,7 @@ Future<int> consistencyCheckReadData(UID myId,
 			// should for sure have found it
 			TraceEvent(SevError, "ConsistencyCheck_ShouldHaveFoundInjectedCorruption", myId);
 		} else {
-			CODE_PROBE(true,
-			           "consistency check potentially missed injected corruption due to failures",
-			           probe::decoration::rare);
+			CODE_PROBE(true, "consistency check potentially missed injected corruption due to failures");
 			TraceEvent(SevInfo, "ConsistencyCheck_MissedCorruptionDueToFailures");
 			fdbSimulationPolicyState().updateConsistencyScanState(FDBSimConsistencyScanState::Enabled_InjectCorruption,
 			                                                      FDBSimConsistencyScanState::Enabled_FoundCorruption);
@@ -1145,8 +1143,7 @@ void resetSimCorruptionCheckOnDeath(Reference<ConsistencyScanMemoryState> memSta
 	if (fdbSimulationPolicyState().consistencyScanCorruptor.present() &&
 	    fdbSimulationPolicyState().consistencyScanCorruptor.get().first == memState->csId) {
 		TraceEvent("ConsistencyScan_ResetCorruptionOnDeath");
-		CODE_PROBE(
-		    true, "Consistency Scan skipped corruption check because scan died in the middle", probe::decoration::rare);
+		CODE_PROBE(true, "Consistency Scan skipped corruption check because scan died in the middle");
 		fdbSimulationPolicyState().updateConsistencyScanState(FDBSimConsistencyScanState::Enabled_InjectCorruption,
 		                                                      FDBSimConsistencyScanState::Enabled_FoundCorruption);
 	}
@@ -2127,7 +2124,7 @@ Future<Void> checkDataConsistency(Database cx,
 	}
 
 	if (customReplicatedShards == SERVER_KNOBS->DD_MAX_SHARDS_ON_LARGE_TEAMS && underReplicatedShards > 0) {
-		CODE_PROBE(true, "Reached max shard on large team limit");
+		CODE_PROBE(true, "Reached max shard on large team limit", probe::decoration::rare);
 	}
 
 	*bytesReadInPrevRound = bytesReadInthisRound;

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -305,7 +305,7 @@ Future<MoveKeysLock> readMoveKeysLock(Database cx) {
 			err = e;
 		}
 		co_await tr.onError(err);
-		CODE_PROBE(true, "readMoveKeysLock retry");
+		CODE_PROBE(true, "readMoveKeysLock retry", probe::decoration::rare);
 	}
 }
 
@@ -1953,7 +1953,7 @@ static Future<Void> finishMoveKeys(Database occ,
 					    .detail("TransactionTooOldRetries", consecutiveTransactionTooOldRetries)
 					    .detail("BackoffSeconds", backoff);
 					if (tooManyConsecutiveTransactionTooOldRetries) {
-						CODE_PROBE(true, "finishMoveKeys giving up after max retries");
+						CODE_PROBE(true, "finishMoveKeys giving up after max retries", probe::decoration::rare);
 						TraceEvent(SevWarnAlways, "RelocateShard_FinishMoveKeysGivingUp", relocationIntervalId)
 						    .error(err)
 						    .detail("KeyBegin", keys.begin)

--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -2431,7 +2431,7 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 					throw error;
 				}
 			} else {
-				CODE_PROBE(true, "move keys failed -- removed server or exceeded retries", probe::decoration::rare);
+				CODE_PROBE(true, "move keys failed -- removed server or exceeded retries");
 				healthyDestinations.addDataInFlightToTeam(-metrics.bytes);
 				auto readLoad = metrics.readLoadKSecond();
 				auto& destinationRef = healthyDestinations;

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -4235,7 +4235,7 @@ double DDTeamCollection::loadBytesBalanceRatio(int64_t smallLoadThreshold) const
 	// avoid division-by-zero
 	double avgLoad = totalLoadBytes / count;
 	if (totalLoadBytes == 0 || avgLoad < smallLoadThreshold) {
-		CODE_PROBE(true, "The cluster load is small enough to ignore load bytes balance.");
+		CODE_PROBE(true, "The cluster load is small enough to ignore load bytes balance.", probe::decoration::rare);
 		return 1;
 	}
 

--- a/fdbserver/datadistributor/DDTxnProcessor.cpp
+++ b/fdbserver/datadistributor/DDTxnProcessor.cpp
@@ -410,7 +410,8 @@ class DDTxnProcessorImpl {
 		Optional<Key> healthyZone = co_await getHealthyZone(cx, distributorId);
 		result->initHealthyZoneValue = healthyZone;
 
-		CODE_PROBE((bool)skipDDModeCheck, "DD Mode won't prevent read initial data distribution.");
+		CODE_PROBE(
+		    (bool)skipDDModeCheck, "DD Mode won't prevent read initial data distribution.", probe::decoration::rare);
 		// Get the server list in its own try/catch block since it modifies result.  We don't want a subsequent failure
 		// causing entries to be duplicated
 		// Phase 1: Single transaction to read server list and all persisted data moves

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -5359,7 +5359,9 @@ Future<Void> dataDistributor_impl(DataDistributorInterface di, Reference<DataDis
 					    .detail("SnapUID", snapUID)
 					    .detail("Result", result.isError() ? result.getError().code() : 0);
 				} else if (ddSnapReqMap.contains(snapReq.snapUID)) {
-					CODE_PROBE(true, "Data distributor received a duplicate ongoing snapshot request");
+					CODE_PROBE(true,
+					           "Data distributor received a duplicate ongoing snapshot request",
+					           probe::decoration::rare);
 					TraceEvent("RetryOngoingDistributorSnapRequest").detail("SnapUID", snapUID);
 					ASSERT(snapReq.snapPayload == ddSnapReqMap[snapUID].snapPayload);
 					// Discard the old request if a duplicate new request is received

--- a/fdbserver/grvproxy/GrvProxyServer.cpp
+++ b/fdbserver/grvproxy/GrvProxyServer.cpp
@@ -1253,7 +1253,7 @@ Future<Void> grvProxyServer(GrvProxyInterface proxy,
 		ASSERT(e.code() !=
 		       error_code_broken_promise); // all broken_promise should be transformed to the correct error code
 		CODE_PROBE(e.code() == error_code_master_failed, "GrvProxyServer master failed");
-		CODE_PROBE(e.code() == error_code_tlog_failed, "GrvProxyServer tlog failed");
+		CODE_PROBE(e.code() == error_code_tlog_failed, "GrvProxyServer tlog failed", probe::decoration::rare);
 		CODE_PROBE(e.code() == error_code_failed_to_progress, "GRV proxy failed to progress");
 		if (e.code() != error_code_worker_removed && e.code() != error_code_tlog_stopped &&
 		    e.code() != error_code_tlog_failed && e.code() != error_code_coordinators_changed &&

--- a/fdbserver/logsystem/LogSet.cpp
+++ b/fdbserver/logsystem/LogSet.cpp
@@ -193,8 +193,7 @@ int LogSet::satelliteTagLocationIndex(Tag tag) const {
 	const int locationCount = static_cast<int>(satelliteTagLocations.size());
 	const int directIndex = static_cast<int>(tag.id) + 1;
 	if (tag.locality == tagLocalityCDC) {
-		CODE_PROBE(
-		    directIndex >= locationCount, "CDC tag exceeds the satellite routing table", probe::decoration::rare);
+		CODE_PROBE(directIndex >= locationCount, "CDC tag exceeds the satellite routing table");
 		return static_cast<int>(tag.id % (locationCount - 1)) + 1;
 	}
 	ASSERT_LT(directIndex, locationCount);

--- a/fdbserver/logsystem/LogSystemPeekCursor.cpp
+++ b/fdbserver/logsystem/LogSystemPeekCursor.cpp
@@ -372,7 +372,7 @@ Future<Void> serverPeekParallelGetMoreImpl(ServerPeekCursor* self, TaskPriority 
 				//
 				// A cursor for a log router can be delayed indefinitely during a network partition, so only fail
 				// simulation tests sufficiently far after we finish simulating network partitions.
-				CODE_PROBE(e.code() == error_code_timed_out, "peek cursor timed out");
+				CODE_PROBE(e.code() == error_code_timed_out, "peek cursor timed out", probe::decoration::rare);
 				if (g_network->isSimulated() && now() >= g_simulator->connectionFailureEnableTime +
 				                                             FLOW_KNOBS->SIM_SPEEDUP_AFTER_SECONDS +
 				                                             SERVER_KNOBS->PEEK_TRACKER_EXPIRATION_TIME) {

--- a/fdbserver/resolver/Resolver.cpp
+++ b/fdbserver/resolver/Resolver.cpp
@@ -543,7 +543,7 @@ Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatchReque
 		if (batchItr != proxyInfoItr->second.outstandingBatches.end()) {
 			req.reply.send(batchItr->second);
 		} else {
-			CODE_PROBE(true, "No outstanding batches for version on proxy", probe::decoration::rare);
+			CODE_PROBE(true, "No outstanding batches for version on proxy");
 			req.reply.send(Never());
 		}
 	} else {

--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -1679,7 +1679,7 @@ public:
 		if (g_network->isSimulated() && !g_simulator->speedUpSimulation &&
 		    now() > fdbSimulationPolicyState().injectTargetedSSRestartTime &&
 		    rebootAfterDurableVersion == std::numeric_limits<Version>::max()) {
-			CODE_PROBE(true, "Injecting SS targeted restart");
+			CODE_PROBE(true, "Injecting SS targeted restart", probe::decoration::rare);
 			TraceEvent("SimSSInjectTargetedRestart", thisServerID).detail("Version", v);
 			rebootAfterDurableVersion = v;
 			fdbSimulationPolicyState().injectTargetedSSRestartTime = std::numeric_limits<double>::max();
@@ -1689,7 +1689,7 @@ public:
 	bool maybeInjectDelay() {
 		if (g_network->isSimulated() && !g_simulator->speedUpSimulation &&
 		    now() > fdbSimulationPolicyState().injectSSDelayTime) {
-			CODE_PROBE(true, "Injecting SS targeted delay");
+			CODE_PROBE(true, "Injecting SS targeted delay", probe::decoration::rare);
 			TraceEvent("SimSSInjectDelay", thisServerID).log();
 			fdbSimulationPolicyState().injectSSDelayTime = std::numeric_limits<double>::max();
 			return true;

--- a/fdbserver/tlog/TLogServer.cpp
+++ b/fdbserver/tlog/TLogServer.cpp
@@ -183,7 +183,7 @@ private:
 
 			Standalone<StringRef> e = co_await self->queue->readNext(payloadSize + 1);
 			if (e.size() != payloadSize + 1) {
-				CODE_PROBE(true, "Zero fill within payload", probe::decoration::rare);
+				CODE_PROBE(true, "Zero fill within payload");
 				zeroFillSize = payloadSize + 1 - e.size();
 				break;
 			}
@@ -199,7 +199,7 @@ private:
 			}
 		}
 		if (zeroFillSize) {
-			CODE_PROBE(true, "Fixing a partial commit at the end of the tlog queue", probe::decoration::rare);
+			CODE_PROBE(true, "Fixing a partial commit at the end of the tlog queue");
 			for (int i = 0; i < zeroFillSize; i++)
 				self->queue->push(StringRef((const uint8_t*)"", 1));
 		}
@@ -2345,8 +2345,7 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 				}
 				if (sequenceData.isSet()) {
 					if (sequenceData.getFuture().get().first != rep.end) {
-						CODE_PROBE(
-						    true, "tlog peek second attempt ended at a different version", probe::decoration::rare);
+						CODE_PROBE(true, "tlog peek second attempt ended at a different version");
 						replyPromise.sendError(operation_obsolete());
 						co_return;
 					}

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -580,9 +580,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 	}
 
 	void recordDurableAckProxyReplacement() {
-		CODE_PROBE(true,
-		           "Native CDC durable acknowledgement validation retries after proxy replacement",
-		           probe::decoration::rare);
+		CODE_PROBE(true, "Native CDC durable acknowledgement validation retries after proxy replacement");
 	}
 
 	Future<CDCProxyBufferStatus> getCurrentProxyStatus(Database cx,
@@ -714,7 +712,9 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 			ASSERT_LT(now(), deadline);
 			co_await delay(0.01);
 		}
-		CODE_PROBE(followedProxyReplacement, "Native CDC pop progress validation follows proxy replacement");
+		CODE_PROBE(followedProxyReplacement,
+		           "Native CDC pop progress validation follows proxy replacement",
+		           probe::decoration::rare);
 		stopped->set(true);
 		co_await timeoutError(requester, operationTimeout);
 	}
@@ -1018,8 +1018,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 				if (status.popRequests != scanInitial.popRequests) {
 					unrelatedPopRequest = true;
 					CODE_PROBE(true,
-					           "Native CDC durable acknowledgement scan retries after an unrelated proxy pop wake",
-					           probe::decoration::rare);
+					           "Native CDC durable acknowledgement scan retries after an unrelated proxy pop wake");
 					break;
 				}
 				if (status.bufferedBytes < scanInitial.bufferedBytes &&
@@ -1277,8 +1276,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 					ASSERT(found != stream->expected.end());
 					ASSERT_LE(versioned.version, found->second.committedVersion);
 					CODE_PROBE(versioned.version < found->second.committedVersion,
-					           "Native CDC validation accepts a committed retry before the returned commit version",
-					           probe::decoration::rare);
+					           "Native CDC validation accepts a committed retry before the returned commit version");
 					ASSERT(found->second.observedVersions.insert(versioned.version).second);
 				}
 			}


### PR DESCRIPTION
## Summary

- Mark 24 infrequently exercised client and server code probes as rare.
- Remove rare annotations from 21 code probes exercised at least 10 times in a 1M-test ensemble.
- Preserve every existing probe condition and runtime behavior while keeping simulation coverage reports focused on expected non-rare paths.
- Leave generated status-schema coverage unchanged.

## Validation

- `git diff --check`
- `git clang-format --diff origin/main`
- Build `fdbclient_test` and run its `/NativeCDC` and `/fdbclient/NativeAPI` suites.
- Build `fdbserver`.
