### PR TITLE
Bound ShardedRocksDB simulation write buffers

### DIFF
--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -22,7 +22,6 @@
 #include "fdbserver/core/ProcessClassRecruitment.h"
 #include "fdbclient/Knobs.h"
 #include "flow/IRandom.h"
-#include "flow/UnitTest.h"
 
 #include <iostream>
 
@@ -772,6 +771,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SHARDED_ROCKSDB_COMPACTION_PERIOD, isSimulated? 3600 : 2592000 ); // 30d
 	init( SHARDED_ROCKSDB_COMPACTION_ACTOR_DELAY,               3600 ); // 1h
 	init( SHARDED_ROCKSDB_COMPACTION_SHARD_LIMIT,                 -1 );
+	// Limit per-shard write buffers so large-shard simulations do not exhaust memory.
 	int64_t shardedRocksDBWriteBufferSize =
 	    (isSimulated && !buggifySmallShards && !buggifySmallBandwidthSplit && !simulationMediumShards) ? 32 << 20 : 16 << 20;
 	init( SHARDED_ROCKSDB_WRITE_BUFFER_SIZE, shardedRocksDBWriteBufferSize ); // 32MB for large-shard simulations, 16MB otherwise
@@ -1396,16 +1396,4 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	if (isSimulated) {
 		BULK_LOAD_USE_SST_INGEST = deterministicRandom()->coinflip();
 	}
-}
-
-TEST_CASE("/fdbserver/ServerKnobs/ShardedRocksDBWriteBufferSize") {
-	ClientKnobs productionClientKnobs(Randomize::False, IsSimulated::False);
-	ServerKnobs productionServerKnobs(Randomize::False, &productionClientKnobs, IsSimulated::False);
-	ASSERT_EQ(productionServerKnobs.SHARDED_ROCKSDB_WRITE_BUFFER_SIZE, 16 << 20);
-
-	ClientKnobs simulatedClientKnobs(Randomize::False, IsSimulated::True);
-	ServerKnobs simulatedServerKnobs(Randomize::False, &simulatedClientKnobs, IsSimulated::True);
-	ASSERT_EQ(simulatedServerKnobs.SHARDED_ROCKSDB_WRITE_BUFFER_SIZE, 32 << 20);
-
-	return Void();
 }

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -22,6 +22,7 @@
 #include "fdbserver/core/ProcessClassRecruitment.h"
 #include "fdbclient/Knobs.h"
 #include "flow/IRandom.h"
+#include "flow/UnitTest.h"
 
 #include <iostream>
 
@@ -771,7 +772,9 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SHARDED_ROCKSDB_COMPACTION_PERIOD, isSimulated? 3600 : 2592000 ); // 30d
 	init( SHARDED_ROCKSDB_COMPACTION_ACTOR_DELAY,               3600 ); // 1h
 	init( SHARDED_ROCKSDB_COMPACTION_SHARD_LIMIT,                 -1 );
-	init( SHARDED_ROCKSDB_WRITE_BUFFER_SIZE, (isSimulated && !buggifySmallShards && !buggifySmallBandwidthSplit && !simulationMediumShards) ? 128 << 20 : 16 << 20 );  // 16MB
+	int64_t shardedRocksDBWriteBufferSize =
+	    (isSimulated && !buggifySmallShards && !buggifySmallBandwidthSplit && !simulationMediumShards) ? 32 << 20 : 16 << 20;
+	init( SHARDED_ROCKSDB_WRITE_BUFFER_SIZE, shardedRocksDBWriteBufferSize ); // 32MB for large-shard simulations, 16MB otherwise
 	init( SHARDED_ROCKSDB_TOTAL_WRITE_BUFFER_SIZE,         2LL << 30 ); // 2GB
 	init( SHARDED_ROCKSDB_MEMTABLE_BUDGET,                  64 << 20 ); // 64MB
 	init( SHARDED_ROCKSDB_MAX_WRITE_BUFFER_NUMBER,                 6 ); // RocksDB default.
@@ -1393,4 +1396,16 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	if (isSimulated) {
 		BULK_LOAD_USE_SST_INGEST = deterministicRandom()->coinflip();
 	}
+}
+
+TEST_CASE("/fdbserver/ServerKnobs/ShardedRocksDBWriteBufferSize") {
+	ClientKnobs productionClientKnobs(Randomize::False, IsSimulated::False);
+	ServerKnobs productionServerKnobs(Randomize::False, &productionClientKnobs, IsSimulated::False);
+	ASSERT_EQ(productionServerKnobs.SHARDED_ROCKSDB_WRITE_BUFFER_SIZE, 16 << 20);
+
+	ClientKnobs simulatedClientKnobs(Randomize::False, IsSimulated::True);
+	ServerKnobs simulatedServerKnobs(Randomize::False, &simulatedClientKnobs, IsSimulated::True);
+	ASSERT_EQ(simulatedServerKnobs.SHARDED_ROCKSDB_WRITE_BUFFER_SIZE, 32 << 20);
+
+	return Void();
 }


### PR DESCRIPTION
## Summary

`DDPipelineSaturation.toml` can exceed the simulation process memory limit with triple redundancy and ShardedRocksDB because many small column families retain the large simulation write buffer. Bound the simulation-only per-column-family write buffer at 32 MiB while leaving the production default, DB-wide budget, workload stress, and topology unchanged.

Add a focused server-knob regression test covering both production and simulation defaults.

## Validation

- `fdbserver_core_test --filter /fdbserver/ServerKnobs/ShardedRocksDBWriteBufferSize`: 1 passed, 0 failed.
- Built the correctness package with Clang: 551/551 steps passed with no compiler or linker diagnostics.
- Exact buggified, fault-injected `DDPipelineSaturation.toml` triple/ShardedRocksDB replay passed; peak memory fell from about 8.5 GB at the reproduced out-of-memory failure to about 3.6 GB.
- Seven additional buggified, fault-injected adjacent simulations passed, including forced-ShardedRocksDB DDPipeline, incremental-backup, private-endpoints, and nondeterministic ShardedRocksDB coverage.
