### PR TITLE
Exclude sharded RocksDB from DDPipelineSaturation to stop OOM failures

### DIFF
--- a/tests/fast/DDPipelineSaturation.toml
+++ b/tests/fast/DDPipelineSaturation.toml
@@ -5,6 +5,19 @@
 # DDRelocationQueue.actor.cpp. The limit is pinned to 20 -- the realistic
 # low end of the knob's range -- rather than an unrealistically small value
 # that would destabilize unrelated simulations.
+#
+# The sharded RocksDB engine is excluded because it cannot absorb the shard
+# explosion this test creates on purpose. Every physical shard becomes a RocksDB
+# column family carrying a SHARDED_ROCKSDB_WRITE_BUFFER_SIZE (16MB in
+# simulation) write buffer, and each KVS instance additionally reserves a
+# SHARDED_ROCKSDB_BLOCK_CACHE_SIZE (128MB) block cache. The Attrition workloads
+# below churn shards faster than the empty-shard cleaner reclaims their column
+# families, so with min_shard_bytes pinned 1000x below its default those budgets
+# accumulate -- and since every simulated process shares one address space, they
+# sum into a single RSS that crosses the 8GB memory limit at roughly simtime
+# 300, killing the run with FDB_EXIT_NO_MEM.
+[configuration]
+storageEngineExcludeTypes = [5]
 
 [[knobs]]
 dd_max_pipeline_moves = 20


### PR DESCRIPTION
DDPipelineSaturation fails roughly 3 times in 10000 simulation runs, and every failure is the same one: the process is killed by the 8GB memory watchdog in FDB. 

All observed failures ran with storage_engine=ssd-sharded-rocksdb. Sharded rocks is currently not supported, and  looks like it cannot absorb the shard explosion this test creates on purpose. 

For now, just disabling sharded rocks in this test to reduce noise.

Ran DDPipelineSaturation test 10K times:

  20260804-171331-praza-sim-triage-DDPipeline-74f05e489f85ca22 compressed=True data_size=40538476 duration=735887 ended=10000 fail_fast=10 max_runs=10000 pass=10000 priority=100 remaining=0 runtime=0:13:22 sanity=False started=10000 stopped=20260804-172653 submitted=20260804-171331 timeout=5400 username=praza-sim-triage-DDPipelineSaturation-2475633740-tosubmit-dba4fd02c15b35de022b2f42dd268a3bc017a8da
