### PR TITLE
Use GitHub private vulnerability reporting for security issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ We use a pre-commit pipeline with black and flake8 to enforce python best coding
 Please refer to the section below on [using GitHub issues and the community forums](#using-github-issues-and-community-forums) for more info.
 
 #### Security issues
-To report a security issue, please **DO NOT** start by filing a public issue or posting to the forums; instead send a private email to [fdb-oss-security@group.apple.com](mailto:fdb-oss-security@group.apple.com).
+To report a security issue, please **DO NOT** start by filing a public issue or posting to the forums. Instead, use GitHub's private vulnerability reporting to [report a vulnerability](https://github.com/apple/foundationdb/security/advisories/new). Only the maintainers can see the report, and we will follow up with you there. See [SECURITY.md](SECURITY.md) for more.
 
 ## Project Communication
 ### Community Forums

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 # Security issues
 
-To report a security issue, please **DO NOT** start by filing a public issue or posting to the forums; instead send a private email to [fdb-oss-security@group.apple.com](mailto:fdb-oss-security@group.apple.com).
+To report a security issue, please **DO NOT** start by filing a public issue or posting to the forums. Instead, use GitHub's private vulnerability reporting to [report a vulnerability](https://github.com/apple/foundationdb/security/advisories/new). Only the maintainers can see the report, and we will follow up with you there.


### PR DESCRIPTION
`SECURITY.md` and `CONTRIBUTING.md` both told reporters to email `fdb-oss-security@group.apple.com`. This points them at GitHub's [private vulnerability reporting](https://github.com/apple/foundationdb/security/advisories/new) instead, so reports stay visible only to maintainers and reporters have a place to follow up. `CONTRIBUTING.md` now links to `SECURITY.md` rather than duplicating the instructions.