### PR TITLE
Fix coordinator queue recovery in restarted simulations

### DIFF
--- a/fdbserver/coordinator/Coordination.cpp
+++ b/fdbserver/coordinator/Coordination.cpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 
 #include "fdbserver/coordinator/CoordinationServer.h"
+#include "fdbserver/core/FDBSimulationPolicy.h"
 #include "fdbserver/core/Knobs.h"
 #include "OnDemandStore.h"
 #include "fdbserver/core/WorkerInterface.h"
@@ -874,7 +875,9 @@ Future<Void> leaderServer(LeaderElectionRegInterface interf,
 	co_await server.run();
 }
 
-Future<Void> coordinationServer(std::string dataFolder, Reference<IClusterConnectionRecord> ccr) {
+static Future<Void> coordinationServerOnce(std::string dataFolder,
+                                           Reference<IClusterConnectionRecord> ccr,
+                                           bool* repairedIncompleteQueue) {
 	UID myID = deterministicRandom()->randomUniqueID();
 	LeaderElectionRegInterface myLeaderInterface(g_network);
 	GenerationRegInterface myInterface(g_network);
@@ -921,7 +924,8 @@ Future<Void> coordinationServer(std::string dataFolder, Reference<IClusterConnec
 	// queue state on the coordinator. In the long term, we should either
 	// modify simulation to consider injected errors as fatal or allow the
 	// coordinator to manually fix disk queue state in real clusters.
-	if (g_network->isSimulated() && g_simulator->speedUpSimulation && err.code() == error_code_file_not_found) {
+	if (g_network->isSimulated() && (g_simulator->speedUpSimulation || fdbSimulationPolicyState().restarted) &&
+	    err.code() == error_code_file_not_found) {
 		std::vector<Future<Reference<IAsyncFile>>> fs;
 		fs.reserve(2);
 		for (int i = 0; i < 2; ++i) {
@@ -956,9 +960,36 @@ Future<Void> coordinationServer(std::string dataFolder, Reference<IClusterConnec
 			co_await IAsyncFileSystem::filesystem()->deleteFile(joinPath(dataFolder, fileCoordinatorPrefix + "0.fdq"),
 			                                                    true);
 		}
+		if (repairedIncompleteQueue != nullptr) {
+			*repairedIncompleteQueue = true;
+		}
 	}
 
 	throw err;
+}
+
+static Future<Void> restartCoordinationServer(std::string dataFolder, Reference<IClusterConnectionRecord> ccr) {
+	while (true) {
+		bool repairedIncompleteQueue = false;
+		try {
+			co_await coordinationServerOnce(dataFolder, ccr, &repairedIncompleteQueue);
+			co_return;
+		} catch (Error& e) {
+			if (e.code() != error_code_file_not_found || !repairedIncompleteQueue) {
+				throw;
+			}
+		}
+
+		TraceEvent("CoordinatorRetryAfterIncompleteQueue").detail("Folder", dataFolder);
+		co_await delay(0);
+	}
+}
+
+Future<Void> coordinationServer(std::string dataFolder, Reference<IClusterConnectionRecord> ccr) {
+	if (g_network->isSimulated() && fdbSimulationPolicyState().restarted) {
+		return restartCoordinationServer(dataFolder, ccr);
+	}
+	return coordinationServerOnce(dataFolder, ccr, nullptr);
 }
 
 Future<Void> changeClusterDescription(std::string datafolder, KeyRef newClusterKey, KeyRef oldClusterKey) {


### PR DESCRIPTION
## Problem

A simulated cluster restart can preserve an incompletely created coordinator
disk queue. Opening the partial queue terminates its coordinator and a
colocated healthy transaction log, preventing cluster recovery from satisfying
the existing log replication policy.

## Fix

Extend the existing simulation-only coordinator disk queue repair to restarted
simulations while preserving its current speed-up simulation behavior. Keep the
verification that exactly one coordinator queue file is missing, then retry the
coordinator only after the failed actor has released its resources. This keeps
the colocated transaction log available without changing production coordinator
failure propagation, transaction-log durability, ordinary simulations, or test
configuration.

## Validation

- `fdbserver_coordinator_test`.
- Complete `tests/restarting/from_7.3.0/ConfigureTestRestart-1.toml` and
  `tests/restarting/from_7.3.0/ConfigureTestRestart-2.toml` restart regression.
