### PR TITLE
Bound fuzzed watch waits to the workload deadline

### DIFF
--- a/fdbserver/workloads/FuzzApiCorrectness.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.cpp
@@ -125,6 +125,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 	    testCases;
 
 	double testDuration;
+	double workloadDeadline = 0.0;
 	int numOps;
 	bool rarelyCommit, adjacentKeys;
 	int minNode, nodes;
@@ -303,6 +304,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 
 	Future<Void> loadAndRun(FuzzApiCorrectnessWorkload* self, Database cx) {
 		double startTime = now();
+		self->workloadDeadline = startTime + self->testDuration;
 		int nodesPerTenant = std::max<int>(1, self->nodes / (self->numTenants + 1));
 		int keysPerBatch =
 		    std::min<int64_t>(1000,
@@ -502,7 +504,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 					co_await unsafeThreadFutureToFuture(*i);
 				}
 
-				co_await timeoutError(ready(future), 1000);
+				co_await timeoutError(ready(future), self->operationTimeout());
 
 				if (future.isError()) {
 					err = future.getError();
@@ -534,6 +536,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 		}
 
 		virtual ThreadFuture<value_type> createFuture(Reference<ITransaction> tr) = 0;
+		virtual double operationTimeout() const { return 1000.0; }
 		virtual Void errorCheck(Reference<ITransaction> tr, value_type result) { return Void(); }
 		virtual void augmentTrace(TraceEvent& e) const { e.detail("Id", id); }
 
@@ -1295,6 +1298,9 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 		}
 
 		ThreadFuture<value_type> createFuture(Reference<ITransaction> tr) override { return tr->watch(key); }
+		double operationTimeout() const override {
+			return std::min(1000.0, std::max(0.0, workload->workloadDeadline - now()));
+		}
 
 		void augmentTrace(TraceEvent& e) const override {
 			base_type::augmentTrace(e);


### PR DESCRIPTION
## Summary

- Keep fuzzed transaction watches within the configured FuzzApiCorrectness workload deadline.
- Preserve the existing timeout for every other API operation and retain all watch creation, expected-error, storage-engine, rollback, clogging, and attrition coverage.
- Prevent valid watches from repeatedly waiting for an uncommitted transaction long after the workload should finish.

## Validation

- Clang builds of `fdbserver_workloads` and `package_tests_u`.
- Seeded `tests/fast/FuzzApiCorrectness.toml` simulation with fault injection.
- `tests/fast/FuzzApiCorrectnessClean.toml` simulation.
- `tests/fast/Watches.toml` simulation.
- `tests/fast/WatchCommitTimeout.toml` simulation.
