### PR TITLE
docker: update base to rockylinux-9.8, golang builder

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM docker.io/rockylinux/rockylinux:9.4-minimal AS base
+FROM docker.io/rockylinux/rockylinux:9.8-minimal AS base
 
 RUN microdnf install -y \
     bind-utils \
@@ -57,7 +57,7 @@ RUN curl -Ls "https://github.com/krallin/tini/releases/download/v0.19.0/tini-$TA
 
 WORKDIR /
 
-FROM golang:1.22.5-bullseye AS go-build
+FROM golang:1.24.13-bookworm AS go-build
 
 COPY fdbkubernetesmonitor/ /fdbkubernetesmonitor
 WORKDIR /fdbkubernetesmonitor
@@ -65,7 +65,7 @@ RUN go build -o /fdb-kubernetes-monitor *.go
 
 FROM base AS foundationdb-base
 
-ARG FDB_VERSION=6.3.22
+ARG FDB_VERSION=7.3.79
 ARG FDB_LIBRARY_VERSIONS="${FDB_VERSION}"
 ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -16,8 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM docker.io/rockylinux/rockylinux:9.8-minimal AS base
+FROM rockylinux/rockylinux:9.8-minimal AS base
 
+# It seems mirrorlist can be less reliable, just use original baseurl for package repo.
+RUN sed -i.bak 's/^#baseurl=/baseurl=/; s/^mirrorlist=/#mirrorlist=/' /etc/yum.repos.d/rocky.repo
 RUN microdnf install -y \
     bind-utils \
     binutils \
@@ -56,6 +58,8 @@ RUN curl -Ls "https://github.com/krallin/tini/releases/download/v0.19.0/tini-$TA
     rm -rf /tmp/*
 
 WORKDIR /
+
+# Check that glibc version in base image >= glibc in go-build image (unless CGO_ENABLED=0)
 
 FROM golang:1.24.13-bookworm AS go-build
 


### PR DESCRIPTION
* update Dockerfile base to rockylinux-9.8
* update golang builder to golang 1.24.13

partial backport of https://github.com/apple/foundationdb/pull/13757