### PR TITLE
Avoid bulk-load lookup trace storms during data distribution

### DIFF
--- a/fdbserver/datadistributor/DataDistribution.h
+++ b/fdbserver/datadistributor/DataDistribution.h
@@ -731,9 +731,11 @@ public:
 				res = bulkLoadTask;
 			}
 		}
-		TraceEvent(SevDebug, "DDBulkLoadTaskCollectionGetPublishedTask", ddId)
-		    .detail("Range", range)
-		    .detail("Task", res.present() ? describe(res.get()) : "");
+		if (res.present()) {
+			TraceEvent(SevDebug, "DDBulkLoadTaskCollectionGetPublishedTask", ddId)
+			    .detail("Range", range)
+			    .detail("Task", describe(res.get()));
+		}
 		return res;
 	}
 


### PR DESCRIPTION
## Summary

Data Distribution probes the bulk-load task collection for every relocation, even when no bulk-load job exists. Its lookup logged a debug event for every empty result, so the pipeline-saturation simulation could emit more than 850,000 useless records and exceed the simulator's one-million-line trace limit.

Only emit the existing published-task lookup diagnostic when a matching task exists. This preserves actual bulk-load task diagnostics and leaves task selection, relocation scheduling, simulator randomness, fault injection, and workload configuration unchanged.

## Validation

- Built the targeted Data Distribution unit-test executable with clang; four focused simulation-mode relocation-queue and shard-tracker tests passed.
- Built the complete clang correctness package successfully.
- Ran three buggified, fault-injected `DDPipelineSaturation` simulations, including the previously failing configuration. All passed, preserved pipeline-full coverage, emitted zero empty-task lookup events, and remained below the trace-line limit.
- Ran a buggified, fault-injected `BulkLoading` simulation. It passed and retained published-task, successful-lookup, task-start, and data-move diagnostics for real bulk-load tasks.
