### PR TITLE
Backport 7.4: Lower MinimumThroughput expectedRate from 0.8 to 0.5

### DIFF
--- a/tests/fast/MinimumThroughput.toml
+++ b/tests/fast/MinimumThroughput.toml
@@ -11,4 +11,4 @@ connectionFailuresDisableDuration = 100000
     transactionsPerSecond = 200.0
     nodeCount = 100000
     readFraction = 0.5
-    expectedRate = 0.8
+    expectedRate = 0.5


### PR DESCRIPTION
The test was introduced in a965d54d49 (PR #13412) and has been failing regularly in nightlies on seed 2555715869, etc. (no buggify) — the workload sustains between 50-80% of the 200 TPS target under simulation overhead (shard metadata audit, etc.), so the 80% threshold is too aggressive.