### PR TITLE
Prevent client profiling maintenance from profiling itself

### DIFF
--- a/fdbclient/DatabaseContext.cpp
+++ b/fdbclient/DatabaseContext.cpp
@@ -616,13 +616,19 @@ struct TrInfoChunk {
 static const Key CLIENT_LATENCY_INFO_PREFIX = "client_latency/"_sr;
 static const Key CLIENT_LATENCY_INFO_CTR_PREFIX = "client_latency_counter/"_sr;
 
+static void resetClientStatusTransaction(Transaction* tr) {
+	tr->reset();
+	// Profiling maintenance must not generate more records for itself to persist.
+	tr->trState->trLogInfo.clear();
+}
+
 static Future<Void> transactionInfoCommitActor(Transaction* tr, std::vector<TrInfoChunk>* chunks) {
 	const Key clientLatencyAtomicCtr = CLIENT_LATENCY_INFO_CTR_PREFIX.withPrefix(fdbClientInfoPrefixRange.begin);
 	int retryCount = 0;
 	while (true) {
 		Error err;
 		try {
-			tr->reset();
+			resetClientStatusTransaction(tr);
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 			[[maybe_unused]] Future<Standalone<StringRef>> vstamp = tr->getVersionstamp();
@@ -656,7 +662,7 @@ static Future<Void> delExcessClntTxnEntriesActor(Transaction* tr, int64_t client
 	while (true) {
 		Error err;
 		try {
-			tr->reset();
+			resetClientStatusTransaction(tr);
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 			Optional<Value> ctrValue = co_await tr->get(KeyRef(clientLatencyAtomicCtr), Snapshot::True);


### PR DESCRIPTION
## Summary

Client transaction profiling can sample the transactions that persist and clean up its own profiling records. After a restart, that feedback can keep the storage queue active even after the profiling workload has completed.

- Disable sampling only for profiling persistence and cleanup transactions after their existing transaction reset.
- Preserve normal client transaction profiling, transaction retries, fault injection, and restart workload coverage.
- Allow the existing strict consistency check to observe a genuinely quiescent storage queue.

## Validation

- `fdbclient_test`: 90 tests passed, zero failed.
- Reproduced the original two-phase `ClientTransactionProfilingCorrectness` restart failure before the change; both unchanged phases pass afterward with ordinary profiling and fault injection preserved.
- Replayed two additional historical restart seed pairs using the original FoundationDB 7.3.43 and 7.4.5 release binaries; all four phases pass.
