### PR TITLE
docker: update base to rockylinux-9.8, golang builder, README

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -16,8 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM docker.io/rockylinux/rockylinux:9.8-minimal AS base
+FROM rockylinux/rockylinux:9.8-minimal AS base
 
+# It seems mirrorlist can be less reliable, just use original baseurl for package repo.
+RUN sed -i.bak 's/^#baseurl=/baseurl=/; s/^mirrorlist=/#mirrorlist=/' /etc/yum.repos.d/rocky.repo
 RUN microdnf install -y \
     bind-utils \
     binutils \
@@ -57,7 +59,9 @@ RUN curl -Ls "https://github.com/krallin/tini/releases/download/v0.19.0/tini-$TA
 
 WORKDIR /
 
-FROM docker.io/library/golang:1.24.13-bookworm AS go-build
+# Check that glibc version in base image >= glibc in go-build image (unless CGO_ENABLED=0)
+
+FROM golang:1.24.13-bookworm AS go-build
 
 COPY fdbkubernetesmonitor/ /fdbkubernetesmonitor
 WORKDIR /fdbkubernetesmonitor

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM docker.io/rockylinux/rockylinux:9.5-minimal AS base
+FROM docker.io/rockylinux/rockylinux:9.8-minimal AS base
 
 RUN microdnf install -y \
     bind-utils \
@@ -57,7 +57,7 @@ RUN curl -Ls "https://github.com/krallin/tini/releases/download/v0.19.0/tini-$TA
 
 WORKDIR /
 
-FROM docker.io/library/golang:1.24.7-bookworm AS go-build
+FROM docker.io/library/golang:1.24.13-bookworm AS go-build
 
 COPY fdbkubernetesmonitor/ /fdbkubernetesmonitor
 WORKDIR /fdbkubernetesmonitor
@@ -84,7 +84,7 @@ ENTRYPOINT ["/usr/bin/fdb-aws-s3-credentials-fetcher", "-dir", "/var/fdb"]
 FROM base AS foundationdb-base
 
 WORKDIR /tmp
-ARG FDB_VERSION=6.3.22
+ARG FDB_VERSION=7.3.79
 ARG FDB_LIBRARY_VERSIONS="${FDB_VERSION}"
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -7,7 +7,25 @@ image tag postfix.
 For more details it is best to read the `build-images.sh` shell script itself to
 learn more about how the images are built. 
 
-For details about what is in the images, peruse `Dockerfile{,.eks}`
+For details about what is in the images, peruse `Dockerfile`
 
-the `samples` directory is out of date, and anything therein should be used with 
-the expectation that it is, at least, partially (if not entirely) incorrect. 
+The `samples` directory is out of date, and anything therein should be used with
+the expectation that it is, at least, partially (if not entirely) incorrect.
+
+## Building images locally without the script
+
+If you only want to build a custom container image based on an already released FDB version you run the following command from the root:
+
+```bash
+FDB_VERSION=7.3.79
+docker build --build-arg FDB_VERSION=${FDB_VERSION} -t foundationdb:${FDB_VERSION} --target foundationdb ./packaging/docker
+```
+
+If you want to build the `fdb-kubernetes-monitor` image (which includes fdb binaries too),
+you need to use the build-output directory, even if not using binaries from the build.
+(Just the cmake configure step is enough to set this up.)
+
+```bash
+FDB_VERSION=7.3.79
+docker build --build-arg FDB_VERSION=${FDB_VERSION} -t fdb-kubernetes-monitor:${FDB_VERSION} --target fdb-kubernetes-monitor .../build-output/packages/docker
+```


### PR DESCRIPTION
* update Dockerfile base to rockylinux-9.8
* update golang builder to golang 1.24.13
* update docker README build instructions, copy from main

backport of https://github.com/apple/foundationdb/pull/13757 (mostly)