### PR TITLE
Re-recruit failed old-epoch backup workers without restarting recovery

### DIFF
--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -435,6 +435,123 @@ Future<Void> recruitFailedLogRouters(ClusterControllerData* cluster,
 	TraceEvent("LogRoutersRecruitmentComplete", cluster->id).detail("Count", tagIds.size());
 }
 
+std::vector<OldBackupWorkerInfo> collectOldBackupWorkers(LogSystemConfig const& config) {
+	std::vector<OldBackupWorkerInfo> workers;
+	for (const auto& old : config.oldTLogs) {
+		const bool rangePartitioned = old.rangePartitionedBackupWorkerTags > 0;
+		const int totalTags = rangePartitioned ? old.rangePartitionedBackupWorkerTags : old.logRouterTags;
+		if (totalTags <= 0) {
+			continue;
+		}
+		for (const auto& logSet : old.tLogs) {
+			for (const auto& worker : logSet.backupWorkers) {
+				if (worker.present()) {
+					workers.push_back({ old.epoch, old.epochEnd, totalTags, rangePartitioned, worker.interf() });
+				}
+			}
+		}
+	}
+	return workers;
+}
+
+bool canMonitorOldBackupWorkers(RecoveryState recoveryState) {
+	return recoveryState >= RecoveryState::ACCEPTING_COMMITS;
+}
+
+bool shouldRestartOldBackupWorkerMonitor(RecoveryState recoveryState,
+                                         LogEpoch monitoredRecoveryCount,
+                                         LogEpoch currentRecoveryCount,
+                                         bool sameLogSystem) {
+	return !canMonitorOldBackupWorkers(recoveryState) || monitoredRecoveryCount != currentRecoveryCount ||
+	       !sameLogSystem;
+}
+
+bool validateOldBackupWorkerProgress(OldBackupWorkerInfo const& failedWorker,
+                                     std::vector<OldBackupWorkerInfo> const& oldWorkers,
+                                     std::map<UID, WorkerBackupStatus> const& workerProgress) {
+	const int8_t locality = failedWorker.rangePartitioned ? tagLocalityRangePartitionedBackup : tagLocalityLogRouter;
+	std::set<Tag> claimedTags;
+	for (const auto& worker : oldWorkers) {
+		if (worker.backupEpoch != failedWorker.backupEpoch) {
+			continue;
+		}
+		if (worker.rangePartitioned != failedWorker.rangePartitioned || worker.totalTags != failedWorker.totalTags) {
+			return false;
+		}
+		auto progress = workerProgress.find(worker.interf.id());
+		if (progress == workerProgress.end()) {
+			continue;
+		}
+		const auto& status = progress->second;
+		if (status.epoch != failedWorker.backupEpoch || status.tag.locality != locality ||
+		    status.totalTags != failedWorker.totalTags || !claimedTags.insert(status.tag).second) {
+			return false;
+		}
+	}
+	return true;
+}
+
+Optional<Tag> resolveOldBackupWorkerTag(OldBackupWorkerInfo const& failedWorker,
+                                        std::vector<OldBackupWorkerInfo> const& oldWorkers,
+                                        std::map<UID, WorkerBackupStatus> const& workerProgress,
+                                        std::map<Tag, Version> const& unfinishedTags) {
+	if (!validateOldBackupWorkerProgress(failedWorker, oldWorkers, workerProgress)) {
+		return Optional<Tag>();
+	}
+	const int8_t locality = failedWorker.rangePartitioned ? tagLocalityRangePartitionedBackup : tagLocalityLogRouter;
+	auto failedProgress = workerProgress.find(failedWorker.interf.id());
+	if (failedProgress != workerProgress.end()) {
+		const auto& status = failedProgress->second;
+		if (status.epoch != failedWorker.backupEpoch || status.tag.locality != locality ||
+		    status.totalTags != failedWorker.totalTags || !unfinishedTags.contains(status.tag)) {
+			return Optional<Tag>();
+		}
+	}
+
+	std::set<Tag> claimedTags;
+	std::vector<UID> unknownWorkers;
+	for (const auto& worker : oldWorkers) {
+		if (worker.backupEpoch != failedWorker.backupEpoch ||
+		    worker.rangePartitioned != failedWorker.rangePartitioned) {
+			continue;
+		}
+
+		auto progress = workerProgress.find(worker.interf.id());
+		if (progress != workerProgress.end()) {
+			if (progress->second.epoch != failedWorker.backupEpoch || progress->second.tag.locality != locality ||
+			    progress->second.totalTags != failedWorker.totalTags) {
+				return Optional<Tag>();
+			}
+			if (!claimedTags.insert(progress->second.tag).second) {
+				return Optional<Tag>();
+			}
+		} else {
+			unknownWorkers.push_back(worker.interf.id());
+		}
+	}
+
+	if (failedProgress != workerProgress.end()) {
+		return failedProgress->second.tag;
+	}
+
+	auto unknown = std::find(unknownWorkers.begin(), unknownWorkers.end(), failedWorker.interf.id());
+	if (unknown == unknownWorkers.end()) {
+		return Optional<Tag>();
+	}
+	const auto unknownIndex = static_cast<size_t>(std::distance(unknownWorkers.begin(), unknown));
+	std::vector<Tag> unclaimedTags;
+	for (const auto& [tag, version] : unfinishedTags) {
+		(void)version;
+		if (tag.locality == locality && !claimedTags.contains(tag)) {
+			unclaimedTags.push_back(tag);
+		}
+	}
+	if (unknownIndex >= unclaimedTags.size()) {
+		return Optional<Tag>();
+	}
+	return unclaimedTags[unknownIndex];
+}
+
 Future<std::vector<int>> monitorLogRouters(Reference<LogSystem> logSystem, int logSetIndex) {
 	std::vector<Future<Void>> failures;
 	LogSystemConfig config = logSystem->getLogSystemConfig();
@@ -577,6 +694,290 @@ Future<Void> monitorAndRecruitLogRouters(ClusterControllerData* self) {
 		    };
 
 		co_await monitorAndRecruitWorkerSet(self, recoveryCount, "LogRouter", monitor, recruit);
+	}
+}
+
+struct OldBackupWorkerProgress {
+	Optional<Value> started;
+	std::map<UID, WorkerBackupStatus> workers;
+};
+
+Future<OldBackupWorkerProgress> getOldBackupWorkerProgress(ClusterControllerData* self) {
+	Transaction tr(self->cx);
+	while (true) {
+		Error err;
+		try {
+			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+			Future<Optional<Value>> started = tr.get(backupStartedKey);
+			RangeResult entries = co_await tr.getRange(backupProgressKeys, CLIENT_KNOBS->TOO_MANY);
+			ASSERT(!entries.more && entries.size() < CLIENT_KNOBS->TOO_MANY);
+
+			OldBackupWorkerProgress progress;
+			progress.started = co_await started;
+			for (const auto& entry : entries) {
+				progress.workers.emplace(decodeBackupProgressKey(entry.key), decodeBackupProgressValue(entry.value));
+			}
+			co_return progress;
+		} catch (Error& e) {
+			err = e;
+		}
+		co_await tr.onError(err);
+	}
+}
+
+Future<Optional<OldBackupWorkerInfo>> waitForFailedOldBackupWorker(ClusterControllerData* self,
+                                                                   Reference<LogSystem> logSystem) {
+	const LogEpoch recoveryCount = self->db.recoveryData->cstate.myDBState.recoveryCount;
+	std::vector<OldBackupWorkerInfo> workers = collectOldBackupWorkers(logSystem->getLogSystemConfig());
+	std::vector<Future<Void>> failures;
+	failures.reserve(workers.size());
+	for (const auto& worker : workers) {
+		failures.push_back(
+		    waitFailureClient(worker.interf.waitFailure,
+		                      SERVER_KNOBS->BACKUP_TIMEOUT,
+		                      -SERVER_KNOBS->BACKUP_TIMEOUT / SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
+		                      /* trace */ true,
+		                      /* traceMsg */ "OldBackupWorkerFailed"_sr));
+	}
+
+	Future<Void> workerFailed = failures.empty() ? Never() : quorum(failures, 1);
+	Future<Void> workersChanged = logSystem->backupWorkerChanged.onTrigger();
+	Future<Void> serverInfoChanged = self->db.serverInfo->onChange();
+	while (true) {
+		auto result = co_await race(workerFailed, workersChanged, serverInfoChanged);
+		if (result.index() == 0) {
+			for (int i = 0; i < failures.size(); ++i) {
+				if (failures[i].isReady() || failures[i].isError()) {
+					co_return Optional<OldBackupWorkerInfo>(workers[i]);
+				}
+			}
+			co_return Optional<OldBackupWorkerInfo>();
+		}
+		if (result.index() == 1 || !self->db.recoveryData.isValid() ||
+		    shouldRestartOldBackupWorkerMonitor(self->db.serverInfo->get().recoveryState,
+		                                        recoveryCount,
+		                                        self->db.recoveryData->cstate.myDBState.recoveryCount,
+		                                        self->db.recoveryData->logSystem.getPtr() == logSystem.getPtr())) {
+			co_return Optional<OldBackupWorkerInfo>();
+		}
+		serverInfoChanged = self->db.serverInfo->onChange();
+	}
+}
+
+bool isCurrentOldBackupRecovery(ClusterControllerData* self,
+                                Reference<LogSystem> const& logSystem,
+                                LogEpoch recoveryCount) {
+	return self->db.recoveryData.isValid() && self->db.recoveryData->cstate.myDBState.recoveryCount == recoveryCount &&
+	       self->db.recoveryData->logSystem.getPtr() == logSystem.getPtr() &&
+	       canMonitorOldBackupWorkers(self->db.serverInfo->get().recoveryState);
+}
+
+bool removeFinishedOldBackupWorker(ClusterControllerData* self,
+                                   Reference<LogSystem> const& logSystem,
+                                   OldBackupWorkerInfo const& worker) {
+	if (!logSystem->removeBackupWorker(BackupWorkerDoneRequest(worker.interf.id(), worker.backupEpoch))) {
+		return false;
+	}
+	self->db.recoveryData->registrationTrigger.trigger();
+	TraceEvent("OldBackupWorkerNoWorkRemaining", self->id)
+	    .detail("Epoch", worker.backupEpoch)
+	    .detail("WorkerID", worker.interf.id());
+	return true;
+}
+
+Future<Void> rerecruitFailedOldBackupWorker(ClusterControllerData* self,
+                                            Reference<LogSystem> logSystem,
+                                            LogEpoch recoveryCount,
+                                            OldBackupWorkerInfo failedWorker) {
+	OldBackupWorkerProgress persisted = co_await getOldBackupWorkerProgress(self);
+	if (!isCurrentOldBackupRecovery(self, logSystem, recoveryCount)) {
+		co_return;
+	}
+
+	std::vector<OldBackupWorkerInfo> oldWorkers = collectOldBackupWorkers(logSystem->getLogSystemConfig());
+	auto failed = std::find_if(oldWorkers.begin(), oldWorkers.end(), [&failedWorker](const auto& worker) {
+		return worker.backupEpoch == failedWorker.backupEpoch && worker.interf.id() == failedWorker.interf.id();
+	});
+	if (failed == oldWorkers.end()) {
+		co_return;
+	}
+	failedWorker = *failed;
+
+	auto status = persisted.workers.find(failedWorker.interf.id());
+	if (status != persisted.workers.end()) {
+		const int8_t expectedLocality =
+		    failedWorker.rangePartitioned ? tagLocalityRangePartitionedBackup : tagLocalityLogRouter;
+		if (status->second.epoch != failedWorker.backupEpoch || status->second.tag.locality != expectedLocality ||
+		    status->second.totalTags != failedWorker.totalTags) {
+			TraceEvent(SevWarn, "OldBackupWorkerInvalidProgress", self->id)
+			    .detail("Epoch", failedWorker.backupEpoch)
+			    .detail("WorkerID", failedWorker.interf.id());
+			throw recruitment_failed();
+		}
+	}
+	if (!validateOldBackupWorkerProgress(failedWorker, oldWorkers, persisted.workers)) {
+		TraceEvent(SevWarn, "OldBackupWorkerInvalidSiblingProgress", self->id)
+		    .detail("Epoch", failedWorker.backupEpoch)
+		    .detail("WorkerID", failedWorker.interf.id());
+		throw recruitment_failed();
+	}
+
+	Optional<Version> minBackupVersion;
+	if (persisted.started.present()) {
+		for (const auto& [backupId, version] : decodeBackupStartedValue(persisted.started.get())) {
+			(void)backupId;
+			minBackupVersion = minBackupVersion.present() ? std::min(minBackupVersion.get(), version) : version;
+		}
+	}
+	if (!minBackupVersion.present() || minBackupVersion.get() + 1 >= failedWorker.epochEnd) {
+		removeFinishedOldBackupWorker(self, logSystem, failedWorker);
+		co_return;
+	}
+
+	auto epochInfos = failedWorker.rangePartitioned ? logSystem->getOldEpochRangePartitionedBackupTagsInfo()
+	                                                : logSystem->getOldEpochLogRouterTagsInfo();
+	std::map<LogEpoch, int32_t> progressTagCounts;
+	for (const auto& [workerId, workerStatus] : persisted.workers) {
+		(void)workerId;
+		auto [epochTagCount, inserted] = progressTagCounts.emplace(workerStatus.epoch, workerStatus.totalTags);
+		if (!inserted && epochTagCount->second != workerStatus.totalTags) {
+			TraceEvent(SevWarn, "OldBackupWorkerInconsistentProgress", self->id)
+			    .detail("Epoch", workerStatus.epoch)
+			    .detail("WorkerID", failedWorker.interf.id());
+			throw recruitment_failed();
+		}
+	}
+	Reference<BackupProgress> progress(new BackupProgress(self->id, epochInfos));
+	progress->setBackupStartedValue(persisted.started);
+	for (const auto& [workerId, workerStatus] : persisted.workers) {
+		(void)workerId;
+		progress->addBackupStatus(workerStatus);
+	}
+	auto unfinished = failedWorker.rangePartitioned ? progress->getUnfinishedRangePartitionedBackup()
+	                                                : progress->getUnfinishedPartitionedBackup();
+	auto unfinishedEpoch = std::find_if(unfinished.begin(), unfinished.end(), [&failedWorker](const auto& entry) {
+		return std::get<0>(entry.first) == failedWorker.backupEpoch;
+	});
+	if (unfinishedEpoch == unfinished.end()) {
+		removeFinishedOldBackupWorker(self, logSystem, failedWorker);
+		co_return;
+	}
+
+	Optional<Tag> tag = resolveOldBackupWorkerTag(failedWorker, oldWorkers, persisted.workers, unfinishedEpoch->second);
+	if (!tag.present()) {
+		if (status != persisted.workers.end() && !unfinishedEpoch->second.contains(status->second.tag)) {
+			removeFinishedOldBackupWorker(self, logSystem, failedWorker);
+			co_return;
+		}
+		TraceEvent(SevWarn, "OldBackupWorkerTagUnknown", self->id)
+		    .detail("Epoch", failedWorker.backupEpoch)
+		    .detail("WorkerID", failedWorker.interf.id());
+		throw recruitment_failed();
+	}
+	auto start = unfinishedEpoch->second.find(tag.get());
+	if (start == unfinishedEpoch->second.end()) {
+		throw recruitment_failed();
+	}
+
+	std::map<Optional<Standalone<StringRef>>, int> workersUsed;
+	self->updateKnownIds(&workersUsed);
+	auto candidates = self->getWorkersForRoleInDatacenter(failedWorker.interf.locality.dcId(),
+	                                                      recruitment::Backup,
+	                                                      static_cast<int>(self->id_worker.size()),
+	                                                      self->db.config,
+	                                                      workersUsed);
+	auto replacement = std::find_if(candidates.begin(), candidates.end(), [&failedWorker](const auto& candidate) {
+		return candidate.interf.locality.processId() != failedWorker.interf.locality.processId() &&
+		       candidate.interf.address() != failedWorker.interf.address();
+	});
+	if (replacement == candidates.end()) {
+		TraceEvent(SevWarn, "OldBackupWorkerNoReplacement", self->id)
+		    .detail("Epoch", failedWorker.backupEpoch)
+		    .detail("FailedWorkerID", failedWorker.interf.id());
+		throw recruitment_failed();
+	}
+
+	const Version endVersion = std::get<1>(unfinishedEpoch->first) - 1;
+	BackupInterface replacementInterface;
+	if (failedWorker.rangePartitioned) {
+		InitializeRangePartitionedBackupRequest request(deterministicRandom()->randomUniqueID());
+		request.recruitedEpoch = recoveryCount;
+		request.backupEpoch = failedWorker.backupEpoch;
+		request.tag = tag.get();
+		request.totalTags = std::get<2>(unfinishedEpoch->first);
+		request.startVersion = start->second;
+		request.endVersion = endVersion;
+		InitializeRangePartitionedBackupReply reply =
+		    co_await throwErrorOr(replacement->interf.rangePartitionedBackup.getReplyUnlessFailedFor(
+		        request, SERVER_KNOBS->BACKUP_TIMEOUT, SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY));
+		replacementInterface = reply.interf;
+	} else {
+		InitializeBackupRequest request(deterministicRandom()->randomUniqueID());
+		request.recruitedEpoch = recoveryCount;
+		request.backupEpoch = failedWorker.backupEpoch;
+		request.tag = tag.get();
+		request.totalTags = std::get<2>(unfinishedEpoch->first);
+		request.startVersion = start->second;
+		request.endVersion = endVersion;
+		InitializeBackupReply reply = co_await throwErrorOr(replacement->interf.backup.getReplyUnlessFailedFor(
+		    request, SERVER_KNOBS->BACKUP_TIMEOUT, SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY));
+		replacementInterface = reply.interf;
+	}
+
+	if (!isCurrentOldBackupRecovery(self, logSystem, recoveryCount)) {
+		co_return;
+	}
+	const bool replaced =
+	    logSystem->replaceBackupWorker(failedWorker.backupEpoch, failedWorker.interf.id(), replacementInterface);
+	if (replaced) {
+		self->db.recoveryData->registrationTrigger.trigger();
+		TraceEvent("OldBackupWorkerRecruited", self->id)
+		    .detail("Epoch", failedWorker.backupEpoch)
+		    .detail("FailedWorkerID", failedWorker.interf.id())
+		    .detail("ReplacementWorkerID", replacementInterface.id())
+		    .detail("Tag", tag.get().toString())
+		    .detail("StartVersion", start->second)
+		    .detail("EndVersion", endVersion)
+		    .detail("RangePartitioned", failedWorker.rangePartitioned);
+	} else {
+		self->db.recoveryData->registrationTrigger.trigger();
+	}
+}
+
+Future<Void> monitorAndRecruitOldBackupWorkers(ClusterControllerData* self) {
+	double failedRecruitDelay = 1.0;
+	while (true) {
+		while (!self->db.recoveryData.isValid() || !self->db.recoveryData->logSystem.isValid() ||
+		       !canMonitorOldBackupWorkers(self->db.serverInfo->get().recoveryState)) {
+			co_await self->db.serverInfo->onChange();
+		}
+
+		Reference<LogSystem> logSystem = self->db.recoveryData->logSystem;
+		const LogEpoch recoveryCount = self->db.recoveryData->cstate.myDBState.recoveryCount;
+		Error recruitmentError;
+		try {
+			Optional<OldBackupWorkerInfo> failed = co_await waitForFailedOldBackupWorker(self, logSystem);
+			if (!failed.present() || !isCurrentOldBackupRecovery(self, logSystem, recoveryCount)) {
+				continue;
+			}
+			co_await rerecruitFailedOldBackupWorker(self, logSystem, recoveryCount, failed.get());
+			failedRecruitDelay = 1.0;
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+			recruitmentError = e;
+			TraceEvent(SevWarnAlways, "OldBackupWorkerRecruitmentFailed", self->id)
+			    .error(e)
+			    .detail("RecoveryCount", recoveryCount)
+			    .detail("RetryDelay", failedRecruitDelay);
+		}
+		if (recruitmentError.code() != invalid_error_code) {
+			co_await delay(failedRecruitDelay);
+			failedRecruitDelay = std::min(failedRecruitDelay * 2, 60.0);
+		}
 	}
 }
 
