### PR TITLE
Retry native CDC recovery on the master machine

### DIFF
--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -1167,11 +1167,11 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		ASSERT(g_network->isSimulated());
 		const uint64_t recoveryCount = dbInfo->get().recoveryCount;
 		while (true) {
-			const auto masterZone = dbInfo->get().master.locality.zoneId();
-			if (g_simulator->killZone(masterZone, ISimulator::KillType::Reboot, true)) {
+			const auto masterMachine = dbInfo->get().master.locality.machineId();
+			if (g_simulator->killMachine(masterMachine, ISimulator::KillType::Reboot, true)) {
 				break;
 			}
-			co_await dbInfo->onChange();
+			co_await (dbInfo->onChange() || delay(1.0));
 		}
 		co_await timeoutError(waitForTransactionSystemRecoveryAfter(recoveryCount), operationTimeout);
 	}


### PR DESCRIPTION
## Summary

- Reboot the machine hosting the current master when forcing Native CDC retired-tag recovery, rather than treating a reboot of another machine in the same failure zone as success.
- Retry once a partially rebooted master machine becomes available while still waking immediately for cluster-information changes.
- Preserve the existing retired-tag assertions, generated topology, storage configuration, and failure-injection workloads.

## Validation

- Clang build of the FoundationDB simulation workload library and correctness package.
- Native CDC retired-recovery simulations, including the previously failing configuration and adjacent single-region and multi-region cases.
- Native CDC end-to-end and satellite simulations with fault injection enabled.
- Additional retired-recovery coverage with both buggify and fault injection enabled.
