### PR TITLE
Require double redundancy in RangeLockCycle test to avoid known single-replica recovery limitation

### DIFF
--- a/tests/fast/RangeLockCycle.toml
+++ b/tests/fast/RangeLockCycle.toml
@@ -1,6 +1,12 @@
 [configuration]
 tenantModes = ['disabled'] # do not support tenant
 encryptModes = ['disabled'] # do not support encryption
+# Require at least double redundancy. With single storage replication, a rapid
+# recovery-generation handoff during initial database bring-up can orphan the
+# sole (not-yet-durable) seed storage server via PeekPoppedTLogData, leaving the
+# database permanently without storage servers and timing out the starting
+# configuration. Extra replicas keep the database available across that handoff.
+minimumReplication = 2
 
 [[knobs]]
 enable_read_lock_on_range = true


### PR DESCRIPTION
Problem - With single storage replication, a rapid recovery-generation handoff during initial database bring up can orphan the sole seed storage server before it makes the seed data durable: the superseding recovery pops the previous generation's TLogs, the still-catching-up storage server hits PeekPoppedTLogData and is removed (KVS deleted), and because there is only one replica no storage server remains and none is re-seeded. The database is then permanently unavailable and the test's starting-configuration change times out. This is a known limitation in FDB. In practice, this does not happen because mostly people have storage replication > 1 (e.g. 3), and also, it only happens for clusters that are being bootstrapped. Even in those cases, a CC restart mitigates the issue. 

Solution - Forcing at least double redundancy keeps the database available across the handoff, matching how other startup-sensitive tests (e.g. LowLatency) pin minimumReplication.

Testing - Running RangeLock test 10K times: 20260724-231250-praza-release-7.4-sim-failu-b5f2f582307981b3 compressed=True data_size=40537133 fail_fast=10 max_runs=10000 priority=100 sanity=False submitted=20260724-231250 timeout=5400 username=praza-release-7.4-sim-failures-76971348d4c6f738edd286d1f24661125b153607
