### PR TITLE
BulkLoad: coalesce manifests to DD target shard size to avoid post-restore merge storm

### DIFF
--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -1097,6 +1097,8 @@ public:
 
 	bool hasEmptyData() const { return bytes == 0; }
 
+	size_t getBytes() const { return bytes; }
+
 	Key getBeginKey() const { return beginKey; }
 
 	Key getEndKey() const { return endKey; }

--- a/fdbclient/include/fdbclient/BulkLoading.h
+++ b/fdbclient/include/fdbclient/BulkLoading.h
@@ -1097,7 +1097,13 @@ public:
 
 	bool hasEmptyData() const { return bytes == 0; }
 
-	size_t getBytes() const { return bytes; }
+	// Data byte count for this manifest entry. Returned as int64_t to match the byte-count
+	// convention (getTotalBytes) and avoid a size_t round-trip of the -1 "unknown" sentinel;
+	// returns 0 when the size is unknown/unset so it can't corrupt byte-based task coalescing.
+	int64_t getBytes() const {
+		const int64_t b = static_cast<int64_t>(bytes);
+		return b > 0 ? b : 0;
+	}
 
 	Key getBeginKey() const { return beginKey; }
 

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -520,6 +520,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SS_BULKLOAD_GETRANGE_BATCH_SIZE,                     10000 ); if (isSimulated) SS_BULKLOAD_GETRANGE_BATCH_SIZE = deterministicRandom()->randomInt(1, 10);
 	init( BULKLOAD_ASYNC_READ_WRITE_BLOCK_SIZE,            1024*1024 ); if (isSimulated) BULKLOAD_ASYNC_READ_WRITE_BLOCK_SIZE = deterministicRandom()->randomInt(1024, 10240);
 	init( MANIFEST_COUNT_MAX_PER_BULKLOAD_TASK,                   10 ); if (isSimulated) MANIFEST_COUNT_MAX_PER_BULKLOAD_TASK = deterministicRandom()->randomInt(1, 11);
+	init( DD_BULKLOAD_TASK_TARGET_RATIO,                         0.6 ); if (isSimulated) DD_BULKLOAD_TASK_TARGET_RATIO = deterministicRandom()->coinflip() ? 0.0 : deterministicRandom()->random01();
 	init( BULKLOAD_SIM_FAILURE_INJECTION,                      false ); if (isSimulated) BULKLOAD_SIM_FAILURE_INJECTION = true;
 	init( DD_BULKLOAD_POWER_OF_D_RATIO,                          2.0 ); if (isSimulated) DD_BULKLOAD_POWER_OF_D_RATIO = deterministicRandom()->randomInt(1, 11);
 	init( DD_BULKLOAD_TASK_SUBMISSION_INTERVAL_SEC,             0.01 );

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -433,6 +433,10 @@ public:
 	int SS_BULKDUMP_BATCH_COUNT_MAX_PER_REQUEST; // the max number of batch count per bulkdump request to a SS
 	int BULKLOAD_ASYNC_READ_WRITE_BLOCK_SIZE; // the block size when performing async read/write for bulkload
 	int MANIFEST_COUNT_MAX_PER_BULKLOAD_TASK; // the max number of manifest that a bulkload task can process
+	double DD_BULKLOAD_TASK_TARGET_RATIO; // coalesce consecutive manifests into one bulkload task until accumulated
+	                                      // bytes reach this fraction of getMaxShardSize(dataset size), so restored
+	                                      // shards are born near DD's adaptive target shard band at any scale
+	                                      // (<1 leaves headroom under the split ceiling; 0 disables → count-based only)
 	bool BULKLOAD_SIM_FAILURE_INJECTION; // Set to true to inject failure in bulkload simulation
 	double DD_BULKLOAD_POWER_OF_D_RATIO; // When selecting the dest team, DD randomly chooses 1/D portion of all valid
 	                                     // teams as the candidates and the DD selects the team with the minimal number

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -436,7 +436,10 @@ public:
 	double DD_BULKLOAD_TASK_TARGET_RATIO; // coalesce consecutive manifests into one bulkload task until accumulated
 	                                      // bytes reach this fraction of getMaxShardSize(dataset size), so restored
 	                                      // shards are born near DD's adaptive target shard band at any scale
