### PR TITLE
Fail ClientMetric workload when metric verification times out

### DIFF
--- a/fdbserver/workloads/ClientMetric.cpp
+++ b/fdbserver/workloads/ClientMetric.cpp
@@ -37,6 +37,7 @@ struct ClientMetricWorkload : TestWorkload {
 	double samplingProbability;
 	double testDuration;
 	bool toSet;
+	bool completed = false;
 	int64_t trInfoSizeLimit;
 	std::vector<Future<Void>> clients;
 
@@ -226,13 +227,20 @@ struct ClientMetricWorkload : TestWorkload {
 			uint64_t vs2 = co_await self->writeKeysAndGetLatencyVersion(cx, self, secondWrites, vs1);
 			std::cout << "vs2=" << vs2 << std::endl;
 			ASSERT(vs2 > vs1);
+			self->completed = true;
 
 		} catch (Error& e) {
 			TraceEvent("ClientMetricError").error(e);
 		}
 	}
 
-	Future<bool> check(Database const& cx) override { return true; }
+	Future<bool> check(Database const& cx) override {
+		if (clientId != 0 || completed) {
+			return true;
+		}
+		TraceEvent(SevError, "ClientMetricCheckFailed").detail("Reason", "WorkloadDidNotComplete");
+		return false;
+	}
 
 	void getMetrics(std::vector<PerfMetric>& m) override {}
 };


### PR DESCRIPTION
## Summary

- Record completion only after the active client observes two strictly increasing client-latency metric versions.
- Emit `ClientMetricCheckFailed` at error severity and fail workload checking if metric verification times out or exits early.
- Keep non-participating clients successful and preserve retry limits, restart topology, fault injection, and simulation scheduling.

## Validation

- Clang `package_tests_u` build: passed.
- Paired `tests/restarting/from_7.3.49/ClientMetricRestart-{1,2}.toml` simulation with standard settings: passed.
- Delayed-client-metric regression: confirmed the baseline false pass and verified that the candidate emits `ClientMetricCheckFailed` and fails as expected.
- Adjacent restart simulation with standard settings: passed.
