### PR TITLE
Apply Flow AST-grep cleanups

### DIFF
--- a/fdbserver/cdcproxy/CDCProxy.cpp
+++ b/fdbserver/cdcproxy/CDCProxy.cpp
@@ -1161,7 +1161,7 @@ Future<Void> CDCProxy::initializeStream(Reference<CDCBufferedStream> stream) {
 		for (const auto& interval : stream->tagIntervals) {
 			auto tag = tags.find(interval.tag);
 			if (tag == tags.end()) {
-				Reference<CDCBufferedTag> newTag = makeReference<CDCBufferedTag>(interval.tag);
+				auto newTag = makeReference<CDCBufferedTag>(interval.tag);
 				tag = tags.emplace(interval.tag, newTag).first;
 				tag->second->streamIds.insert(stream->streamId);
 				actors.add(bufferTag(newTag));
@@ -1411,7 +1411,7 @@ void CDCProxy::reconcileStreams() {
 		if (proxyId == id) {
 			assignedStreams.insert(streamId);
 			if (!streams.contains(streamId)) {
-				Reference<CDCBufferedStream> stream = makeReference<CDCBufferedStream>(streamId);
+				auto stream = makeReference<CDCBufferedStream>(streamId);
 				streams.emplace(streamId, stream);
 				actors.add(initializeStream(stream));
 			}
@@ -1968,8 +1968,8 @@ TEST_CASE("/NativeCDC/LagMetrics") {
 
 TEST_CASE("/NativeCDC/StreamInitializationLifecycle") {
 	std::unordered_map<CDCStreamId, Reference<CDCBufferedStream>> streams;
-	Reference<CDCBufferedStream> stream = makeReference<CDCBufferedStream>(1);
-	Reference<CDCBufferedStream> replacement = makeReference<CDCBufferedStream>(1);
+	auto stream = makeReference<CDCBufferedStream>(1);
+	auto replacement = makeReference<CDCBufferedStream>(1);
 
 	ASSERT(!isCurrentStreamInitialization(streams, stream));
 	streams.emplace(stream->streamId, stream);

--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -3508,7 +3508,7 @@ TEST_CASE("/DataDistribution/DDQueue/RetryDestinationTeamFailure") {
 }
 
 TEST_CASE("/DataDistribution/DDQueue/SerializeRelocatorError") {
-	Reference<DDQueue> self = makeReference<DDQueue>();
+	auto self = makeReference<DDQueue>();
 	DDQueueImpl::RunState state(self);
 	Promise<Void> error;
 	Future<Void> propagated;

--- a/fdbserver/worker/worker.cpp
+++ b/fdbserver/worker/worker.cpp
@@ -1355,7 +1355,7 @@ Future<Void> healthMonitor(Reference<AsyncVar<Optional<ClusterControllerFullInte
 			nextHealthCheckDelay = delay(SERVER_KNOBS->WORKER_HEALTH_MONITOR_INTERVAL);
 			Optional<PrimaryAndRemoteAddresses> storageServers;
 			if (db.present()) {
-				co_await store(storageServers, getStorageServers(db.get(), dbInfo));
+				storageServers = co_await getStorageServers(db.get(), dbInfo);
 			}
 			req = doPeerHealthCheck(interf, locality, dbInfo, req, enablePrimaryTxnSystemHealthCheck, storageServers);
 
@@ -2981,7 +2981,7 @@ Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 
 	// When set to true, the health monitor running in this worker starts monitor other transaction process in this
 	// cluster.
-	Reference<AsyncVar<bool>> enablePrimaryTxnSystemHealthCheck = makeReference<AsyncVar<bool>>(false);
+	auto enablePrimaryTxnSystemHealthCheck = makeReference<AsyncVar<bool>>(false);
 
 	co_await yield();
 	Future<Void> grpc = registerWorkerGrpcServices(interf.id(), connRecord);
@@ -3570,10 +3570,10 @@ TEST_CASE("/fdbserver/worker/swversion/writeVerifyVersion") {
 		co_return;
 	}
 
-	co_await success(errorOr(updateNewestSoftwareVersion(swversionTestDirName,
-	                                                     ProtocolVersion::withStorageInterfaceReadiness(),
-	                                                     ProtocolVersion::withStorageInterfaceReadiness(),
-	                                                     ProtocolVersion::withTSS())));
+	co_await errorOr(updateNewestSoftwareVersion(swversionTestDirName,
+	                                             ProtocolVersion::withStorageInterfaceReadiness(),
+	                                             ProtocolVersion::withStorageInterfaceReadiness(),
+	                                             ProtocolVersion::withTSS()));
 
 	ErrorOr<SWVersion> swversion = co_await errorOr(
 	    testSoftwareVersionCompatibility(swversionTestDirName, ProtocolVersion::withStorageInterfaceReadiness()));
@@ -3593,10 +3593,10 @@ TEST_CASE("/fdbserver/worker/swversion/runCompatibleOlder") {
 		co_return;
 	}
 
-	co_await success(errorOr(updateNewestSoftwareVersion(swversionTestDirName,
-	                                                     ProtocolVersion::withStorageInterfaceReadiness(),
-	                                                     ProtocolVersion::withStorageInterfaceReadiness(),
-	                                                     ProtocolVersion::withTSS())));
+	co_await errorOr(updateNewestSoftwareVersion(swversionTestDirName,
+	                                             ProtocolVersion::withStorageInterfaceReadiness(),
+	                                             ProtocolVersion::withStorageInterfaceReadiness(),
+	                                             ProtocolVersion::withTSS()));
 
 	{
 		ErrorOr<SWVersion> swversion = co_await errorOr(
@@ -3613,10 +3613,10 @@ TEST_CASE("/fdbserver/worker/swversion/runCompatibleOlder") {
 		}
 	}
 
-	co_await success(errorOr(updateNewestSoftwareVersion(swversionTestDirName,
-	                                                     ProtocolVersion::withTSS(),
-	                                                     ProtocolVersion::withStorageInterfaceReadiness(),
-	                                                     ProtocolVersion::withTSS())));
+	co_await errorOr(updateNewestSoftwareVersion(swversionTestDirName,
+	                                             ProtocolVersion::withTSS(),
+	                                             ProtocolVersion::withStorageInterfaceReadiness(),
+	                                             ProtocolVersion::withTSS()));
 
 	{
 		ErrorOr<SWVersion> swversion = co_await errorOr(
@@ -3673,10 +3673,10 @@ TEST_CASE("/fdbserver/worker/swversion/runNewer") {
 		co_return;
 	}
 
-	co_await success(errorOr(updateNewestSoftwareVersion(swversionTestDirName,
-	                                                     ProtocolVersion::withTSS(),
-	                                                     ProtocolVersion::withTSS(),
-	                                                     ProtocolVersion::withCacheRole())));
+	co_await errorOr(updateNewestSoftwareVersion(swversionTestDirName,
+	                                             ProtocolVersion::withTSS(),
+	                                             ProtocolVersion::withTSS(),
+	                                             ProtocolVersion::withCacheRole()));
 
 	{
 		ErrorOr<SWVersion> swversion = co_await errorOr(
@@ -3689,10 +3689,10 @@ TEST_CASE("/fdbserver/worker/swversion/runNewer") {
 		}
 	}
 
-	co_await success(errorOr(updateNewestSoftwareVersion(swversionTestDirName,
-	                                                     ProtocolVersion::withStorageInterfaceReadiness(),
-	                                                     ProtocolVersion::withStorageInterfaceReadiness(),
-	                                                     ProtocolVersion::withTSS())));
+	co_await errorOr(updateNewestSoftwareVersion(swversionTestDirName,
+	                                             ProtocolVersion::withStorageInterfaceReadiness(),
+	                                             ProtocolVersion::withStorageInterfaceReadiness(),
+	                                             ProtocolVersion::withTSS()));
 
 	{
 		ErrorOr<SWVersion> swversion = co_await errorOr(

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -700,7 +700,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		bool followedProxyReplacement = proxy->id() != initialProxyStatus.first.id();
 		updateObservedProxy(*proxy, initialProxyStatus.first);
 		const CDCProxyBufferStatus initial = initialProxyStatus.second;
-		Reference<AsyncVar<bool>> stopped = makeReference<AsyncVar<bool>>(false);
+		auto stopped = makeReference<AsyncVar<bool>>(false);
 		Future<Void> requester = requestPopsUntilStopped(cx, stopped);
 		const double deadline = now() + operationTimeout;
 		while (true) {
@@ -734,7 +734,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		}
 
 		Promise<Void> releaseAcknowledgements;
-		Reference<AsyncVar<int>> completed = makeReference<AsyncVar<int>>(0);
+		auto completed = makeReference<AsyncVar<int>>(0);
 		std::vector<Future<Void>> consumers;
 		consumers.reserve(streams.size());
 		for (const auto& stream : streams) {

--- a/fdbserver/workloads/TaskBucketCorrectness.cpp
+++ b/fdbserver/workloads/TaskBucketCorrectness.cpp
@@ -265,7 +265,7 @@ struct TaskBucketCorrectnessWorkload : TestWorkload {
 				TraceEvent("TaskBucketCorrectness").detail("ClearingDb", "...");
 				co_await taskBucket->clear(cx);
 
-				Reference<Task> cancelledTask =
+				auto cancelledTask =
 				    makeReference<Task>(CancelledTaskFunc::name, CancelledTaskFunc::version, StringRef(), 0);
 				Future<bool> cancelledResult = taskBucket->doTask(cx, futureBucket, cancelledTask);
 				ASSERT(cancelledResult.isReady() && cancelledResult.isError());


### PR DESCRIPTION
## Summary

- Apply the FoundationDB Flow AST-grep cleanups to the worker, CDC proxy, data distributor, and simulation workloads.
- Remove redundant coroutine `success(...)` wrappers and replace an awaited `store(...)` call with direct assignment.
- Use `auto` for same-type `makeReference<T>(...)` declarations without changing ownership or behavior.
- Resolve all 15 warnings from the enabled Flow rules without applying unrelated general C++ style changes.

## Validation

- Flow AST-grep rule tests, including the disabled experimental rule fixtures: 11 passed.
- Full FoundationDB Flow AST-grep scan: 1,125 files and no remaining warnings.
- Worker software-version unit tests: 5 passed.
- Native CDC proxy unit tests: 11 passed.
- Data-distribution queue unit tests: 5 passed.
- Full FoundationDB server build.
