### PR TITLE
Avoid false-positive shard estimate consistency failures

### DIFF
--- a/fdbserver/consistencyscan/ConsistencyScan.cpp
+++ b/fdbserver/consistencyscan/ConsistencyScan.cpp
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+#include <cmath>
+#include <limits>
+
 #include "fdbclient/JSONDoc.h"
 #include "fdbclient/SystemData.h"
 #include "fdbclient/json_spirit/json_spirit_value.h"
@@ -46,6 +49,7 @@
 #include "fdbserver/core/QuietDatabase.h"
 #include "flow/DeterministicRandom.h"
 #include "flow/Trace.h"
+#include "flow/UnitTest.h"
 #include "flow/CoroUtils.h"
 
 #define DEBUG_SCAN_PROGRESS false
@@ -1201,6 +1205,150 @@ Future<Void> consistencyScan(ConsistencyScanInterface csInterf, Reference<AsyncV
 // Everything below this line is not relevant to the ConsistencyScan Role anymore.
 // It is only used by workloads/ConsistencyCheck
 
+namespace {
+
+class ShardSampleMoments {
+public:
+	void add(ByteSampleInfo const& sample) {
+		const double probability = sample.probability;
+		const double complement = 1.0 - probability;
+		const double sampledSize = static_cast<double>(sample.sampledSize);
+		const double variance = probability * complement * std::pow(sampledSize, 2);
+
+		variance_ += variance;
+		thirdAbsoluteMoment_ += variance * sampledSize * (probability * probability + complement * complement);
+		if (probability < 1.0) {
+			expectedConditionalSamples_ += probability;
+		}
+	}
+
+	[[nodiscard]] double variance() const { return variance_; }
+	[[nodiscard]] double thirdAbsoluteMoment() const { return thirdAbsoluteMoment_; }
+	[[nodiscard]] double expectedConditionalSamples() const { return expectedConditionalSamples_; }
+
+	[[nodiscard]] double normalEffectiveSamples() const {
+		if (!std::isfinite(variance_) || !std::isfinite(thirdAbsoluteMoment_) || variance_ <= 0.0 ||
+		    thirdAbsoluteMoment_ <= 0.0) {
+			return 0.0;
+		}
+
+		const double normalRatio = std::sqrt(variance_) / (thirdAbsoluteMoment_ / variance_);
+		if (!std::isfinite(normalRatio)) {
+			return 0.0;
+		}
+
+		const double effectiveSamples = normalRatio * normalRatio;
+		return std::isfinite(effectiveSamples) ? effectiveSamples : std::numeric_limits<double>::max();
+	}
+
+private:
+	double variance_ = 0.0;
+	double thirdAbsoluteMoment_ = 0.0;
+	double expectedConditionalSamples_ = 0.0;
+};
+
+} // namespace
+
+TEST_CASE("/fdbserver/ConsistencyCheck/ShardEstimate/heterogeneousSamples") {
+	ShardSampleMoments moments;
+	int sampledKeysWithProb = 0;
+	int64_t actualBytes = 0;
+	int64_t sampledBytes = 0;
+	const ByteSampleInfo smallSample = isKeyValueInSample("0000000000"_sr, 10);
+
+	auto addSample = [&](ByteSampleInfo const& sample) {
+		moments.add(sample);
+		actualBytes += sample.size;
+		if (sample.inSample) {
+			sampledBytes += sample.sampledSize;
+			sampledKeysWithProb += sample.probability < 1.0;
+		}
+	};
+
+	for (int i = 0; i < 100000; ++i) {
+		const std::string key = format("%010d", i);
+		addSample(isKeyValueInSample(StringRef(key), key.size()));
+	}
+
+	std::string largeKey(10000, 'x');
+	largeKey[0] = 'z';
+	largeKey[1] = '\0';
+	largeKey[2] = 'W';
+	const ByteSampleInfo largeSample = isKeyValueInSample(StringRef(largeKey), largeKey.size());
+	addSample(largeSample);
+
+	ASSERT_EQ(actualBytes, 1010000);
+	ASSERT_EQ(sampledBytes, 41 * smallSample.sampledSize + largeSample.sampledSize);
+	ASSERT_EQ(sampledKeysWithProb, 42);
+	ASSERT_GT(std::abs(static_cast<double>(actualBytes - sampledBytes)), 7.0 * std::sqrt(moments.variance()));
+	ASSERT_LT(moments.normalEffectiveSamples(), 30.0);
+	return Void();
+}
+
+TEST_CASE("/fdbserver/ConsistencyCheck/ShardEstimate/nearCertainSamples") {
+	ShardSampleMoments moments;
+	int sampledKeysWithProb = 0;
+	int64_t actualBytes = 0;
+	int64_t sampledBytes = 0;
+
+	auto addKey = [&](int index) {
+		std::string key(100, 'x');
+		key[0] = 'y';
+		key[1] = static_cast<char>(index >> 24);
+		key[2] = static_cast<char>(index >> 16);
+		key[3] = static_cast<char>(index >> 8);
+		key[4] = static_cast<char>(index);
+
+		const ByteSampleInfo sample = isKeyValueInSample(StringRef(key), 49995);
+		moments.add(sample);
+		actualBytes += sample.size;
+		if (sample.inSample) {
+			sampledBytes += sample.sampledSize;
+			sampledKeysWithProb += sample.probability < 1.0;
+		}
+	};
+
+	for (int i = 0; i < 33; ++i) {
+		addKey(i);
+	}
+	addKey(9222);
+
+	ASSERT_EQ(actualBytes, 1699830);
+	ASSERT_EQ(sampledBytes, 1650000);
+	ASSERT_EQ(sampledKeysWithProb, 33);
+	ASSERT_GT(std::abs(static_cast<double>(actualBytes - sampledBytes)), 7.0 * std::sqrt(moments.variance()));
+	ASSERT_LT(moments.normalEffectiveSamples(), 30.0);
+	return Void();
+}
+
+TEST_CASE("/fdbserver/ConsistencyCheck/ShardEstimate/normalSamples") {
+	const ByteSampleInfo smallSample = isKeyValueInSample("0000000000"_sr, 10);
+	ShardSampleMoments homogeneous;
+	for (int i = 0; i < 100000; ++i) {
+		homogeneous.add(smallSample);
+	}
+
+	ASSERT_EQ(smallSample.sampledSize,
+	          static_cast<int64_t>(static_cast<double>(smallSample.size) / smallSample.probability));
+	ASSERT_GT(std::abs(1000000.0 - 79.0 * smallSample.sampledSize), 7.0 * std::sqrt(homogeneous.variance()));
+	ASSERT_GT(homogeneous.normalEffectiveSamples(), 30.0);
+
+	ShardSampleMoments fair;
+	const ByteSampleInfo fairSample{ true, 1, 0.5, 2 };
+	for (int i = 0; i < 30; ++i) {
+		fair.add(fairSample);
+	}
+	ASSERT_LE(fair.normalEffectiveSamples(), 30.0);
+	fair.add(fairSample);
+	ASSERT_GT(fair.normalEffectiveSamples(), 30.0);
+
+	ShardSampleMoments deterministic;
+	deterministic.add(ByteSampleInfo{ false, 0, 0.0, 0 });
+	deterministic.add(ByteSampleInfo{ true, 1, 1.0, 1 });
+	ASSERT_EQ(deterministic.normalEffectiveSamples(), 0.0);
+	return Void();
+}
+
 // Gets a version at which to read from the storage servers
 Future<Version> getStorageServerReadVersion(Database cx) {
 	while (true) {
@@ -1781,7 +1929,7 @@ Future<Void> checkDataConsistency(Database cx,
 			int firstKeySampledBytes = 0;
 			int sampledKeys = 0;
 			int sampledKeysWithProb = 0;
-			double shardVariance = 0;
+			ShardSampleMoments shardSampleMoments;
 			bool canSplit = false;
 			Key lastSampleKey;
 			Key lastStartSampleKey;
@@ -1865,10 +2013,7 @@ Future<Void> checkDataConsistency(Database cx,
 							ASSERT_GE(sampleInfo.probability, 0);
 							ASSERT_LE(sampleInfo.probability, 1);
 
-							// Variance of a single Bernoulli trial, for which X=n with probability p,
-							// is p * (1-p) * n^2.
-							shardVariance += sampleInfo.probability * (1 - sampleInfo.probability) *
-							                 pow((double)sampleInfo.sampledSize, 2);
+							shardSampleMoments.add(sampleInfo);
 
 							if (sampleInfo.inSample) {
 								sampledBytes += sampleInfo.sampledSize;
@@ -2003,6 +2148,7 @@ Future<Void> checkDataConsistency(Database cx,
 
 			// Compute the difference between the shard size estimate and its actual size.  If it is sufficiently
 			// large, then fail
+			const double shardVariance = shardSampleMoments.variance();
 			double stdDev = sqrt(shardVariance);
 
 			double failErrorNumStdDev = 7;
@@ -2012,6 +2158,7 @@ Future<Void> checkDataConsistency(Database cx,
 			// normal distribution
 			if (sampledKeysWithProb > 30 && estimateError > failErrorNumStdDev * stdDev) {
 				double numStdDev = estimateError / sqrt(shardVariance);
+				const double normalEffectiveSamples = shardSampleMoments.normalEffectiveSamples();
 				TraceEvent("ConsistencyCheck_InaccurateShardEstimate")
 				    .detail("Min", shardBounds.min.bytes)
 				    .detail("Max", shardBounds.max.bytes)
@@ -2019,6 +2166,13 @@ Future<Void> checkDataConsistency(Database cx,
 				    .detail("Actual", shardBytes)
 				    .detail("NumStdDev", numStdDev)
 				    .detail("Variance", shardVariance)
+				    .detail("AbsoluteThirdMoment", shardSampleMoments.thirdAbsoluteMoment())
+				    .detail("NormalEffectiveSamples", normalEffectiveSamples)
+				    .detail("ExpectedConditionalSamples", shardSampleMoments.expectedConditionalSamples())
+				    .detail("StorageServerEstimate", estimatedBytes.empty() ? int64_t{ -1 } : estimatedBytes.front())
+				    .detail("StorageEstimateMatchesSample",
+				            !estimatedBytes.empty() && estimatedBytes.front() == sampledBytes)
+				    .detail("PerformQuiescentChecks", performQuiescentChecks)
 				    .detail("StdDev", stdDev)
 				    .detail("ShardBegin", printable(range.begin))
 				    .detail("ShardEnd", printable(range.end))
@@ -2026,10 +2180,12 @@ Future<Void> checkDataConsistency(Database cx,
 				    .detail("NumSampledKeys", sampledKeys)
 				    .detail("NumSampledKeysWithProb", sampledKeysWithProb);
 
-				testFailure(format("Shard size is more than %f std dev from estimate", failErrorNumStdDev),
-				            performQuiescentChecks,
-				            success,
-				            failureIsError);
+				if (normalEffectiveSamples > 30.0) {
+					testFailure(format("Shard size is more than %f std dev from estimate", failErrorNumStdDev),
+					            performQuiescentChecks,
+					            success,
+					            failureIsError);
+				}
 			}
 
 			TraceEvent("ConsistencyCheck_CheckSplits").detail("Range", range).detail("CanSplit", canSplit);


### PR DESCRIPTION
## Summary

- Require sufficient normal-approximation support before reporting a byte-sampled shard estimate as inconsistent.
- Preserve the existing seven-standard-deviation threshold, fault injection, and independent storage-server metric checks.
- Add deterministic regression coverage for heterogeneous samples, near-certain samples, and genuine high-confidence outliers.

## Validation

- `fdbserver -r unittests -f /fdbserver/ConsistencyCheck/ShardEstimate/`
- Exact replay of `tests/fast/FuzzApiCorrectness.toml` with fault injection enabled.
