### PR TITLE
Address Round 6 review feedback from PR 13344

### DIFF
--- a/design/memory-tracker.md
+++ b/design/memory-tracker.md
@@ -454,6 +454,19 @@ overloads retry through the installed `std::new_handler` on failure, exactly as
 the default `operator new` does, so an allocation failure still reaches FDB's
 `platform::outOfMemory` handler (`FDB_EXIT_NO_MEM`) instead of throwing past it.
 
+**One exception — tracker bookkeeping fails open.** The tracker's own metadata
+allocations (map growth on the sampled path, the reporter's scratch vectors /
+strings / TraceEvents) route through this same global `operator new`. If one of
+*those* fails, running the fatal handler would terminate the server on behalf of a
+diagnostic — even though the caller's real allocation already succeeded. So the
+tracker marks its bookkeeping regions with a thread-local
+`MemTrackerInternalAlloc` guard (`gInMemTrackerAlloc`); `mallocWithNewHandler`
+sees that flag and throws `std::bad_alloc` **directly**, skipping the handler. The
+tracker catches it and drops the sample or report. This flag is deliberately
+distinct from the `gInMemTracker` reentrancy guard, which `Arena` also sets around
+genuine user-owned allocations (a large `new uint8_t[]`) that must keep the fatal
+OOM semantics.
+
 These overloads live in a translation unit compiled directly into the
 `fdbserver` executable — not in the `flow` static library — for two
 reasons:
@@ -488,6 +501,15 @@ unconditional `memTrackerOnAlloc(p, Size)` / `memTrackerOnFree(ptr)` call added
 next to (not replacing) the existing conditional `ALLOC_INSTRUMENTATION`
 `recordAllocation`/`recordDeallocation` lines, which are left in place. `Size`
 is a compile-time template parameter, so no size lookup is needed.
+
+The `USE_GPERFTOOLS` / `ADDRESS_SANITIZER` and precise-Valgrind
+(`FDB_VALGRIND_PRECISE`) configurations replace the freelist with a per-block
+`aligned_alloc` / `aligned_free` and `return` early, before reaching the hook at
+the bottom of the function. The same `memTrackerOnAlloc` / `memTrackerOnFree`
+calls are therefore repeated on each of those early-return paths — otherwise every
+FastAllocator size class (and the small `Arena` blocks backed by it) would be
+invisible to the tracker under those builds. The per-block `aligned_alloc` does
+not go through `operator new`, so there is no double-tracking.
 
 The global `operator new` / `delete` overrides (both the tracker path
 and the legacy `ALLOC_INSTRUMENTATION` path) live in
