### PR TITLE
[main] Exclude sharded RocksDB from DDPipelineSaturation to stop OOM failures

### DIFF
--- a/tests/fast/DDPipelineSaturation.toml
+++ b/tests/fast/DDPipelineSaturation.toml
@@ -5,6 +5,19 @@
 # DDRelocationQueue.cpp. The limit is pinned to 20 -- the realistic
 # low end of the knob's range -- rather than an unrealistically small value
 # that would destabilize unrelated simulations.
+#
+# The sharded RocksDB engine is excluded because it cannot absorb the shard
+# explosion this test creates on purpose. Every physical shard becomes a RocksDB
+# column family carrying a SHARDED_ROCKSDB_WRITE_BUFFER_SIZE (16MB in
+# simulation) write buffer, and each KVS instance additionally reserves a
+# SHARDED_ROCKSDB_BLOCK_CACHE_SIZE (128MB) block cache. The Attrition workloads
+# below churn shards faster than the empty-shard cleaner reclaims their column
+# families, so with min_shard_bytes pinned 1000x below its default those budgets
+# accumulate -- and since every simulated process shares one address space, they
+# sum into a single RSS that crosses the 8GB memory limit at roughly simtime
+# 300, killing the run with FDB_EXIT_NO_MEM.
+[configuration]
+storageEngineExcludeTypes = [5]
 
 [[knobs]]
 dd_max_pipeline_moves = 20


### PR DESCRIPTION
Forward port of #13808 

100K: 20260805-222144-praza-port-main-pr13808-8df-8d57aedb19c8758f compressed=True data_size=37388881 duration=3555315 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:27:11 sanity=False started=100000 stopped=20260805-224855 submitted=20260805-222144 timeout=5400 username=praza-port-main-pr13808-8df0d5f4c0e6aaa0b683c2a84f23e97a9b74ae0a
