### PR TITLE
Expose watch metrics in status json

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -222,6 +222,27 @@
                      "counter":0,
                      "roughness":0.0
                   },
+                  "active_watches":0,
+                  "total_watches":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
+                  "triggered_watches":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
+                  "timed_out_watches":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
+                  "errored_watches":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
                   "mutation_bytes":{
                      "hz":0.0,
                      "counter":0,

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -207,6 +207,27 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
                      "counter":0,
                      "roughness":0.0
                   },
+                  "active_watches":0,
+                  "total_watches":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
+                  "triggered_watches":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
+                  "timed_out_watches":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
+                  "errored_watches":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
                   "mutation_bytes":{
                      "hz":0.0,
                      "counter":0,

--- a/fdbserver/clustercontroller/Status.cpp
+++ b/fdbserver/clustercontroller/Status.cpp
@@ -515,6 +515,11 @@ struct RolesInfo {
 			obj["low_priority_queries"] = StatusCounter(storageMetrics.getValue("LowPriorityQueries")).getStatus();
 			obj["bytes_queried"] = StatusCounter(storageMetrics.getValue("BytesQueried")).getStatus();
 			obj["keys_queried"] = StatusCounter(storageMetrics.getValue("RowsQueried")).getStatus();
+			obj.setKeyRawNumber("active_watches", storageMetrics.getValue("ActiveWatches"));
+			obj["total_watches"] = StatusCounter(storageMetrics.getValue("WatchQueries")).getStatus();
+			obj["triggered_watches"] = StatusCounter(storageMetrics.getValue("TriggeredWatches")).getStatus();
+			obj["timed_out_watches"] = StatusCounter(storageMetrics.getValue("TimedOutWatches")).getStatus();
+			obj["errored_watches"] = StatusCounter(storageMetrics.getValue("ErroredWatches")).getStatus();
 			obj["mutation_bytes"] = StatusCounter(storageMetrics.getValue("MutationBytes")).getStatus();
 			obj["mutations"] = StatusCounter(storageMetrics.getValue("Mutations")).getStatus();
 			obj.setKeyRawNumber("local_rate", storageMetrics.getValue("LocalRate"));

--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -1265,6 +1265,10 @@ public:
 		Counter allQueries, systemKeyQueries, getKeyQueries, getValueQueries, getRangeQueries, getRangeSystemKeyQueries,
 		    getRangeStreamQueries, lowPriorityQueries, rowsQueried, watchQueries, emptyQueries;
 
+		// How the watches counted by watchQueries ended. Exactly one is incremented per watch, so
+		// watchQueries == triggeredWatches + timedOutWatches + erroredWatches + numWatches.
+		Counter triggeredWatches, timedOutWatches, erroredWatches;
+
 		// counters related to getMappedRange queries
 		Counter getMappedRangeBytesQueried, finishedGetMappedRangeSecondaryQueries, getMappedRangeQueries,
 		    finishedGetMappedRangeQueries;
@@ -1342,8 +1346,10 @@ public:
 		    getRangeSystemKeyQueries("GetRangeSystemKeyQueries", cc),
 		    getMappedRangeQueries("GetMappedRangeQueries", cc), getRangeStreamQueries("GetRangeStreamQueries", cc),
 		    lowPriorityQueries("LowPriorityQueries", cc), rowsQueried("RowsQueried", cc),
-		    watchQueries("WatchQueries", cc), emptyQueries("EmptyQueries", cc),
-		    logicalBytesInput("LogicalBytesInput", cc), logicalBytesMoveInOverhead("LogicalBytesMoveInOverhead", cc),
+		    watchQueries("WatchQueries", cc), triggeredWatches("TriggeredWatches", cc),
+		    timedOutWatches("TimedOutWatches", cc), erroredWatches("ErroredWatches", cc),
+		    emptyQueries("EmptyQueries", cc), logicalBytesInput("LogicalBytesInput", cc),
+		    logicalBytesMoveInOverhead("LogicalBytesMoveInOverhead", cc),
 		    kvCommitLogicalBytes("KVCommitLogicalBytes", cc), kvClearRanges("KVClearRanges", cc),
 		    kvClearSingleKey("KVClearSingleKey", cc), kvSystemClearRanges("KVSystemClearRanges", cc),
 		    bytesDurable("BytesDurable", cc), sampledBytesCleared("SampledBytesCleared", cc),
@@ -2427,6 +2433,7 @@ Future<Void> watchValueSendReply(coro::FrameSizeRecorder,
 
 					// fire watch
 					req.reply.send(WatchValueReply{ ver });
+					++data->counters.triggeredWatches;
 					finishWatchValueReply(data, metadata);
 					--data->numWatches;
 					data->watchBytes -= WATCH_OVERHEAD_WATCHQ;
@@ -2444,9 +2451,11 @@ Future<Void> watchValueSendReply(coro::FrameSizeRecorder,
 				if (response.present()) {
 					// fire watch
 					req.reply.send(WatchValueReply{ response.get() });
+					++data->counters.triggeredWatches;
 				} else {
 					// watch timed out
 					data->sendErrorWithPenalty(req.reply, timed_out(), data->getPenalty());
+					++data->counters.timedOutWatches;
 				}
 				finishWatchValueReply(data, metadata);
 				--data->numWatches;
@@ -2460,6 +2469,7 @@ Future<Void> watchValueSendReply(coro::FrameSizeRecorder,
 			data->watchBytes -= WATCH_OVERHEAD_WATCHQ;
 			finishWatchValueReply(data, metadata);
 			--data->numWatches;
+			++data->counters.erroredWatches;
 
 			if (!canReplyWith(e))
 				throw e;


### PR DESCRIPTION
Fixes #13652

Adds the watch metrics that issue asks for to the storage role section of `status json`:

| field | source |
| --- | --- |
| `active_watches` | existing `ActiveWatches` counter |
| `total_watches` | existing `WatchQueries` counter |
| `triggered_watches` | new |
| `timed_out_watches` | new |
| `errored_watches` | new |

`errored_watches` is not on the wishlist, but without it the numbers don't reconcile. A watch can also end by cancellation, by the client disconnecting, or with `watch_cancelled` after exceeding `MAX_STORAGE_SERVER_WATCH_BYTES`, and that remainder would otherwise read as leaked watches.

The three new counters increment on exactly the paths that already decrement `numWatches`, so `total_watches == triggered_watches + timed_out_watches + errored_watches + active_watches` holds to the same degree the existing `numWatches` bookkeeping does. Related: #13786.
