### PR TITLE
Keep simulated low-disk TLog handling local

### DIFF
--- a/fdbserver/tlog/TLogServer.cpp
+++ b/fdbserver/tlog/TLogServer.cpp
@@ -3459,9 +3459,8 @@ static void failIfTLogCannotAcceptNewData(TLogData* self, Reference<LogData> log
 		    .detail("QueueDiskBytesAvailable", queueBytes.available)
 		    .detail("QueueDiskBytesTotal", queueBytes.total)
 		    .detail("Version", ver);
-		if (self->shouldAcceptNewData(kvStoreBytes, queueBytes, 0.0)) {
-			return;
-		}
+		// Bypass only this simulated pull; do not speed up the whole simulation.
+		return;
 	}
 	CODE_PROBE(true, "pullAsyncData blocked by TLOG_MIN_AVAILABLE_SPACE_RATIO", probe::decoration::rare);
 	// Outside speedUpSimulation, fail recovery and temporarily exclude this worker from TLog recruitment until disk

--- a/fdbserver/tlog/TLogServer.cpp
+++ b/fdbserver/tlog/TLogServer.cpp
@@ -3450,7 +3450,8 @@ static void failIfTLogCannotAcceptNewData(TLogData* self, Reference<LogData> log
 		return;
 	}
 	if (g_network->isSimulated() && !g_simulator->speedUpSimulation) {
-		TraceEvent(SevWarnAlways, "TLogPullAsyncDataLowDiskSpeedUpSimulation", logData->logId)
+		TraceEvent(SevWarnAlways, "TLogPullAsyncDataLowDiskSimulationBypass", logData->logId)
+		    .suppressFor(60.0)
 		    .detail("MinAvailableSpaceRatio", minAvailableSpaceRatio)
 		    .detail("AvailableSpaceRatio", self->availableSpaceRatio(kvStoreBytes, queueBytes))
 		    .detail("KvstoreBytesAvailable", kvStoreBytes.available)
@@ -3458,8 +3459,7 @@ static void failIfTLogCannotAcceptNewData(TLogData* self, Reference<LogData> log
 		    .detail("QueueDiskBytesAvailable", queueBytes.available)
 		    .detail("QueueDiskBytesTotal", queueBytes.total)
 		    .detail("Version", ver);
-		g_simulator->speedUpSimulation = true;
-		if (self->shouldAcceptNewData(kvStoreBytes, queueBytes, effectiveTLogMinAvailableSpaceRatio())) {
+		if (self->shouldAcceptNewData(kvStoreBytes, queueBytes, 0.0)) {
 			return;
 		}
 	}


### PR DESCRIPTION
## Summary

A simulated low-disk transaction log currently enables simulator-wide speedup to bypass its local disk-space threshold. Enabling speedup already makes the effective threshold zero, so the existing path unconditionally accepts the simulated pull. However, changing global simulator state also disables transaction profiling and can prevent client metrics from advancing after an otherwise successful restart.

- Express the existing simulation-only low-disk bypass with a direct return after the local diagnostic.
- Preserve production disk thresholds, transaction-log recovery, failure injection, and the client's strict metric-completion checks without enabling simulator-wide speedup.
- Rename and rate-limit the simulation-only low-disk diagnostic to prevent warning floods.

## Validation

- Clang `fdbserver_tlog_test`.
- Three paired `tests/restarting/from_7.3.49/ClientMetricRestart-{1,2}.toml` regressions covering six successful restart phases, both historical upgrade binaries, buggify, fault injection, and increasing persisted client-metric versions.