@@ -3266,6 +3667,7 @@ ACTOR Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
 	// These actors also drain durable CDC state when new stream registration is disabled.
 	self.addActor.send(monitorCDCProxyAssignments(&self));
 	self.addActor.send(monitorAndRecruitCDCProxies(&self));
+	self.addActor.send(monitorAndRecruitOldBackupWorkers(&self));
 	self.addActor.send(updatedChangingDatacenters(&self));
 	self.addActor.send(updatedChangedDatacenters(&self));
 	self.addActor.send(updateDatacenterVersionDifference(&self));

--- a/fdbserver/clustercontroller/ClusterController.h
+++ b/fdbserver/clustercontroller/ClusterController.h
@@ -127,6 +127,28 @@ struct RecruitRemoteWorkersInfo : ReferenceCounted<RecruitRemoteWorkersInfo> {
 
 struct ClusterRecoveryData;
 
+struct OldBackupWorkerInfo {
+	LogEpoch backupEpoch;
+	Version epochEnd;
+	int totalTags;
+	bool rangePartitioned;
+	BackupInterface interf;
+};
+
+std::vector<OldBackupWorkerInfo> collectOldBackupWorkers(LogSystemConfig const& config);
+bool canMonitorOldBackupWorkers(RecoveryState recoveryState);
+bool shouldRestartOldBackupWorkerMonitor(RecoveryState recoveryState,
+                                         LogEpoch monitoredRecoveryCount,
+                                         LogEpoch currentRecoveryCount,
+                                         bool sameLogSystem);
+bool validateOldBackupWorkerProgress(OldBackupWorkerInfo const& failedWorker,
+                                     std::vector<OldBackupWorkerInfo> const& oldWorkers,
+                                     std::map<UID, WorkerBackupStatus> const& workerProgress);
+Optional<Tag> resolveOldBackupWorkerTag(OldBackupWorkerInfo const& failedWorker,
+                                        std::vector<OldBackupWorkerInfo> const& oldWorkers,
+                                        std::map<UID, WorkerBackupStatus> const& workerProgress,
+                                        std::map<Tag, Version> const& unfinishedTags);
+
 class ClusterControllerData {
 public:
 	struct DBInfo {

--- a/fdbserver/clustercontroller/OldBackupWorkerRecruitmentTests.cpp
+++ b/fdbserver/clustercontroller/OldBackupWorkerRecruitmentTests.cpp
@@ -1,0 +1,390 @@
+/*
+ * OldBackupWorkerRecruitmentTests.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ClusterController.h"
+
+#include "fdbserver/core/RecoveryState.h"
+#include "flow/UnitTest.h"
+
+namespace {
+
+BackupInterface makeBackupWorker(NetworkAddress const& address, UID id, std::string const& processId) {
+	LocalityData locality;
+	locality.set(LocalityData::keyProcessId, Standalone<StringRef>(processId));
+	BackupInterface worker(locality);
+	worker.waitFailure = RequestStream<ReplyPromise<Void>>(Endpoint({ address }, id));
+	return worker;
+}
+
+LogSystemConfig makeOldBackupConfiguration(LogEpoch currentEpoch,
+                                           LogEpoch oldEpoch,
+                                           Version oldEndVersion,
+                                           int oldClassicTags,
+                                           int oldRangePartitionedTags,
+                                           BackupInterface const& currentWorker,
+                                           std::vector<BackupInterface> const& oldWorkers) {
+	LogSystemConfig config(currentEpoch);
+	config.logRouterTags = 1;
+	config.rangePartitionedBackupWorkerTags = oldRangePartitionedTags > 0 ? 1 : 0;
+	config.oldestBackupEpoch = oldEpoch;
+
+	TLogSet currentSet;
+	currentSet.backupWorkers.emplace_back(currentWorker);
+	config.tLogs.push_back(currentSet);
+
+	TLogSet oldSet;
+	for (auto const& worker : oldWorkers) {
+		oldSet.backupWorkers.emplace_back(worker);
+	}
+	OldTLogConf old;
+	old.epoch = oldEpoch;
+	old.epochBegin = 100;
+	old.epochEnd = oldEndVersion;
+	old.logRouterTags = oldClassicTags;
+	old.rangePartitionedBackupWorkerTags = oldRangePartitionedTags;
+	old.tLogs.push_back(oldSet);
+	config.oldTLogs.push_back(old);
+	return config;
+}
+
+} // namespace
+
+TEST_CASE("/fdbserver/clustercontroller/oldBackupWorker/monitorBeforeFullyRecovered") {
+	ASSERT(!canMonitorOldBackupWorkers(RecoveryState::UNINITIALIZED));
+	ASSERT(!canMonitorOldBackupWorkers(RecoveryState::READING_CSTATE));
+	ASSERT(!canMonitorOldBackupWorkers(RecoveryState::LOCKING_CSTATE));
+	ASSERT(!canMonitorOldBackupWorkers(RecoveryState::RECRUITING));
+	ASSERT(!canMonitorOldBackupWorkers(RecoveryState::RECOVERY_TRANSACTION));
+	ASSERT(!canMonitorOldBackupWorkers(RecoveryState::WRITING_CSTATE));
+	ASSERT(canMonitorOldBackupWorkers(RecoveryState::ACCEPTING_COMMITS));
+	ASSERT(canMonitorOldBackupWorkers(RecoveryState::ALL_LOGS_RECRUITED));
+	ASSERT(canMonitorOldBackupWorkers(RecoveryState::STORAGE_RECOVERED));
+	ASSERT(canMonitorOldBackupWorkers(RecoveryState::FULLY_RECOVERED));
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/oldBackupWorker/preservesFailureDeadlineAcrossSameRecoveryDbInfoChanges") {
+	constexpr LogEpoch monitoredRecovery = 17;
+	for (int update = 0; update < 100; ++update) {
+		ASSERT(!shouldRestartOldBackupWorkerMonitor(
+		    RecoveryState::ACCEPTING_COMMITS, monitoredRecovery, monitoredRecovery, true));
+	}
+	ASSERT(!shouldRestartOldBackupWorkerMonitor(
+	    RecoveryState::ALL_LOGS_RECRUITED, monitoredRecovery, monitoredRecovery, true));
+	ASSERT(!shouldRestartOldBackupWorkerMonitor(
+	    RecoveryState::STORAGE_RECOVERED, monitoredRecovery, monitoredRecovery, true));
+	ASSERT(!shouldRestartOldBackupWorkerMonitor(
+	    RecoveryState::FULLY_RECOVERED, monitoredRecovery, monitoredRecovery, true));
+
+	ASSERT(shouldRestartOldBackupWorkerMonitor(
+	    RecoveryState::ACCEPTING_COMMITS, monitoredRecovery, monitoredRecovery + 1, true));
+	ASSERT(
+	    shouldRestartOldBackupWorkerMonitor(RecoveryState::WRITING_CSTATE, monitoredRecovery, monitoredRecovery, true));
+	ASSERT(shouldRestartOldBackupWorkerMonitor(
+	    RecoveryState::ACCEPTING_COMMITS, monitoredRecovery, monitoredRecovery, false));
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/oldBackupWorker/collectsOnlyOldGenerationInterfaces") {
+	constexpr LogEpoch currentEpoch = 20;
+	constexpr LogEpoch oldEpoch = 19;
+	NetworkAddress sharedAddress(IPAddress(0x01010101), 1);
+	BackupInterface currentWorker = makeBackupWorker(sharedAddress, UID(1, 1), "shared-process");
+	BackupInterface colocatedOldWorker = makeBackupWorker(sharedAddress, UID(1, 2), "shared-process");
+	BackupInterface oldOnlyWorker =
+	    makeBackupWorker(NetworkAddress(IPAddress(0x02020202), 1), UID(2, 1), "old-only-process");
+	LogSystemConfig config = makeOldBackupConfiguration(
+	    currentEpoch, oldEpoch, 500, 2, 0, currentWorker, { colocatedOldWorker, oldOnlyWorker });
+
+	std::vector<OldBackupWorkerInfo> oldWorkers = collectOldBackupWorkers(config);
+	ASSERT_EQ(oldWorkers.size(), 2);
+	ASSERT(oldWorkers[0].interf == colocatedOldWorker);
+	ASSERT(oldWorkers[1].interf == oldOnlyWorker);
+	ASSERT(oldWorkers[0].interf.id() != currentWorker.id());
+	ASSERT(oldWorkers[0].interf.address() == currentWorker.address());
+	ASSERT_EQ(oldWorkers[0].backupEpoch, oldEpoch);
+	ASSERT_EQ(oldWorkers[0].epochEnd, 500);
+	ASSERT_EQ(oldWorkers[0].totalTags, 2);
+	ASSERT(!oldWorkers[0].rangePartitioned);
+	ASSERT_EQ(oldWorkers[1].backupEpoch, oldEpoch);
+	ASSERT_EQ(oldWorkers[1].totalTags, 2);
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/oldBackupWorker/collectsRangePartitionedGeneration") {
+	constexpr LogEpoch currentEpoch = 30;
+	constexpr LogEpoch oldEpoch = 29;
+	BackupInterface currentWorker = makeBackupWorker(NetworkAddress(IPAddress(0x03030303), 1), UID(3, 1), "current");
+	BackupInterface oldWorker = makeBackupWorker(NetworkAddress(IPAddress(0x04040404), 1), UID(4, 1), "old-range");
+	LogSystemConfig config =
+	    makeOldBackupConfiguration(currentEpoch, oldEpoch, 800, 0, 3, currentWorker, { oldWorker });
+
+	std::vector<OldBackupWorkerInfo> oldWorkers = collectOldBackupWorkers(config);
+	ASSERT_EQ(oldWorkers.size(), 1);
+	ASSERT(oldWorkers[0].interf == oldWorker);
+	ASSERT(oldWorkers[0].rangePartitioned);
+	ASSERT_EQ(oldWorkers[0].totalTags, 3);
+	ASSERT_EQ(oldWorkers[0].backupEpoch, oldEpoch);
+	ASSERT_EQ(oldWorkers[0].epochEnd, 800);
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/oldBackupWorker/ignoresMissingWorkersAndZeroTagGenerations") {
+	constexpr LogEpoch currentEpoch = 80;
+	constexpr LogEpoch oldEpoch = 79;
+	BackupInterface currentWorker = makeBackupWorker(NetworkAddress(IPAddress(0x10101010), 1), UID(16, 1), "current");
+	BackupInterface oldWorker = makeBackupWorker(NetworkAddress(IPAddress(0x11111111), 1), UID(17, 1), "stale");
+
+	LogSystemConfig zeroTags =
+	    makeOldBackupConfiguration(currentEpoch, oldEpoch, 900, 0, 0, currentWorker, { oldWorker });
+	ASSERT(collectOldBackupWorkers(zeroTags).empty());
+
+	LogSystemConfig missing = makeOldBackupConfiguration(currentEpoch, oldEpoch, 900, 1, 0, currentWorker, {});
+	missing.oldTLogs[0].tLogs[0].backupWorkers.emplace_back(UID(99, 1));
+	ASSERT(collectOldBackupWorkers(missing).empty());
+
+	LogSystemConfig noOldGenerations(currentEpoch);
+	TLogSet currentSet;
+	currentSet.backupWorkers.emplace_back(currentWorker);
+	noOldGenerations.tLogs.push_back(currentSet);
+	ASSERT(collectOldBackupWorkers(noOldGenerations).empty());
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/oldBackupWorker/resolvesExactPersistedClassicTag") {
+	constexpr LogEpoch oldEpoch = 39;
+	BackupInterface currentWorker = makeBackupWorker(NetworkAddress(IPAddress(0x05050505), 1), UID(5, 1), "current");
+	BackupInterface firstOldWorker = makeBackupWorker(NetworkAddress(IPAddress(0x06060606), 1), UID(6, 1), "first");
+	BackupInterface failedWorker = makeBackupWorker(NetworkAddress(IPAddress(0x07070707), 1), UID(7, 1), "failed");
+	LogSystemConfig config =
+	    makeOldBackupConfiguration(oldEpoch + 1, oldEpoch, 600, 2, 0, currentWorker, { firstOldWorker, failedWorker });
+	std::vector<OldBackupWorkerInfo> oldWorkers = collectOldBackupWorkers(config);
+	Tag firstTag(tagLocalityLogRouter, 0);
+	Tag failedTag(tagLocalityLogRouter, 1);
+	std::map<UID, WorkerBackupStatus> progress;
+	progress.emplace(firstOldWorker.id(), WorkerBackupStatus(oldEpoch, 199, firstTag, 2));
+	progress.emplace(failedWorker.id(), WorkerBackupStatus(oldEpoch, 349, failedTag, 2));
+	std::map<Tag, Version> unfinished{ { firstTag, 200 }, { failedTag, 350 } };
+
+	Optional<Tag> resolved = resolveOldBackupWorkerTag(oldWorkers[1], oldWorkers, progress, unfinished);
+	ASSERT(resolved.present());
+	ASSERT(resolved.get() == failedTag);
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/oldBackupWorker/resolvesExactPersistedRangePartitionedTag") {
+	constexpr LogEpoch oldEpoch = 49;
+	BackupInterface currentWorker = makeBackupWorker(NetworkAddress(IPAddress(0x08080808), 1), UID(8, 1), "current");
+	BackupInterface failedWorker = makeBackupWorker(NetworkAddress(IPAddress(0x09090909), 1), UID(9, 1), "failed");
+	LogSystemConfig config =
+	    makeOldBackupConfiguration(oldEpoch + 1, oldEpoch, 900, 0, 2, currentWorker, { failedWorker });
+	std::vector<OldBackupWorkerInfo> oldWorkers = collectOldBackupWorkers(config);
+	Tag failedTag(tagLocalityRangePartitionedBackup, 1);
+	std::map<UID, WorkerBackupStatus> progress;
+	progress.emplace(failedWorker.id(), WorkerBackupStatus(oldEpoch, 450, failedTag, 2));
+	std::map<Tag, Version> unfinished{ { Tag(tagLocalityRangePartitionedBackup, 0), 100 }, { failedTag, 451 } };
+
+	Optional<Tag> resolved = resolveOldBackupWorkerTag(oldWorkers[0], oldWorkers, progress, unfinished);
+	ASSERT(resolved.present());
+	ASSERT(resolved.get() == failedTag);
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/oldBackupWorker/infersDistinctMissingProgressTags") {
+	constexpr LogEpoch oldEpoch = 59;
+	BackupInterface currentWorker = makeBackupWorker(NetworkAddress(IPAddress(0x0a0a0a0a), 1), UID(10, 1), "current");
+	BackupInterface knownWorker = makeBackupWorker(NetworkAddress(IPAddress(0x0b0b0b0b), 1), UID(11, 1), "known");
+	BackupInterface firstUnsavedWorker =
+	    makeBackupWorker(NetworkAddress(IPAddress(0x0c0c0c0c), 1), UID(12, 1), "first-unsaved");
+	BackupInterface secondUnsavedWorker =
+	    makeBackupWorker(NetworkAddress(IPAddress(0x0d0d0d0d), 1), UID(13, 1), "second-unsaved");
+	LogSystemConfig config = makeOldBackupConfiguration(
+	    oldEpoch + 1, oldEpoch, 700, 3, 0, currentWorker, { knownWorker, firstUnsavedWorker, secondUnsavedWorker });
+	std::vector<OldBackupWorkerInfo> oldWorkers = collectOldBackupWorkers(config);
+	Tag knownTag(tagLocalityLogRouter, 0);
+	Tag firstUnsavedTag(tagLocalityLogRouter, 1);
+	Tag secondUnsavedTag(tagLocalityLogRouter, 2);
+	std::map<UID, WorkerBackupStatus> progress;
+	progress.emplace(knownWorker.id(), WorkerBackupStatus(oldEpoch, 150, knownTag, 3));
+	std::map<Tag, Version> unfinished{ { knownTag, 151 }, { firstUnsavedTag, 100 }, { secondUnsavedTag, 100 } };
+
+	Optional<Tag> firstResolved = resolveOldBackupWorkerTag(oldWorkers[1], oldWorkers, progress, unfinished);
+	Optional<Tag> secondResolved = resolveOldBackupWorkerTag(oldWorkers[2], oldWorkers, progress, unfinished);
+	ASSERT(firstResolved.present());
+	ASSERT(secondResolved.present());
+	ASSERT(firstResolved.get() == firstUnsavedTag);
+	ASSERT(secondResolved.get() == secondUnsavedTag);
+	ASSERT(firstResolved.get() != secondResolved.get());
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/oldBackupWorker/ambiguousMissingProgressFailsClosed") {
+	constexpr LogEpoch oldEpoch = 89;
+	BackupInterface currentWorker = makeBackupWorker(NetworkAddress(IPAddress(0x12121212), 1), UID(18, 1), "current");
+	BackupInterface firstUnsavedWorker =
+	    makeBackupWorker(NetworkAddress(IPAddress(0x13131313), 1), UID(19, 1), "first-unsaved");
+	BackupInterface failedWorker =
+	    makeBackupWorker(NetworkAddress(IPAddress(0x14141414), 1), UID(20, 1), "failed-unsaved");
+	LogSystemConfig config = makeOldBackupConfiguration(
+	    oldEpoch + 1, oldEpoch, 800, 2, 0, currentWorker, { firstUnsavedWorker, failedWorker });
+	std::vector<OldBackupWorkerInfo> oldWorkers = collectOldBackupWorkers(config);
+	std::map<Tag, Version> unfinished{ { Tag(tagLocalityLogRouter, 1), 300 } };
+	std::map<UID, WorkerBackupStatus> progress;
+
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[1], oldWorkers, progress, unfinished).present());
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/oldBackupWorker/rejectsInvalidSiblingProgressAndDuplicateTags") {
+	constexpr LogEpoch oldEpoch = 99;
+	BackupInterface currentWorker = makeBackupWorker(NetworkAddress(IPAddress(0x15151515), 1), UID(21, 1), "current");
+	BackupInterface firstSibling = makeBackupWorker(NetworkAddress(IPAddress(0x16161616), 1), UID(22, 1), "first");
+	BackupInterface secondSibling = makeBackupWorker(NetworkAddress(IPAddress(0x17171717), 1), UID(23, 1), "second");
+	BackupInterface failedWorker = makeBackupWorker(NetworkAddress(IPAddress(0x18181818), 1), UID(24, 1), "failed");
+	LogSystemConfig config = makeOldBackupConfiguration(
+	    oldEpoch + 1, oldEpoch, 900, 3, 0, currentWorker, { firstSibling, secondSibling, failedWorker });
+	std::vector<OldBackupWorkerInfo> oldWorkers = collectOldBackupWorkers(config);
+	Tag firstTag(tagLocalityLogRouter, 0);
+	Tag secondTag(tagLocalityLogRouter, 1);
+	Tag failedTag(tagLocalityLogRouter, 2);
+	std::map<Tag, Version> unfinished{ { firstTag, 200 }, { secondTag, 300 }, { failedTag, 400 } };
+	std::map<UID, WorkerBackupStatus> progress;
+
+	progress.emplace(firstSibling.id(), WorkerBackupStatus(oldEpoch - 1, 199, firstTag, 3));
+	progress.emplace(secondSibling.id(), WorkerBackupStatus(oldEpoch, 299, secondTag, 3));
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[2], oldWorkers, progress, unfinished).present());
+
+	progress.clear();
+	progress.emplace(firstSibling.id(),
+	                 WorkerBackupStatus(oldEpoch, 199, Tag(tagLocalityRangePartitionedBackup, 0), 3));
+	progress.emplace(secondSibling.id(), WorkerBackupStatus(oldEpoch, 299, secondTag, 3));
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[2], oldWorkers, progress, unfinished).present());
+
+	progress.clear();
+	progress.emplace(firstSibling.id(), WorkerBackupStatus(oldEpoch, 199, firstTag, 4));
+	progress.emplace(secondSibling.id(), WorkerBackupStatus(oldEpoch, 299, secondTag, 3));
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[2], oldWorkers, progress, unfinished).present());
+
+	progress.clear();
+	progress.emplace(firstSibling.id(), WorkerBackupStatus(oldEpoch, 199, firstTag, 3));
+	progress.emplace(secondSibling.id(), WorkerBackupStatus(oldEpoch, 299, firstTag, 3));
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[2], oldWorkers, progress, unfinished).present());
+
+	progress.clear();
+	progress.emplace(firstSibling.id(), WorkerBackupStatus(oldEpoch - 1, 199, firstTag, 3));
+	progress.emplace(secondSibling.id(), WorkerBackupStatus(oldEpoch, 299, secondTag, 3));
+	progress.emplace(failedWorker.id(), WorkerBackupStatus(oldEpoch, 399, failedTag, 3));
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[2], oldWorkers, progress, unfinished).present());
+
+	progress.clear();
+	progress.emplace(firstSibling.id(),
+	                 WorkerBackupStatus(oldEpoch, 199, Tag(tagLocalityRangePartitionedBackup, 0), 3));
+	progress.emplace(secondSibling.id(), WorkerBackupStatus(oldEpoch, 299, secondTag, 3));
+	progress.emplace(failedWorker.id(), WorkerBackupStatus(oldEpoch, 399, failedTag, 3));
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[2], oldWorkers, progress, unfinished).present());
+
+	progress.clear();
+	progress.emplace(firstSibling.id(), WorkerBackupStatus(oldEpoch, 199, firstTag, 4));
+	progress.emplace(secondSibling.id(), WorkerBackupStatus(oldEpoch, 299, secondTag, 3));
+	progress.emplace(failedWorker.id(), WorkerBackupStatus(oldEpoch, 399, failedTag, 3));
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[2], oldWorkers, progress, unfinished).present());
+
+	progress.clear();
+	progress.emplace(firstSibling.id(), WorkerBackupStatus(oldEpoch, 199, firstTag, 3));
+	progress.emplace(secondSibling.id(), WorkerBackupStatus(oldEpoch, 299, secondTag, 3));
+	progress.emplace(failedWorker.id(), WorkerBackupStatus(oldEpoch, 399, secondTag, 3));
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[2], oldWorkers, progress, unfinished).present());
+
+	progress.clear();
+	progress.emplace(firstSibling.id(), WorkerBackupStatus(oldEpoch, 199, firstTag, 3));
+	progress.emplace(secondSibling.id(), WorkerBackupStatus(oldEpoch, 299, firstTag, 3));
+	progress.emplace(failedWorker.id(), WorkerBackupStatus(oldEpoch, 399, failedTag, 3));
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[2], oldWorkers, progress, unfinished).present());
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/oldBackupWorker/validatesPersistedProgressBeforeAggregation") {
+	constexpr LogEpoch oldEpoch = 109;
+	BackupInterface currentWorker = makeBackupWorker(NetworkAddress(IPAddress(0x19191919), 1), UID(25, 1), "current");
+	BackupInterface firstSibling = makeBackupWorker(NetworkAddress(IPAddress(0x1a1a1a1a), 1), UID(26, 1), "first");
+	BackupInterface secondSibling = makeBackupWorker(NetworkAddress(IPAddress(0x1b1b1b1b), 1), UID(27, 1), "second");
+	BackupInterface failedWorker = makeBackupWorker(NetworkAddress(IPAddress(0x1c1c1c1c), 1), UID(28, 1), "failed");
+	LogSystemConfig config = makeOldBackupConfiguration(
+	    oldEpoch + 1, oldEpoch, 1'000, 3, 0, currentWorker, { firstSibling, secondSibling, failedWorker });
+	std::vector<OldBackupWorkerInfo> oldWorkers = collectOldBackupWorkers(config);
+	Tag firstTag(tagLocalityLogRouter, 0);
+	Tag secondTag(tagLocalityLogRouter, 1);
+	Tag failedTag(tagLocalityLogRouter, 2);
+	std::map<UID, WorkerBackupStatus> progress;
+	progress.emplace(firstSibling.id(), WorkerBackupStatus(oldEpoch, 199, firstTag, 3));
+	progress.emplace(secondSibling.id(), WorkerBackupStatus(oldEpoch, 299, secondTag, 3));
+	ASSERT(validateOldBackupWorkerProgress(oldWorkers[2], oldWorkers, progress));
+
+	progress.emplace(failedWorker.id(), WorkerBackupStatus(oldEpoch, 399, failedTag, 3));
+	ASSERT(validateOldBackupWorkerProgress(oldWorkers[2], oldWorkers, progress));
+
+	progress[firstSibling.id()] = WorkerBackupStatus(oldEpoch - 1, 199, firstTag, 3);
+	ASSERT(!validateOldBackupWorkerProgress(oldWorkers[2], oldWorkers, progress));
+
+	progress[firstSibling.id()] = WorkerBackupStatus(oldEpoch, 199, Tag(tagLocalityRangePartitionedBackup, 0), 3);
+	ASSERT(!validateOldBackupWorkerProgress(oldWorkers[2], oldWorkers, progress));
+
+	progress[firstSibling.id()] = WorkerBackupStatus(oldEpoch, 199, firstTag, 4);
+	ASSERT(!validateOldBackupWorkerProgress(oldWorkers[2], oldWorkers, progress));
+
+	progress[firstSibling.id()] = WorkerBackupStatus(oldEpoch, 199, secondTag, 3);
+	ASSERT(!validateOldBackupWorkerProgress(oldWorkers[2], oldWorkers, progress));
+
+	progress[firstSibling.id()] = WorkerBackupStatus(oldEpoch, 199, failedTag, 3);
+	ASSERT(!validateOldBackupWorkerProgress(oldWorkers[2], oldWorkers, progress));
+	return Void();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/oldBackupWorker/rejectsStaleFinishedAndWrongFlavorTags") {
+	constexpr LogEpoch oldEpoch = 69;
+	BackupInterface currentWorker = makeBackupWorker(NetworkAddress(IPAddress(0x0e0e0e0e), 1), UID(14, 1), "current");
+	BackupInterface failedWorker = makeBackupWorker(NetworkAddress(IPAddress(0x0f0f0f0f), 1), UID(15, 1), "failed");
+	LogSystemConfig config =
+	    makeOldBackupConfiguration(oldEpoch + 1, oldEpoch, 750, 2, 0, currentWorker, { failedWorker });
+	std::vector<OldBackupWorkerInfo> oldWorkers = collectOldBackupWorkers(config);
+	Tag classicTag(tagLocalityLogRouter, 1);
+	Tag rangeTag(tagLocalityRangePartitionedBackup, 1);
+	std::map<Tag, Version> unfinished{ { classicTag, 300 } };
+	std::map<UID, WorkerBackupStatus> progress;
+
+	progress.emplace(failedWorker.id(), WorkerBackupStatus(oldEpoch - 1, 299, classicTag, 2));
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[0], oldWorkers, progress, unfinished).present());
+
+	progress.clear();
+	progress.emplace(failedWorker.id(), WorkerBackupStatus(oldEpoch, 299, rangeTag, 2));
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[0], oldWorkers, progress, unfinished).present());
+
+	progress.clear();
+	progress.emplace(failedWorker.id(), WorkerBackupStatus(oldEpoch, 299, classicTag, 3));
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[0], oldWorkers, progress, unfinished).present());
+
+	progress.clear();
+	progress.emplace(failedWorker.id(), WorkerBackupStatus(oldEpoch, 749, classicTag, 2));
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[0], oldWorkers, progress, {}).present());
+
+	progress.clear();
+	ASSERT(!resolveOldBackupWorkerTag(oldWorkers[0], oldWorkers, progress, {}).present());
+	return Void();
+}

--- a/fdbserver/logsystem/LogSystem.cpp
+++ b/fdbserver/logsystem/LogSystem.cpp
@@ -1355,6 +1355,45 @@ void LogSystem::setRangePartitionedBackupWorkers(const std::vector<InitializeRan
 	backupWorkerChanged.trigger();
 }
 
+bool LogSystem::replaceBackupWorker(LogEpoch backupEpoch, UID failedWorkerId, BackupInterface const& replacement) {
+	Reference<LogSet> logset = getEpochLogSet(backupEpoch);
+	if (!logset.isValid()) {
+		return false;
+	}
+
+	for (auto worker = logset->backupWorkers.begin(); worker != logset->backupWorkers.end(); ++worker) {
+		if ((*worker)->get().id() != failedWorkerId) {
+			continue;
+		}
+
+		if (removedBackupWorkers.erase(replacement.id()) != 0) {
+			logset->backupWorkers.erase(worker);
+			oldestBackupEpoch = epoch;
+			for (const auto& old : oldLogData) {
+				if (old.epoch < oldestBackupEpoch && !old.tLogs[0]->backupWorkers.empty()) {
+					oldestBackupEpoch = old.epoch;
+				}
+			}
+			backupWorkerChanged.trigger();
+			TraceEvent("OldBackupWorkerReplacementAlreadyDone", dbgid)
+			    .detail("Epoch", backupEpoch)
+			    .detail("FailedWorkerID", failedWorkerId)
+			    .detail("ReplacementWorkerID", replacement.id());
+			return false;
+		}
+
+		(*worker)->set(OptionalInterface<BackupInterface>(replacement));
+		backupWorkerChanged.trigger();
+		TraceEvent("OldBackupWorkerReplaced", dbgid)
+		    .detail("Epoch", backupEpoch)
+		    .detail("FailedWorkerID", failedWorkerId)
+		    .detail("ReplacementWorkerID", replacement.id());
+		return true;
+	}
+
+	return false;
+}
+
 bool LogSystem::removeBackupWorker(const BackupWorkerDoneRequest& req) {
 	bool removed = false;
 	Reference<LogSet> logset = getEpochLogSet(req.backupEpoch);

--- a/fdbserver/logsystem/LogSystemRecoveryTests.cpp
+++ b/fdbserver/logsystem/LogSystemRecoveryTests.cpp
@@ -34,6 +34,19 @@ Reference<LogSet> makeSingleLogSet(const std::vector<TLogInterface>& tlogs, bool
 	return logSet;
 }
 
+BackupInterface makeBackupWorkerInterface(NetworkAddress const& address, UID id, std::string const& processId) {
+	LocalityData locality;
+	locality.set(LocalityData::keyProcessId, Standalone<StringRef>(processId));
+	BackupInterface worker(locality);
+	worker.waitFailure = RequestStream<ReplyPromise<Void>>(Endpoint({ address }, id));
+	return worker;
+}
+
+void addBackupWorker(Reference<LogSet> const& logSet, BackupInterface const& worker) {
+	logSet->backupWorkers.push_back(
+	    makeReference<AsyncVar<OptionalInterface<BackupInterface>>>(OptionalInterface<BackupInterface>(worker)));
+}
+
 std::tuple<int, std::vector<TLogLockResult>, bool> makeLogGroupResults(
     int replicationFactor,
     const std::vector<std::vector<UnknownCommittedVersions>>& perTLogUCV,
@@ -111,6 +124,243 @@ TEST_CASE("/LogSystem/PeekLogRouter/EmptyOldRangeIsExhausted") {
 	auto cursor = consumer.peekLogRouter(router.id(), old.epochEnd, Tag(tagLocalityLogRouter, 0), false);
 	ASSERT(cursor->isExhausted());
 	ASSERT(cursor->version().version == old.epochEnd);
+	return Void();
+}
+
+TEST_CASE("/LogSystem/ReplaceBackupWorker/OldOnlyWorkerWithMoreRetainedTags") {
+	constexpr LogEpoch currentEpoch = 10;
+	constexpr LogEpoch oldEpoch = 9;
+	auto logSystem = makeReference<LogSystem>(UID(), LocalityData(), currentEpoch);
+	logSystem->logRouterTags = 1;
+	logSystem->oldestBackupEpoch = oldEpoch;
+
+	BackupInterface currentWorker =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x01010101), 1), UID(1, 1), "current");
+	BackupInterface firstOldWorker =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x02020202), 1), UID(2, 1), "old-first");
+	BackupInterface oldOnlyWorker =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x03030303), 1), UID(3, 1), "old-only");
+	BackupInterface replacement =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x04040404), 1), UID(4, 1), "replacement");
+
+	auto currentSet = makeReference<LogSet>();
+	addBackupWorker(currentSet, currentWorker);
+	logSystem->tLogs.push_back(currentSet);
+
+	auto oldSet = makeReference<LogSet>();
+	addBackupWorker(oldSet, firstOldWorker);
+	addBackupWorker(oldSet, oldOnlyWorker);
+	OldLogData old;
+	old.epoch = oldEpoch;
+	old.logRouterTags = 2;
+	old.tLogs.push_back(oldSet);
+	logSystem->oldLogData.push_back(old);
+
+	auto observedOldWorker = oldSet->backupWorkers[1];
+	Future<Void> interfaceChanged = observedOldWorker->onChange();
+	Future<Void> backupChanged = logSystem->backupWorkerChanged.onTrigger();
+	ASSERT(logSystem->replaceBackupWorker(oldEpoch, oldOnlyWorker.id(), replacement));
+	ASSERT(interfaceChanged.isReady());
+	ASSERT(backupChanged.isReady());
+	ASSERT_EQ(logSystem->epoch, currentEpoch);
+	ASSERT_EQ(logSystem->getOldestBackupEpoch(), oldEpoch);
+	ASSERT_EQ(logSystem->logRouterTags, 1);
+	ASSERT_EQ(logSystem->oldLogData[0].logRouterTags, 2);
+	ASSERT_EQ(currentSet->backupWorkers.size(), 1);
+	ASSERT(currentSet->backupWorkers[0]->get().interf() == currentWorker);
+	ASSERT_EQ(oldSet->backupWorkers.size(), 2);
+	ASSERT(oldSet->backupWorkers[0]->get().interf() == firstOldWorker);
+	ASSERT(oldSet->backupWorkers[1] == observedOldWorker);
+	ASSERT(oldSet->backupWorkers[1]->get().interf() == replacement);
+	return Void();
+}
+
+TEST_CASE("/LogSystem/ReplaceBackupWorker/ColocatedCurrentRoleDoesNotChange") {
+	constexpr LogEpoch currentEpoch = 20;
+	constexpr LogEpoch oldEpoch = 19;
+	NetworkAddress sharedAddress(IPAddress(0x05050505), 1);
+	BackupInterface currentWorker = makeBackupWorkerInterface(sharedAddress, UID(5, 1), "shared-worker");
+	BackupInterface colocatedOldWorker = makeBackupWorkerInterface(sharedAddress, UID(5, 2), "shared-worker");
+	BackupInterface replacement =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x06060606), 1), UID(6, 1), "replacement");
+
+	auto logSystem = makeReference<LogSystem>(UID(), LocalityData(), currentEpoch);
+	logSystem->oldestBackupEpoch = oldEpoch;
+	const bool recoveryWasComplete = logSystem->recoveryCompleteWrittenToCoreState.get();
+	auto currentSet = makeReference<LogSet>();
+	addBackupWorker(currentSet, currentWorker);
+	logSystem->tLogs.push_back(currentSet);
+	auto oldSet = makeReference<LogSet>();
+	addBackupWorker(oldSet, colocatedOldWorker);
+	OldLogData old;
+	old.epoch = oldEpoch;
+	old.tLogs.push_back(oldSet);
+	logSystem->oldLogData.push_back(old);
+
+	auto observedOldWorker = oldSet->backupWorkers[0];
+	Future<Void> interfaceChanged = observedOldWorker->onChange();
+	ASSERT(currentWorker.address() == colocatedOldWorker.address());
+	ASSERT(currentWorker.locality.processId() == colocatedOldWorker.locality.processId());
+	ASSERT(currentWorker.id() != colocatedOldWorker.id());
+	ASSERT(logSystem->replaceBackupWorker(oldEpoch, colocatedOldWorker.id(), replacement));
+	ASSERT(interfaceChanged.isReady());
+	ASSERT_EQ(logSystem->epoch, currentEpoch);
+	ASSERT_EQ(logSystem->getOldestBackupEpoch(), oldEpoch);
+	ASSERT_EQ(logSystem->recoveryCompleteWrittenToCoreState.get(), recoveryWasComplete);
+	ASSERT_EQ(currentSet->backupWorkers.size(), 1);
+	ASSERT(currentSet->backupWorkers[0]->get().interf() == currentWorker);
+	ASSERT_EQ(oldSet->backupWorkers.size(), 1);
+	ASSERT(oldSet->backupWorkers[0] == observedOldWorker);
+	ASSERT(oldSet->backupWorkers[0]->get().interf() == replacement);
+	return Void();
+}
+
+TEST_CASE("/LogSystem/ReplaceBackupWorker/StaleAndCurrentGenerationRequestsFailClosed") {
+	constexpr LogEpoch currentEpoch = 30;
+	constexpr LogEpoch oldEpoch = 29;
+	BackupInterface currentWorker =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x07070707), 1), UID(7, 1), "current");
+	BackupInterface oldWorker = makeBackupWorkerInterface(NetworkAddress(IPAddress(0x08080808), 1), UID(8, 1), "old");
+	BackupInterface replacement =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x09090909), 1), UID(9, 1), "replacement");
+
+	auto logSystem = makeReference<LogSystem>(UID(), LocalityData(), currentEpoch);
+	logSystem->oldestBackupEpoch = oldEpoch;
+	auto currentSet = makeReference<LogSet>();
+	addBackupWorker(currentSet, currentWorker);
+	logSystem->tLogs.push_back(currentSet);
+	auto oldSet = makeReference<LogSet>();
+	addBackupWorker(oldSet, oldWorker);
+	OldLogData old;
+	old.epoch = oldEpoch;
+	old.tLogs.push_back(oldSet);
+	logSystem->oldLogData.push_back(old);
+
+	auto observedOldWorker = oldSet->backupWorkers[0];
+	Future<Void> interfaceChanged = observedOldWorker->onChange();
+	Future<Void> backupChanged = logSystem->backupWorkerChanged.onTrigger();
+	ASSERT(!logSystem->replaceBackupWorker(currentEpoch, currentWorker.id(), replacement));
+	ASSERT(!logSystem->replaceBackupWorker(oldEpoch - 1, oldWorker.id(), replacement));
+	ASSERT(!logSystem->replaceBackupWorker(oldEpoch, UID(99, 1), replacement));
+	ASSERT(!logSystem->replaceBackupWorker(oldEpoch, currentWorker.id(), replacement));
+	ASSERT(!interfaceChanged.isReady());
+	ASSERT(!backupChanged.isReady());
+	ASSERT_EQ(logSystem->getOldestBackupEpoch(), oldEpoch);
+	ASSERT(currentSet->backupWorkers[0]->get().interf() == currentWorker);
+	ASSERT(oldSet->backupWorkers[0]->get().interf() == oldWorker);
+
+	ASSERT(logSystem->replaceBackupWorker(oldEpoch, oldWorker.id(), replacement));
+	ASSERT(interfaceChanged.isReady());
+	ASSERT(backupChanged.isReady());
+	ASSERT(oldSet->backupWorkers[0] == observedOldWorker);
+	ASSERT(oldSet->backupWorkers[0]->get().interf() == replacement);
+	return Void();
+}
+
+TEST_CASE("/LogSystem/ReplaceBackupWorker/StaleCompletionCannotRemoveReplacement") {
+	constexpr LogEpoch currentEpoch = 40;
+	constexpr LogEpoch oldEpoch = 39;
+	BackupInterface currentWorker =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x0a0a0a0a), 1), UID(10, 1), "current");
+	BackupInterface oldWorker = makeBackupWorkerInterface(NetworkAddress(IPAddress(0x0b0b0b0b), 1), UID(11, 1), "old");
+	BackupInterface replacement =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x0c0c0c0c), 1), UID(12, 1), "replacement");
+
+	auto logSystem = makeReference<LogSystem>(UID(), LocalityData(), currentEpoch);
+	logSystem->oldestBackupEpoch = oldEpoch;
+	auto currentSet = makeReference<LogSet>();
+	addBackupWorker(currentSet, currentWorker);
+	logSystem->tLogs.push_back(currentSet);
+	auto oldSet = makeReference<LogSet>();
+	addBackupWorker(oldSet, oldWorker);
+	OldLogData old;
+	old.epoch = oldEpoch;
+	old.tLogs.push_back(oldSet);
+	logSystem->oldLogData.push_back(old);
+
+	ASSERT(logSystem->replaceBackupWorker(oldEpoch, oldWorker.id(), replacement));
+	ASSERT(!logSystem->removeBackupWorker(BackupWorkerDoneRequest(oldWorker.id(), oldEpoch)));
+	ASSERT_EQ(oldSet->backupWorkers.size(), 1);
+	ASSERT(oldSet->backupWorkers[0]->get().interf() == replacement);
+	ASSERT_EQ(logSystem->getOldestBackupEpoch(), oldEpoch);
+
+	ASSERT(logSystem->removeBackupWorker(BackupWorkerDoneRequest(replacement.id(), oldEpoch)));
+	ASSERT(oldSet->backupWorkers.empty());
+	ASSERT_EQ(logSystem->getOldestBackupEpoch(), currentEpoch);
+	ASSERT(currentSet->backupWorkers[0]->get().interf() == currentWorker);
+	return Void();
+}
+
+TEST_CASE("/LogSystem/ReplaceBackupWorker/CompletedReplacementIsNotInstalled") {
+	constexpr LogEpoch currentEpoch = 45;
+	constexpr LogEpoch oldEpoch = 44;
+	BackupInterface currentWorker =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x11111111), 1), UID(17, 1), "current");
+	BackupInterface oldWorker = makeBackupWorkerInterface(NetworkAddress(IPAddress(0x12121212), 1), UID(18, 1), "old");
+	BackupInterface completedReplacement =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x13131313), 1), UID(19, 1), "completed-replacement");
+
+	auto logSystem = makeReference<LogSystem>(UID(), LocalityData(), currentEpoch);
+	logSystem->oldestBackupEpoch = oldEpoch;
+	auto currentSet = makeReference<LogSet>();
+	addBackupWorker(currentSet, currentWorker);
+	logSystem->tLogs.push_back(currentSet);
+	auto oldSet = makeReference<LogSet>();
+	addBackupWorker(oldSet, oldWorker);
+	OldLogData old;
+	old.epoch = oldEpoch;
+	old.tLogs.push_back(oldSet);
+	logSystem->oldLogData.push_back(old);
+
+	ASSERT(!logSystem->removeBackupWorker(BackupWorkerDoneRequest(completedReplacement.id(), oldEpoch)));
+	ASSERT(logSystem->removedBackupWorkers.contains(completedReplacement.id()));
+	Future<Void> backupChanged = logSystem->backupWorkerChanged.onTrigger();
+	ASSERT(!logSystem->replaceBackupWorker(oldEpoch, oldWorker.id(), completedReplacement));
+	ASSERT(backupChanged.isReady());
+	ASSERT(!logSystem->removedBackupWorkers.contains(completedReplacement.id()));
+	ASSERT(oldSet->backupWorkers.empty());
+	ASSERT_EQ(logSystem->epoch, currentEpoch);
+	ASSERT_EQ(logSystem->getOldestBackupEpoch(), currentEpoch);
+	ASSERT_EQ(currentSet->backupWorkers.size(), 1);
+	ASSERT(currentSet->backupWorkers[0]->get().interf() == currentWorker);
+	return Void();
+}
+
+TEST_CASE("/LogSystem/ReplaceBackupWorker/RangePartitionedRetainedGeneration") {
+	constexpr LogEpoch currentEpoch = 50;
+	constexpr LogEpoch oldEpoch = 49;
+	BackupInterface currentWorker =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x0d0d0d0d), 1), UID(13, 1), "current-range");
+	BackupInterface firstOldWorker =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x0e0e0e0e), 1), UID(14, 1), "old-range-first");
+	BackupInterface failedOldWorker =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x0f0f0f0f), 1), UID(15, 1), "old-range-failed");
+	BackupInterface replacement =
+	    makeBackupWorkerInterface(NetworkAddress(IPAddress(0x10101010), 1), UID(16, 1), "range-replacement");
+
+	auto logSystem = makeReference<LogSystem>(UID(), LocalityData(), currentEpoch);
+	logSystem->oldestBackupEpoch = oldEpoch;
+	logSystem->rangePartitionedBackupWorkerTags = 1;
+	auto currentSet = makeReference<LogSet>();
+	addBackupWorker(currentSet, currentWorker);
+	logSystem->tLogs.push_back(currentSet);
+	auto oldSet = makeReference<LogSet>();
+	addBackupWorker(oldSet, firstOldWorker);
+	addBackupWorker(oldSet, failedOldWorker);
+	OldLogData old;
+	old.epoch = oldEpoch;
+	old.rangePartitionedBackupWorkerTags = 2;
+	old.tLogs.push_back(oldSet);
+	logSystem->oldLogData.push_back(old);
+
+	ASSERT(logSystem->replaceBackupWorker(oldEpoch, failedOldWorker.id(), replacement));
+	ASSERT_EQ(logSystem->epoch, currentEpoch);
+	ASSERT_EQ(logSystem->getOldestBackupEpoch(), oldEpoch);
+	ASSERT_EQ(logSystem->rangePartitionedBackupWorkerTags, 1);
+	ASSERT_EQ(logSystem->oldLogData[0].rangePartitionedBackupWorkerTags, 2);
+	ASSERT(currentSet->backupWorkers[0]->get().interf() == currentWorker);
+	ASSERT(oldSet->backupWorkers[0]->get().interf() == firstOldWorker);
+	ASSERT(oldSet->backupWorkers[1]->get().interf() == replacement);
 	return Void();
 }
 

--- a/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
+++ b/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
@@ -472,6 +472,7 @@ struct LogSystem : ReferenceCounted<LogSystem> {
 
 	void setBackupWorkers(const std::vector<InitializeBackupReply>& replies);
 	void setRangePartitionedBackupWorkers(const std::vector<InitializeRangePartitionedBackupReply>& replies);
+	bool replaceBackupWorker(LogEpoch backupEpoch, UID failedWorkerId, BackupInterface const& replacement);
 
 	bool removeBackupWorker(const BackupWorkerDoneRequest& req);
 


### PR DESCRIPTION
## Summary

- Monitor failed backup workers retained for older transaction-log epochs without restarting transaction-system recovery or disturbing current-generation roles.
- Re-recruit classic and range-partitioned backup workers from persisted progress, including workers that fail before their first progress update.
- Fail closed on stale or ambiguous worker state, preserve failure-detection deadlines across controller updates, and handle replacement/completion races.
- Add focused regression coverage for old-only and colocated workers, both backup formats, first-save failures, malformed progress, and replacement lifecycle invariants.

## Validation

- `fdbserver_logsystem_test`: 23 tests passed, including six focused old-generation replacement regressions.
- `fdbserver_clustercontroller_test`: 34 tests passed, including twelve focused monitoring, persisted-progress, and rerecruitment regressions.
- `tests/slow/BackupAndRestore.toml`: passed with fault injection and buggification enabled.
- `tests/slow/BackupCorrectnessPartitioned.toml`: passed with fault injection and buggification enabled.
