### PR TITLE
Preserve DD pipeline control during initial quiescence

### DIFF
--- a/fdbserver/core/QuietDatabase.cpp
+++ b/fdbserver/core/QuietDatabase.cpp
@@ -1052,7 +1052,7 @@ Future<Void> waitForQuietDatabase(Database cx,
 
 	co_await disableConsistencyScanInSim(cx, false);
 
-	if (g_network->isSimulated()) {
+	if (g_network->isSimulated() && phase != "Start") {
 		disableDDPipelineControl();
 	}
 


### PR DESCRIPTION
## Summary

- Keep data distribution pipeline control enabled during initial simulation quiescence.
- Preserve the existing bypass for final and explicit consistency-check quiescence.
- Prevent initial quiescence from permanently disabling relocation backpressure before a workload starts.

## Validation

- `fdbserver_core_test`: 24 tests passed.
- Original `tests/fast/DDPipelineSaturation.toml` simulation replay with buggification and fault injection: passed.