-	                                      // (<1 leaves headroom under the split ceiling; 0 disables → count-based only)
+	                                      // (<1 leaves headroom under the split ceiling; 0 disables → count-based
+	                                      // only). MANIFEST_COUNT_MAX_PER_BULKLOAD_TASK still caps manifests/task, so
+	                                      // for dumps whose manifests are smaller than ~target/that-cap the coalesced
+	                                      // shard can still land below DD's merge floor.
 	bool BULKLOAD_SIM_FAILURE_INJECTION; // Set to true to inject failure in bulkload simulation
 	double DD_BULKLOAD_POWER_OF_D_RATIO; // When selecting the dest team, DD randomly chooses 1/D portion of all valid
 	                                     // teams as the candidates and the DD selects the team with the minimal number

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -2051,7 +2051,7 @@ Future<Void> scheduleBulkLoadJob(Reference<DataDistributor> self, Promise<Void> 
 	if (SERVER_KNOBS->DD_BULKLOAD_TASK_TARGET_RATIO > 0) {
 		int64_t datasetBytes = 0;
 		for (const auto& manifestEntryPair : *self->bulkLoadJobManager.get().manifestEntryMap) {
-			datasetBytes += static_cast<int64_t>(manifestEntryPair.second.getBytes());
+			datasetBytes += manifestEntryPair.second.getBytes();
 		}
 		bulkLoadTaskTargetBytes = static_cast<int64_t>(getMaxShardSize(static_cast<double>(datasetBytes)) *
 		                                               SERVER_KNOBS->DD_BULKLOAD_TASK_TARGET_RATIO);
@@ -2136,7 +2136,7 @@ Future<Void> scheduleBulkLoadJob(Reference<DataDistributor> self, Promise<Void> 
 						ASSERT(it != self->bulkLoadJobManager.get().manifestEntryMap->end());
 						manifestEntry = it->second;
 						manifestEntries.push_back(manifestEntry);
-						accumulatedBytes += static_cast<int64_t>(manifestEntry.getBytes());
+						accumulatedBytes += manifestEntry.getBytes();
 						beginKey = manifestEntry.getEndKey();
 						if (bulkLoadTaskTargetBytes > 0 && accumulatedBytes >= bulkLoadTaskTargetBytes) {
 							break; // reached ~target shard size; cut the task here

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -44,6 +44,7 @@
 #include "fdbserver/core/Knobs.h"
 #include "fdbserver/core/MoveKeys.h"
 #include "fdbserver/core/QuietDatabase.h"
+#include "fdbserver/core/ShardSizing.h"
 #include "fdbserver/core/TLogInterface.h"
 #include "fdbserver/core/WaitFailure.h"
 #include "fdbserver/core/WorkloadKeys.h"
@@ -2041,6 +2042,24 @@ Future<Void> scheduleBulkLoadJob(Reference<DataDistributor> self, Promise<Void> 
 	std::vector<Future<Void>> actors;
 	Database cx = self->txnProcessor->context();
 	Transaction tr(cx);
+	// Byte-based coalescing target, computed once from the FINAL dataset size (sum of all manifest bytes),
+	// sized to DD's adaptive shard band via getMaxShardSize. Using the dataset size (not the live, growing
+	// dbSizeEstimate) keeps the target stable so restored shards are born near target at any scale. The
+	// ratio (<1) biases below maxShardSize so the one-manifest overshoot stays under the split ceiling.
+	// Ratio 0 disables byte-based coalescing (pure count-based, legacy behavior).
+	int64_t bulkLoadTaskTargetBytes = 0;
+	if (SERVER_KNOBS->DD_BULKLOAD_TASK_TARGET_RATIO > 0) {
+		int64_t datasetBytes = 0;
+		for (const auto& manifestEntryPair : *self->bulkLoadJobManager.get().manifestEntryMap) {
+			datasetBytes += static_cast<int64_t>(manifestEntryPair.second.getBytes());
+		}
+		bulkLoadTaskTargetBytes = static_cast<int64_t>(getMaxShardSize(static_cast<double>(datasetBytes)) *
+		                                               SERVER_KNOBS->DD_BULKLOAD_TASK_TARGET_RATIO);
+		TraceEvent(SevInfo, "DDBulkLoadJobManagerTaskTargetBytes", self->ddId)
+		    .detail("DatasetBytes", datasetBytes)
+		    .detail("TargetBytes", bulkLoadTaskTargetBytes)
+		    .detail("Ratio", SERVER_KNOBS->DD_BULKLOAD_TASK_TARGET_RATIO);
+	}
 	// We load the bulkload task from the job manifest.
 	// The job manifest is organized in a sorted map. The key is the beginKey of the manifest.
 	// The value is the manifest. For details, please see comments in getBulkLoadJobManifestData.
@@ -2103,13 +2122,28 @@ Future<Void> scheduleBulkLoadJob(Reference<DataDistributor> self, Promise<Void> 
 				ASSERT(beginKey == res[i].key);
 				while (beginKey < res[i + 1].key) {
 					std::vector<BulkLoadJobFileManifestEntry> manifestEntries;
-					while (manifestEntries.size() < SERVER_KNOBS->MANIFEST_COUNT_MAX_PER_BULKLOAD_TASK &&
-					       beginKey < res[i + 1].key) {
+					// Coalesce consecutive (adjacent) manifests into one task until we accumulate roughly
+					// bulkLoadTaskTargetBytes (derived from getMaxShardSize(dataset) * DD_BULKLOAD_TASK_TARGET_RATIO)
+					// of data, so the restored shard is born near DD's target
+					// shard size (avoids the post-restore merge storm from sub-floor shards and the split
+					// storm from oversized ones). MANIFEST_COUNT_MAX_PER_BULKLOAD_TASK remains a hard upper
+					// bound so a run of empty (0-byte) manifests can't create an unbounded task. This is the
+					// same left-to-right adjacent sweep as before (beginKey -> endKey); only the cut
+					// condition changes from count-based to byte-based.
+					int64_t accumulatedBytes = 0;
+					while (beginKey < res[i + 1].key) {
 						auto it = self->bulkLoadJobManager.get().manifestEntryMap->find(beginKey);
 						ASSERT(it != self->bulkLoadJobManager.get().manifestEntryMap->end());
 						manifestEntry = it->second;
 						manifestEntries.push_back(manifestEntry);
+						accumulatedBytes += static_cast<int64_t>(manifestEntry.getBytes());
 						beginKey = manifestEntry.getEndKey();
+						if (bulkLoadTaskTargetBytes > 0 && accumulatedBytes >= bulkLoadTaskTargetBytes) {
+							break; // reached ~target shard size; cut the task here
+						}
+						if (manifestEntries.size() >= SERVER_KNOBS->MANIFEST_COUNT_MAX_PER_BULKLOAD_TASK) {
+							break; // hard safety cap on manifests per task
+						}
 					}
 					ASSERT(!manifestEntries.empty());
 					actors.push_back(bulkLoadJobNewTask(self,


### PR DESCRIPTION
Bulkload restore created one shard per manifest (= source shard size). When a dump's manifests fall below DD's adaptive shard-size floor (maxShardSize/4) -- shard is sparse, hasn't been merged up on source cluster -- the DD ends up merging up the sub-floor shards after restore, which at scale is a multi-hour, self-refilling merge storm (~99 GB in-queue / priority MERGE_SHARD / ~1h at 1B). The manifest size cannot be grown at dump time (bulkdump is one manifest per source shard; SS_BULKDUMP_BATCH_BYTES only splits), so coalesce on the load side.

The bulkload task scheduler now sums the dataset size once and derives a target via getMaxShardSize(datasetBytes) * DD_BULKLOAD_TASK_TARGET_RATIO (default 0.6), then glues consecutive (adjacent) manifests into one task until accumulated bytes reach that target, so restored shards are born inside DD's band at any scale (MANIFEST_COUNT_MAX_PER_BULKLOAD_TASK remains a hard upper cap). Ratio 0 disables byte-based coalescing and restores the prior count-only behavior.

Validated at 1B: DD trace shows TargetBytes ~123 MB (943 GB dataset x 0.6), and the post-restore cluster settles with 0 moving data / Healthy at completion, vs priority-340 / ~99 GB / ~1h without the change.
`
  20260727-052042-stack-e7bec2c41c2ea5d4             compressed=True data_size=38423185 duration=2786569 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:33:07 sanity=False started=100000 stopped=20260727-055349 submitted=20260727-052042 timeout=5400 username=stack`