@@ -853,10 +875,20 @@ binary that links the global `operator new`/`delete` override and can exercise i
   `arenaMediumAccounting`, `arenaHugeAccounting`** — byte/block accounting
   per allocation path; the "exactly one site carries the sentinel's frames"
   assertion is the B1 double-tracking regression test (the medium and huge
-  `Arena` paths are the ones that regressed).
-- **`failOpenOnMetadataAllocFailure`** — an injected tracker-metadata allocation
-  failure is swallowed: the underlying `new`/`delete` still succeeds and tracking
-  recovers on the thread afterward (the reentrancy guard is restored, not leaked).
+  `Arena` paths are the ones that regressed). `fastAlloc32Accounting` and
+  `arenaSmallAccounting` are not sanitizer-guarded, so under `USE_GPERFTOOLS` /
+  `ADDRESS_SANITIZER` / precise-Valgrind builds they also cover the
+  `FastAllocator` early-return paths — where the block comes from a per-block
+  `aligned_alloc` and the hook has to be invoked explicitly (see the FastAllocator
+  hook-site note above). Without that hook these tests would see zero
+  sentinel-attributed `FastAllocator` bytes under those builds.
+- **`failOpenOnMetadataAllocFailure`** — a one-shot forces an *actual*
+  tracker-internal allocation (map growth), routed through the global
+  `operator new` override, to fail. The tracker fails open: the failure is
+  swallowed, the underlying `new`/`delete` still succeeds, the installed
+  `std::new_handler` is **not** invoked (asserted — this is the "diagnostic
+  bookkeeping never terminates the server" guarantee), and tracking recovers on
+  the thread afterward (the reentrancy guards are restored, not leaked).
 
 Not yet covered by a dedicated unit test: a frame-pointer-walk-depth test — that
 behavior is exercised indirectly by the sentinel tests above.

--- a/fdbserver/GlobalNewDelete.cpp
+++ b/fdbserver/GlobalNewDelete.cpp
@@ -121,18 +121,41 @@ namespace {
 
 // Retry through the installed std::new_handler on failure, as the default
 // operator new does. fdbserver installs platform::outOfMemory, so an allocation
-// failure (including the tracker's own map growth) reaches FDB's OOM diagnostics
-// and FDB_EXIT_NO_MEM rather than throwing straight past them.
+// failure reaches FDB's OOM diagnostics and FDB_EXIT_NO_MEM rather than throwing
+// straight past them.
+//
+// Exception: the tracker's own bookkeeping allocations (gInMemTrackerAlloc set —
+// map growth on the sampled path, reporter scratch) fail OPEN. They throw
+// std::bad_alloc directly, skipping the fatal handler, so a diagnostic allocation
+// that fails just drops the sample or report (the tracker catches it) instead of
+// terminating the server after the caller's real allocation already succeeded.
 void* mallocWithNewHandler(std::size_t n) {
-	void* p;
-	while (!(p = std::malloc(n))) {
+	while (true) {
+		void* p = std::malloc(n);
+		// Test-only: make one tracker-internal allocation look like it failed, so the
+		// fail-open decision below is driven through the real allocator path — see
+		// memTrackerFailNextInternalAllocForTest. Gated on gInMemTrackerAlloc so an
+		// unrelated allocation can't consume the one-shot before the tracker runs.
+		if (p && gInMemTrackerAlloc && gMemTrackerFailNextInternalAllocForTest) {
+			gMemTrackerFailNextInternalAllocForTest = false;
+			std::free(p);
+			p = nullptr;
+		}
+		if (p) {
+			return p;
+		}
+		// Allocation failed. Tracker bookkeeping fails open — throw straight to the
+		// tracker's catch, never the fatal handler. Everything else honors the
+		// installed std::new_handler / OOM path.
+		if (gInMemTrackerAlloc) {
+			throw std::bad_alloc();
+		}
 		std::new_handler h = std::get_new_handler();
 		if (!h) {
 			throw std::bad_alloc();
 		}
 		h();
 	}
-	return p;
 }
 
 // Same handler loop for over-aligned allocations. C11 aligned_alloc requires the
@@ -143,15 +166,20 @@ void* alignedAllocWithNewHandler(std::size_t alignment, std::size_t n) {
 	if (rounded < n) {
 		throw std::bad_alloc(); // round-up overflowed; the request can't be satisfied
 	}
-	void* p;
-	while (!(p = aligned_alloc(alignment, rounded))) {
+	while (true) {
+		void* p = aligned_alloc(alignment, rounded);
+		if (p) {
+			return p;
+		}
+		if (gInMemTrackerAlloc) {
+			throw std::bad_alloc(); // tracker bookkeeping fails open (see mallocWithNewHandler)
+		}
 		std::new_handler h = std::get_new_handler();
 		if (!h) {
 			throw std::bad_alloc();
 		}
 		h();
 	}
-	return p;
 }
 
 } // namespace

--- a/fdbserver/MemoryTrackerTest.cpp
+++ b/fdbserver/MemoryTrackerTest.cpp
@@ -696,22 +696,55 @@ TEST_CASE("/flow/MemoryTracker/operatorNewAccounting") {
 }
 
 TEST_CASE("/flow/MemoryTracker/failOpenOnMetadataAllocFailure") {
-	// The tracker must fail open: if its own metadata allocation throws, the
-	// underlying user allocation still succeeds and tracking recovers on this
-	// thread afterward (the reentrancy guard is restored, not leaked). Runs on all
+	// The tracker must fail open: if one of its own bookkeeping allocations fails,
+	// the underlying user allocation still succeeds, the process is NOT terminated
+	// through the installed std::new_handler, and tracking recovers on this thread
+	// afterward (the reentrancy guards are restored, not leaked). Runs on all
 	// platforms — no frame inspection.
+	//
+	// Unlike a throw injected at the top of the sampled path, this drives the real
+	// failure route: the one-shot forces an actual tracker-internal allocation
+	// (map growth) through the global operator new override, which — seeing the
+	// tracker-internal context — throws std::bad_alloc WITHOUT running the handler.
 	KnobOverride ko; // inverse = 1: sample every allocation
 	memTrackerResetForTest();
 
-	// Arm the one-shot; it is consumed by the next sampled allocation, which throws
-	// inside the tracker. new/delete must not observe that exception.
-	memTrackerFailNextSampleForTest();
+	// Install a new_handler that records if it ran. The tracker-internal fail-open
+	// path must never reach it; if it does (bug), we still break the retry loop so
+	// the test fails cleanly instead of spinning or aborting via the real
+	// platform::outOfMemory handler.
+	static bool handlerRan;
+	handlerRan = false;
+	std::new_handler prevHandler = std::set_new_handler([]() {
+		handlerRan = true;
+		throw std::bad_alloc();
+	});
+
+	// Arm the one-shot; the next tracker-internal allocation is forced to fail
+	// inside mallocWithNewHandler, which throws bad_alloc (fail open) and the
+	// tracker swallows it. The user's new[] must observe none of this.
+	//
+	// escape(p) is essential: at -O3 clang elides a new/delete pair whose pointer
+	// never escapes (P0593), so without it the allocation never reaches the global
+	// operator new, the sampler never runs, and the one-shot is never consumed — the
+	// test would pass without exercising anything (see the consumption assert below).
+	memTrackerFailNextInternalAllocForTest();
 	int* p = new int[4];
 	ASSERT(p != nullptr);
 	p[0] = 42;
+	escape(p);
 	int observed = p[0];
 	delete[] p;
+
+	std::set_new_handler(prevHandler);
+
+	// The one-shot must have been consumed by a real tracker-internal allocation;
+	// if it's still armed, no tracker metadata allocation went through the global
+	// operator new and the fail-open path was never exercised (the test would then
+	// pass trivially — exactly the weakness this rewrite fixes).
+	ASSERT(!gMemTrackerFailNextInternalAllocForTest);
 	ASSERT_EQ(observed, 42);
+	ASSERT(!handlerRan); // fail-open path must bypass the fatal OOM handler
 
 	// Tracking must still work after the injected failure.
 	memTrackerResetForTest();

--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -384,14 +384,25 @@ void* FastAllocator<Size>::allocate() {
 	bytes->increment(size);
 
 #if defined(USE_GPERFTOOLS) || defined(ADDRESS_SANITIZER)
-	// Some usages of FastAllocator require 4096 byte alignment.
-	return aligned_alloc(Size >= 4096 ? 4096 : alignof(void*), Size);
+	{
+		// Some usages of FastAllocator require 4096 byte alignment.
+		// This path bypasses the freelist and the memTrackerOnAlloc at the bottom
+		// of the function, so track here too — otherwise every FastAllocator size
+		// class (and the small Arena blocks backed by it) would be invisible to the
+		// tracker under gperftools / ASan. Symmetric with release() below. (Braces
+		// scope this `p` so it can't collide with the freelist `p` compiled below.)
+		void* p = aligned_alloc(Size >= 4096 ? 4096 : alignof(void*), Size);
+		memTrackerOnAlloc(p, Size);
+		return p;
+	}
 #endif
 
 #if VALGRIND
 	if (valgrindPrecise()) {
 		// Some usages of FastAllocator require 4096 byte alignment
-		return aligned_alloc(Size >= 4096 ? 4096 : alignof(void*), Size);
+		void* p = aligned_alloc(Size >= 4096 ? 4096 : alignof(void*), Size);
+		memTrackerOnAlloc(p, Size); // track here too (see the gperftools/ASan path above)
+		return p;
 	}
 #endif
 
@@ -459,11 +470,15 @@ void FastAllocator<Size>::release(void* ptr) {
 	bytes->increment(size);
 
 #if defined(USE_GPERFTOOLS) || defined(ADDRESS_SANITIZER)
+	// Mirror allocate()'s early-return tracking so frees on this path debit the
+	// live table (without this the block would leak in the tracker's accounting).
+	memTrackerOnFree(ptr);
 	return aligned_free(ptr);
 #endif
 
 #if VALGRIND
 	if (valgrindPrecise()) {
+		memTrackerOnFree(ptr); // mirror allocate() (see the gperftools/ASan path above)
 		return aligned_free(ptr);
 	}
 #endif

--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -387,14 +387,25 @@ void* FastAllocator<Size>::allocate() {
 	bytes->increment(size);
 
 #if defined(USE_GPERFTOOLS) || defined(ADDRESS_SANITIZER)
-	// Some usages of FastAllocator require 4096 byte alignment.
-	return aligned_alloc(Size >= 4096 ? 4096 : alignof(void*), Size);
+	{
+		// Some usages of FastAllocator require 4096 byte alignment.
+		// This path bypasses the freelist and the memTrackerOnAlloc at the bottom
+		// of the function, so track here too — otherwise every FastAllocator size
+		// class (and the small Arena blocks backed by it) would be invisible to the
+		// tracker under gperftools / ASan. Symmetric with release() below. (Braces
+		// scope this `p` so it can't collide with the freelist `p` compiled below.)
+		void* p = aligned_alloc(Size >= 4096 ? 4096 : alignof(void*), Size);
+		memTrackerOnAlloc(p, Size);
+		return p;
+	}
 #endif
 
 #if VALGRIND
 	if (valgrindPrecise()) {
 		// Some usages of FastAllocator require 4096 byte alignment
-		return aligned_alloc(Size >= 4096 ? 4096 : alignof(void*), Size);
+		void* p = aligned_alloc(Size >= 4096 ? 4096 : alignof(void*), Size);
+		memTrackerOnAlloc(p, Size); // track here too (see the gperftools/ASan path above)
+		return p;
 	}
 #endif
 
@@ -472,11 +483,15 @@ void FastAllocator<Size>::release(void* ptr) {
 	bytes->increment(size);
 
 #if defined(USE_GPERFTOOLS) || defined(ADDRESS_SANITIZER)
+	// Mirror allocate()'s early-return tracking so frees on this path debit the
+	// live table (without this the block would leak in the tracker's accounting).
+	memTrackerOnFree(ptr);
 	return aligned_free(ptr);
 #endif
 
 #if VALGRIND
 	if (valgrindPrecise()) {
+		memTrackerOnFree(ptr); // mirror allocate() (see the gperftools/ASan path above)
 		return aligned_free(ptr);
 	}
 #endif

--- a/flow/MemoryTracker.cpp
+++ b/flow/MemoryTracker.cpp
@@ -65,10 +65,16 @@ thread_local std::size_t gForceSampleBytes = static_cast<std::size_t>(-1);
 // Starts false so the first allocation on each thread reaches the slow path to
 // read the knob; set true there if sampling is off (see memTrackerSampleAlloc).
 thread_local bool gMemTrackerOff = false;
+// Set (nest-safe, via MemTrackerInternalAlloc) only around the tracker's own
+// bookkeeping allocations, so those fail open instead of tripping the fatal OOM
+// handler on failure. See flow/include/flow/MemoryTracker.h.
+thread_local bool gInMemTrackerAlloc = false;
 
-// Test-only one-shot: when set, the next sampled allocation throws to simulate a
-// tracker metadata-allocation failure (see memTrackerFailNextSampleForTest).
-static thread_local bool gFailNextSampleForTest = false;
+// Test-only one-shot, read by mallocWithNewHandler (fdbserver/GlobalNewDelete.cpp):
+// when set, the next tracker-internal allocation is forced to fail, exercising the
+// fail-open path end-to-end (real map/report allocation, real operator new) without
+// a genuine OOM. See memTrackerFailNextInternalAllocForTest.
+thread_local bool gMemTrackerFailNextInternalAllocForTest = false;
 
 // Definition of the cache-line-isolated enabled flag declared in the header.
 MemTrackerEnabledFlag g_memTrackerEnabled;
@@ -272,10 +278,6 @@ void memTrackerInit() {
 }
 
 static void memTrackerSampleAllocImpl(void* p, std::size_t n) {
-	if (gFailNextSampleForTest) {
-		gFailNextSampleForTest = false;
-		throw std::bad_alloc(); // simulate a tracker metadata-allocation failure (test only)
-	}
 	int inverse = 0;
 	int frames = 6;
 	bool liveTracking = true;
@@ -347,6 +349,12 @@ static void memTrackerSampleAllocImpl(void* p, std::size_t n) {
 	std::uint64_t fp = (kept == 0) ? 0 : fnv64(keep, static_cast<std::size_t>(kept) * sizeof(void*));
 
 	ThreadSpinLockHolder lk(g_mtLock);
+	// Everything below that allocates is tracker-owned bookkeeping (map
+	// construction, node inserts, rehash). Mark it so a heap-allocation failure
+	// here fails open — throws std::bad_alloc, caught by memTrackerSampleAlloc,
+	// dropping the sample — rather than invoking the fatal OOM handler after the
+	// caller's real allocation already succeeded. See MemTrackerInternalAlloc.
+	MemTrackerInternalAlloc _internal;
 	ensureMaps();
 
 	auto nBytes = static_cast<std::int64_t>(n);
@@ -436,8 +444,10 @@ static void memTrackerSampleAllocImpl(void* p, std::size_t n) {
 
 void memTrackerSampleAlloc(void* p, std::size_t n) {
 	// Fail open: the tracker is a diagnostic; a std::bad_alloc from its own map
-	// growth (or the test injection) must never propagate into the caller's
-	// allocation path, which has already handed out the underlying block.
+	// growth must never propagate into the caller's allocation path, which has
+	// already handed out the underlying block. Tracker-internal allocations are
+	// marked (MemTrackerInternalAlloc) so the global operator new throws here
+	// instead of running the fatal OOM handler — so this catch actually runs.
 	try {
 		memTrackerSampleAllocImpl(p, n);
 	} catch (...) {
@@ -496,6 +506,8 @@ void memTrackerForEachSite(std::function<void(const MemoryTrackerCallSite&)> cb)
 	std::vector<MemoryTrackerCallSite> snapshot;
 	{
 		ThreadSpinLockHolder lk(g_mtLock);
+		// The snapshot copy below is tracker-owned; fail open if it can't allocate.
+		MemTrackerInternalAlloc _internal;
 		if (g_aggMap) {
 			snapshot.reserve(g_aggMap->size());
 			for (auto& kv : *g_aggMap) {
@@ -531,16 +543,21 @@ void memTrackerResetForTest() {
 	// Publish the enabled flag and arm this thread from the current knob value
 	// (a test typically sets MEMORY_TRACKING_SAMPLE_INVERSE via KnobOverride just
 	// before calling this), mirroring memTrackerInit at process startup.
-	gFailNextSampleForTest = false;
+	gMemTrackerFailNextInternalAllocForTest = false;
 	memTrackerArmFromKnobs();
 }
 
-void memTrackerFailNextSampleForTest() {
-	gFailNextSampleForTest = true;
+void memTrackerFailNextInternalAllocForTest() {
+	gMemTrackerFailNextInternalAllocForTest = true;
 }
 
 static void memTrackerDumpImpl(int64_t bytesThreshold) {
 	MemTrackerSuppress _suppress;
+	// The report's scratch (sites/qualifying vectors, addr2line strings) and the
+	// TraceEvents it emits are all tracker-owned; fail open on allocation failure
+	// (caught by memTrackerDump) rather than crashing the server while building a
+	// diagnostic report. See MemTrackerInternalAlloc.
+	MemTrackerInternalAlloc _internal;
 
 	std::vector<MemoryTrackerCallSite> sites;
 	int aggSize = 0;

--- a/flow/include/flow/MemoryTracker.h
+++ b/flow/include/flow/MemoryTracker.h
@@ -97,6 +97,29 @@ struct MemoryTrackerCallSite {
 extern thread_local bool gInMemTracker;
 extern thread_local int gMemTrackerCounter;
 extern thread_local std::size_t gForceSampleBytes;
+
+// Set true (per thread, nest-safe via MemTrackerInternalAlloc) only around the
+// tracker's OWN bookkeeping allocations — map construction / node inserts / rehash
+// on the sampled path, and the reporter's scratch vectors, strings, and
+// TraceEvents. The global operator new override (fdbserver/GlobalNewDelete.cpp)
+// reads this: an allocation failure inside this window throws std::bad_alloc
+// straight to the tracker's fail-open catch instead of invoking the installed
+// std::new_handler (platform::outOfMemory, which terminates with FDB_EXIT_NO_MEM).
+// So a diagnostic bookkeeping allocation that fails just drops the sample or
+// report; it cannot terminate the server after the caller's real allocation has
+// already succeeded.
+//
+// Deliberately distinct from gInMemTracker: gInMemTracker is also set by Arena
+// around genuine user-owned allocations (new uint8_t[] for a large block), which
+// must keep the fatal OOM semantics. Only the tracker's own metadata fails open.
+extern thread_local bool gInMemTrackerAlloc;
+
+// Test-only one-shot, read by the global operator new override
+// (fdbserver/GlobalNewDelete.cpp). When set, the next tracker-internal allocation
+// (gInMemTrackerAlloc active) is forced to fail there, so tests can drive the
+// fail-open path through the real mallocWithNewHandler. Armed via
+// memTrackerFailNextInternalAllocForTest; cleared by memTrackerResetForTest.
+extern thread_local bool gMemTrackerFailNextInternalAllocForTest;
 // Set true (per thread) once this thread's slow path observes sampling is off,
 // so the alloc hot path then short-circuits on a single TLS load instead of
 // decrementing the counter and reading gForceSampleBytes every call. Per-thread
@@ -139,6 +162,23 @@ public:
 	~MemTrackerSuppress() { gInMemTracker = prev; }
 	MemTrackerSuppress(const MemTrackerSuppress&) = delete;
 	MemTrackerSuppress& operator=(const MemTrackerSuppress&) = delete;
+};
+
+// RAII: marks the enclosed region as tracker-internal bookkeeping, so a heap
+// allocation failure there fails open (throws std::bad_alloc, caught by the
+// tracker) rather than tripping the fatal OOM handler — see gInMemTrackerAlloc.
+// Nest-safe (saves and restores prev). Distinct from MemTrackerSuppress:
+// MemTrackerSuppress gates the sampling hook and is also used around real user
+// allocations; this guard only changes allocation-failure behavior, and only for
+// the tracker's own metadata.
+class MemTrackerInternalAlloc {
+	bool prev;
+
+public:
+	MemTrackerInternalAlloc() : prev(gInMemTrackerAlloc) { gInMemTrackerAlloc = true; }
+	~MemTrackerInternalAlloc() { gInMemTrackerAlloc = prev; }
+	MemTrackerInternalAlloc(const MemTrackerInternalAlloc&) = delete;
+	MemTrackerInternalAlloc& operator=(const MemTrackerInternalAlloc&) = delete;
 };
 
 // Initialize the tracker from the current knob values. Call once, from process
@@ -196,12 +236,15 @@ void memTrackerForEachSite(std::function<void(const MemoryTrackerCallSite&)> cb)
 // Reset all state. Tests only — not safe for production use.
 void memTrackerResetForTest();
 
-// Test only: arm a one-shot so the next sampled allocation simulates a tracker
-// metadata-allocation failure (the sampled path throws std::bad_alloc, which the
-// tracker swallows). Lets tests verify the tracker fails open — the underlying
-// allocation still succeeds and tracking recovers afterward. Never used in
-// production.
-void memTrackerFailNextSampleForTest();
+// Test only: arm a one-shot so the next tracker-internal (bookkeeping) allocation
+// is forced to fail. Unlike a throw injected at the top of the sampled path, this
+// drives the real failure route: an actual map/report allocation goes through the
+// global operator new (fdbserver/GlobalNewDelete.cpp), which — seeing the
+// tracker-internal context — throws std::bad_alloc WITHOUT invoking the installed
+// std::new_handler, and the tracker swallows it. Lets tests verify the tracker
+// fails open (underlying allocation preserved, handler not invoked, tracking
+// recovers afterward). Never used in production.
+void memTrackerFailNextInternalAllocForTest();
 
 #else // !FDB_MEMORY_TRACKER — compiled out: hooks are no-ops, no operator new override.
 


### PR DESCRIPTION
Followups from Round 6 review on PR#13344.

- Bug (tracker bookkeeping can terminate the server): Added a nest-safe gInMemTrackerAlloc context (distinct from gInMemTracker, which Arena sets around real user allocations) so the tracker's own metadata/reporter allocations throw bad_alloc straight to its fail-open catch instead of tripping the fatal OOM handler after the caller's real allocation already succeeded.  (As discussed in PR#13344 we think the impact of this is likely negligible, but why not fix it while we're here.)
- Bug (sanitizer/gperftools/Valgrind bypass FastAllocator tracking): Added memTrackerOnAlloc/memTrackerOnFree to the USE_GPERFTOOLS/ADDRESS_SANITIZER/precise-Valgrind early-return paths in FastAllocator::allocate/release, so those builds still attribute every FastAllocator size class and the small Arena blocks backed by it.
- Omission (no test forces a real tracker-owned allocation failure): Rewrote failOpenOnMetadataAllocFailure to force an actual map allocation to fail through mallocWithNewHandler and assert the installed new_handler is never invoked — and in doing so found and fixed a P0593 heap-elision bug that had made the original test pass without allocating anything.
- Omission (no coverage under ASan/gperftools/Valgrind): Documented that the un-guarded fastAlloc32Accounting/arenaSmallAccounting tests now exercise the new sanitizer-path hooks under those builds (verified by the clean 100k Joshua run rather than a dedicated sanitizer CI job).

Ran 1000 iterations of new tests and also:

  20260803-184807-gglass-39545f72cc3ffaa1            compressed=True data_size=38391356 duration=3971129 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:46:56 sanity=False started=100000 stopped=20260803-193503 submitted=20260803-184807 timeout=5400 username=gglass
