### PR TITLE
Backport call-site aware memory tracking to release-7.4 (PR #13344)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,157 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents working in this repository.
+
+## Build
+
+```bash
+mkdir build && cd build
+cmake -G Ninja <SOURCE_DIR>
+ninja
+# or: ninja fdbserver fdbcli fdbclient  (specific targets)
+```
+
+Key cmake options:
+- `-DCMAKE_BUILD_TYPE=Debug` (default Release)
+- `-DUSE_WERROR=ON` for development
+- `-DOPEN_FOR_IDE=ON` to generate IDE project without building
+
+macOS: add `-DBUILD_SWIFT_BINDING=OFF` if Swift issues arise.
+
+Linux with Clang: `CC=clang CXX=clang++ cmake -DUSE_LD=LLD -DUSE_LIBCXX=1 -G Ninja ..`
+
+## Testing
+
+**Unit tests** use `TEST_CASE("/path/to/test")` macros (defined in `flow/include/flow/UnitTest.h`). Run them through the `fdbserver` unit-test runner:
+
+```bash
+ninja fdbserver
+bin/fdbserver -r unittests                     # all registered unit tests
+bin/fdbserver -r unittests -f "<test-prefix>"  # tests matching a prefix
+```
+
+Use `fdbserver -r simulation` for broader end-to-end validation.
+
+**Simulation tests** use TOML workload definitions in `tests/fast/`, `tests/slow/`, etc.:
+
+```bash
+bin/fdbserver -r simulation -f tests/fast/CycleTest.toml
+```
+
+**Via ctest:**
+
+```bash
+ctest -L fast                    # all fast tests
+ctest -R "StatusDuringOutage"    # by name pattern
+```
+
+Enable simulation tests in cmake: `-DENABLE_SIMULATION_TESTS=ON`
+
+**Adding new tests:**
+
+- For a new otherwise-unreferenced translation unit containing `TEST_CASE`, add a `forceLinkXxxTests()` stub and call it from `fdbserver/workloads/UnitTests.actor.cpp`, or the linker can drop the tests.
+- Register new `.toml` or `.txt` tests under `tests/` in `tests/CMakeLists.txt` via `add_fdb_test`. `configure_testing(... ERROR_ON_ADDITIONAL_FILES)` and `verify_testing()` should catch unregistered files during CMake configuration.
+
+**Joshua**: bulk correctness/simulation testing runs on the internal Joshua cluster against optimized Release builds. Local `fdbserver -r simulation` runs are for iteration; large-scale shake-out happens on Joshua.
+
+**Trace logs**: simulation and test runs emit `trace.*.xml` (or `.json`) files in the run directory. `TraceEvent(...)` is the canonical logging mechanism — search trace files by event name when debugging a simulation failure.
+
+- A `SevError` (Severity 40) `TraceEvent` **fails** a simulation/Joshua run. Use `SevWarnAlways` for "shouldn't happen but non-fatal." Errors carrying an injected fault are auto-downgraded; genuine `SevError`s are not. Expected errors must be suppressed/allowlisted, never emitted at `SevError`.
+- Keep a `TraceEvent` small: any single `detail()` value over 495 bytes is truncated (`...`), and an event whose fields total over 4000 bytes is **dropped entirely** and re-logged as `TraceEventOverflow` — at `SevError` in simulation, so an oversized event *fails the test*. Chunk long payloads (joined lists, command lines, serialized blobs) across multiple events.
+
+## Architecture
+
+FoundationDB is a distributed ordered key-value store with strict serializability. The codebase is organized into ~12 subsystems. For background on subsystems before diving into code, the `design/` directory holds human-authored design docs.
+
+### Concurrency Model: Flow Actors and C++ Coroutines
+
+FDB uses cooperative single-threaded concurrency. Code is written using either:
+
+- **Flow actors** (`.actor.cpp` / `.actor.h` files): A custom preprocessor (`actorcompiler`) translates `ACTOR`, `state`, `wait()`, `choose/when` syntax into generated C++ state machines. The `#include "flow/actorcompiler.h"` must be the **last** include in actor files.
+- **C++ coroutines**: Newer code uses `co_await` and `co_return` instead of `wait()` and actor-style `return`. Coroutines can appear in regular `.cpp` files and in `.actor.cpp` files that still contain actorcompiler input; actors and coroutines can be mixed. New code should use coroutines; see `design/coroutines.md`.
+
+Key types: `Future<T>`, `Promise<T>`, `PromiseStream<T>`, `Reference<T>` (ref-counted pointer), `Optional<T>`, `ErrorOr<T>`, `Arena` (region-based allocation).
+
+#### Common pitfalls
+
+- `wait()` / `waitNext()` cannot appear inside ternary expressions, function arguments, or other sub-expressions. Assign to a `state` variable first, or use a small gating actor.
+- C++ coroutines: `co_await` is not allowed inside a `catch` handler. Capture the error, exit the catch, then `co_await` outside.
+- `ACTOR` functions declared in headers must not be defined inside an anonymous namespace, or call sites get ambiguous-overload errors.
+- Errors are integer codes (`flow/include/flow/error_definitions.h`), not exceptions with messages. When you `catch (Error& e)`, re-throw `actor_cancelled` (and never silently swallow `broken_promise`) — eating cancellation causes hangs and leaks. Transaction retry goes through `tr.onError(e)`, not a bare loop.
+- `StringRef`/`KeyRef`/`ValueRef` are non-owning views into an `Arena`. Returning or storing one past its arena's lifetime is a dangling-reference bug; use `Standalone<>` (or `Key`/`Value`) when you need to own the bytes.
+
+### Core Subsystems
+
+- **`flow/`** — Async runtime, event loop, tracing, deterministic random, arenas
+- **`fdbrpc/`** — Endpoint-addressed RPC, peer management, failure monitor, Sim2 (deterministic simulation network)
+- **`fdbclient/`** — Transaction API (`NativeAPI.actor.cpp`), read-your-writes (`ReadYourWrites.actor.cpp`), location cache, multi-version client
+- **`fdbserver/`** — All server roles (flat layout; headers under `fdbserver/include/fdbserver/`):
+  - Cluster controller — Leader election, role recruitment, ServerDBInfo broadcasting
+  - Coordinators — Paxos-based coordination state (generation registers)
+  - Commit proxies, GRV proxies, resolver — Transaction commit pipeline
+  - TLogs, log system — Durable mutation log (tag-partitioned)
+  - Storage servers — Serve reads, apply mutations from TLogs
+  - Key-value stores — Pluggable storage engines (RocksDB, SQLite, memory/DiskQueue)
+  - Data distributor — Shard management, team building, data movement
+  - Ratekeeper — Back-pressure and throttling
+  - `workloads/` — Simulation test workloads
+
+### Write Path
+
+Client commit → GRV Proxy (assigns read version) → Commit Proxy (batches, sends to Resolver for conflict check, writes to TLogs) → TLogs (durable WAL) → Storage Servers (pull from TLogs, apply)
+
+### Read Path
+
+Client read → Storage Server (serves from MVCC versioned data or underlying storage engine)
+
+### Recovery
+
+When the transaction system fails, the Cluster Controller drives nine recovery phases (`READING_CSTATE` through `FULLY_RECOVERED`; `UNINITIALIZED` is state 0) defined in `fdbserver/include/fdbserver/RecoveryState.h`. Recovery reads coordinated state from coordinators, locks old TLogs, recruits the next transaction system, and recovers durable mutations from old log generations.
+
+### Coordinator Consensus
+
+Coordinators implement generation registers in `fdbserver/Coordination.actor.cpp`. `CoordinatedState` in `fdbserver/CoordinatedState.actor.cpp` performs quorum reads and writes over them for recovery metadata. Coordinators separately participate in leader election, but transaction commits use the resolver/TLog pipeline instead.
+
+### Simulation Testing
+
+`fdbserver -r simulation` runs the entire cluster in a single process using Sim2, a deterministic simulated network. `BUGGIFY` macros inject faults (delays, failures, corruption). Tests are TOML files that compose workloads. This is FDB's primary testing strategy.
+
+### Knobs
+
+Runtime-tunable parameters are declared in `fdbclient/include/fdbclient/ServerKnobs.h`, `fdbclient/include/fdbclient/Knobs.h`, and `flow/include/flow/Knobs.h` (UPPER_CASE names). Access them via `SERVER_KNOBS`, `CLIENT_KNOBS`, or `FLOW_KNOBS`. Defaults and buggification ranges live in `fdbclient/ServerKnobs.cpp`, `fdbclient/ClientKnobs.cpp`, and `flow/Knobs.cpp`.
+
+## Compatibility
+
+Before changing a serialized type that persists on disk, inspect its `serializer()` and adjacent versioning or downgrade comments. Do not reorder, remove, or change encoded fields without the appropriate version gate or migration and compatibility coverage.
+
+## Naming Conventions
+
+- **Variables, functions, methods**: camelCase (`smoothTotal`, `getWorkerForRole`)
+- **Classes, structs, enums**: PascalCase (`StorageServer`, `RecoveryState`)
+- **Knobs/constants**: UPPER_CASE (`MAX_BATCH_SIZE`, `VERSIONS_PER_SECOND`)
+- **Globals**: `g_` prefix for important ones (`g_network`, `g_simulator`)
+
+## Code Formatting
+
+`clang-format` is used. Python code uses `black` and `flake8` (pre-commit hooks: `pip install pre-commit && pre-commit install`).
+
+Edit `.actor.cpp` and `.actor.h` sources, not actorcompiler-generated output under the build directory.
+
+## Source File Headers
+
+Every new `.cpp` / `.h` / `.actor.cpp` / `.actor.h` file starts with the standard Apache 2.0 license block, with the filename on line 2 and the current year on the copyright line. Copy from any existing file in the tree (e.g. `flow/Knobs.cpp`). Add file-purpose comments *after* the license block, not in place of it.
+
+## Code Review
+
+Unless you have specific instructions to the contrary, when asked to review code (named files or a diff), address all of these explicitly:
+
+- What is it trying to accomplish?
+- Is it correct?
+- Are there bugs?
+- Are there omissions?
+- Are there things that could be done better?
+- Should it be LGTM'd? (clear yes / no / not-yet)
+
+## Branching
+
+PRs target `main`. Release branches receive cherry-picks rather than direct PRs — don't open backport PRs without confirming first.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,12 @@ if (WITH_ACAC)
   add_compile_definitions(WITH_ACAC)
 endif()
 
+option(FDB_MEMORY_TRACKER "Compile in the sampled per-call-site memory tracker (flow/MemoryTracker)" ON)
+if(NOT FDB_MEMORY_TRACKER)
+  message(STATUS "Building FoundationDB with the memory tracker compiled out")
+  add_compile_definitions(FDB_MEMORY_TRACKER=0)
+endif()
+
 ################################################################################
 # Packages used for bindings
 ################################################################################

--- a/fdbserver/GlobalNewDelete.cpp
+++ b/fdbserver/GlobalNewDelete.cpp
@@ -1,0 +1,248 @@
+/*
+ * GlobalNewDelete.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Process-wide replacements for the global operator new / operator delete set,
+// owned by the fdbserver binary.
+//
+// These live here, in a translation unit compiled directly into the fdbserver
+// executable, rather than in the `flow` static library, for two reasons:
+//
+//  1. Correctness of interposition. operator new / operator delete are
+//     replaceable functions; a definition sitting in a static archive is only
+//     pulled into the link if the linker already needs some other symbol from
+//     that same object file. Placing them in an executable TU guarantees the
+//     replacements are part of the final link instead of relying on incidental
+//     archive pull-in.
+//
+//  2. Client isolation. `flow` is linked into libfdb_c and every client
+//     binding; a global-new override compiled into it would interpose the
+//     entire host process's allocator in any application that loads the client.
+//     fdbserver is a standalone executable that clients never link, so keeping
+//     these here confines the interposition to the server.
+//
+// Exactly one implementation is compiled, chosen by the same ALLOC_INSTRUMENTATION
+// flags the legacy accounting framework uses (so the two never define the global
+// operators twice):
+//
+//   - ALLOC_INSTRUMENTATION[_STDOUT] on  -> legacy FastAlloc accounting hooks.
+//   - otherwise                          -> the sampled per-call-site memory
+//                                           tracker (flow/MemoryTracker.*).
+
+#include <cstdlib>
+#include <new>
+
+#include "flow/MemoryTracker.h" // for FDB_MEMORY_TRACKER (default on)
+
+// TODO: the old ALLOC_INSTRUMENTATION doesn't seem to be usable at
+// scale. Consider deleting it.
+#if defined(ALLOC_INSTRUMENTATION) || defined(ALLOC_INSTRUMENTATION_STDOUT)
+
+#include "flow/FastAlloc.h"
+
+void* operator new(std::size_t size) {
+	void* p = malloc(size);
+	if (!p) {
+		throw std::bad_alloc();
+	}
+	recordAllocation(p, size);
+	return p;
+}
+void operator delete(void* ptr) throw() {
+	recordDeallocation(ptr);
+	free(ptr);
+}
+
+void* operator new(std::size_t size, const std::nothrow_t&) throw() {
+	void* p = malloc(size);
+	recordAllocation(p, size);
+	return p;
+}
+void operator delete(void* ptr, const std::nothrow_t&) throw() {
+	recordDeallocation(ptr);
+	free(ptr);
+}
+
+void* operator new[](std::size_t size) {
+	void* p = malloc(size);
+	if (!p) {
+		throw std::bad_alloc();
+	}
+	recordAllocation(p, size);
+	return p;
+}
+void operator delete[](void* ptr) throw() {
+	recordDeallocation(ptr);
+	free(ptr);
+}
+
+void* operator new[](std::size_t size, const std::nothrow_t&) throw() {
+	void* p = malloc(size);
+	recordAllocation(p, size);
+	return p;
+}
+void operator delete[](void* ptr, const std::nothrow_t&) throw() {
+	recordDeallocation(ptr);
+	free(ptr);
+}
+
+#else // sampled memory tracker, see design/memory-tracker.md
+
+#include "flow/Platform.h" // aligned_alloc / aligned_free (portable across MSVC/POSIX)
+
+#if FDB_MEMORY_TRACKER
+
+// NOTE: We (Apple) do not maintain a local facility to build FDB with MSVC on
+// Windows, and CI only *configures* (not compiles) there — so the MSVC-specific
+// pieces below are best-effort and not compile-verified: the exact signatures of
+// the replaceable global operator new/delete set, and the
+// aligned_alloc/aligned_free ↔ _aligned_malloc/_aligned_free pairing routed
+// through flow/Platform.h. This code may have issues on MSVC; community help for
+// the Windows build would be welcome. (See flow/MemoryTracker.cpp for the parallel
+// note on the non-Linux frame walker.)
+
+namespace {
+
+// Retry through the installed std::new_handler on failure, as the default
+// operator new does. fdbserver installs platform::outOfMemory, so an allocation
+// failure (including the tracker's own map growth) reaches FDB's OOM diagnostics
+// and FDB_EXIT_NO_MEM rather than throwing straight past them.
+void* mallocWithNewHandler(std::size_t n) {
+	void* p;
+	while (!(p = std::malloc(n))) {
+		std::new_handler h = std::get_new_handler();
+		if (!h) {
+			throw std::bad_alloc();
+		}
+		h();
+	}
+	return p;
+}
+
+// Same handler loop for over-aligned allocations. C11 aligned_alloc requires the
+// size to be a multiple of the alignment, so round up (harmless over-allocation)
+// to accept arbitrary operator-new sizes.
+void* alignedAllocWithNewHandler(std::size_t alignment, std::size_t n) {
+	std::size_t rounded = (n + alignment - 1) & ~(alignment - 1);
+	if (rounded < n) {
+		throw std::bad_alloc(); // round-up overflowed; the request can't be satisfied
+	}
+	void* p;
+	while (!(p = aligned_alloc(alignment, rounded))) {
+		std::new_handler h = std::get_new_handler();
+		if (!h) {
+			throw std::bad_alloc();
+		}
+		h();
+	}
+	return p;
+}
+
+} // namespace
+
+void* operator new(std::size_t n) {
+	void* p = mallocWithNewHandler(n);
+	memTrackerOnAlloc(p, n);
+	return p;
+}
+void operator delete(void* p) noexcept {
+	memTrackerOnFree(p);
+	std::free(p);
+}
+void operator delete(void* p, std::size_t) noexcept {
+	memTrackerOnFree(p);
+	std::free(p);
+}
+
+void* operator new[](std::size_t n) {
+	void* p = mallocWithNewHandler(n);
+	memTrackerOnAlloc(p, n);
+	return p;
+}
+void operator delete[](void* p) noexcept {
+	memTrackerOnFree(p);
+	std::free(p);
+}
+void operator delete[](void* p, std::size_t) noexcept {
+	memTrackerOnFree(p);
+	std::free(p);
+}
+
+void* operator new(std::size_t n, const std::nothrow_t&) noexcept {
+	try {
+		void* p = mallocWithNewHandler(n);
+		memTrackerOnAlloc(p, n);
+		return p;
+	} catch (...) {
+		return nullptr;
+	}
+}
+void operator delete(void* p, const std::nothrow_t&) noexcept {
+	memTrackerOnFree(p);
+	std::free(p);
+}
+
+void* operator new[](std::size_t n, const std::nothrow_t&) noexcept {
+	try {
+		void* p = mallocWithNewHandler(n);
+		memTrackerOnAlloc(p, n);
+		return p;
+	} catch (...) {
+		return nullptr;
+	}
+}
+void operator delete[](void* p, const std::nothrow_t&) noexcept {
+	memTrackerOnFree(p);
+	std::free(p);
+}
+
+// C++17 over-aligned new/delete. aligned_alloc/aligned_free (flow/Platform.h)
+// keep the alloc and free sides paired on MSVC (_aligned_malloc/_aligned_free).
+void* operator new(std::size_t n, std::align_val_t a) {
+	void* p = alignedAllocWithNewHandler(static_cast<std::size_t>(a), n);
+	memTrackerOnAlloc(p, n);
+	return p;
+}
+void operator delete(void* p, std::align_val_t) noexcept {
+	memTrackerOnFree(p);
+	aligned_free(p);
+}
+void operator delete(void* p, std::size_t, std::align_val_t) noexcept {
+	memTrackerOnFree(p);
+	aligned_free(p);
+}
+
+void* operator new[](std::size_t n, std::align_val_t a) {
+	void* p = alignedAllocWithNewHandler(static_cast<std::size_t>(a), n);
+	memTrackerOnAlloc(p, n);
+	return p;
+}
+void operator delete[](void* p, std::align_val_t) noexcept {
+	memTrackerOnFree(p);
+	aligned_free(p);
+}
+void operator delete[](void* p, std::size_t, std::align_val_t) noexcept {
+	memTrackerOnFree(p);
+	aligned_free(p);
+}
+
+#else // !FDB_MEMORY_TRACKER — no global operator new/delete override; libc++'s is used.
+#endif // FDB_MEMORY_TRACKER
+
+#endif // ALLOC_INSTRUMENTATION

--- a/fdbserver/MemoryTrackerTest.cpp
+++ b/fdbserver/MemoryTrackerTest.cpp
@@ -1,0 +1,769 @@
+/*
+ * MemoryTrackerTest.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Unit tests for the per-call-site memory tracker.
+//
+// The "coverage" test uses sentinel functions: each sentinel triggers exactly
+// one allocation path (operator new, FastAllocator, Arena), and the test
+// confirms that some call site in the aggregation table contains a frame
+// inside that sentinel's body. We compare raw return-address values against
+// function-pointer values at runtime, so this works on stripped builds with
+// no symbolization.
+
+#include "flow/Arena.h"
+#include "flow/FastAlloc.h"
+#include "flow/Knobs.h"
+#include "flow/MemoryTracker.h"
+#include "flow/Platform.h"
+#include "flow/UnitTest.h"
+
+#include <climits>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <new>
+#include <vector>
+
+// Force this TU to link. The TEST_CASE macro registers via a static
+// initializer; in a static library, a TU containing only static initializers
+// gets dropped by the linker because nothing references its symbols.
+// fdbserver/workloads/UnitTests.cpp calls this function to keep the TU.
+void forceLinkMemoryTrackerTests() {}
+
+#if FDB_MEMORY_TRACKER
+
+namespace {
+
+// A sentinel is an out-of-line function that performs exactly one kind of
+// allocation, then returns its own address. We use the returned address to
+// recognize captured stack frames that fell inside the sentinel's body.
+constexpr uintptr_t SENTINEL_FUNC_SIZE = 4096;
+
+// Defeat clang -O3 heap elision (P0593): if the allocated pointer doesn't
+// escape, the compiler is free to drop the new/delete pair entirely, which
+// then never reaches our operator-new override and the test sees zero samples.
+void* volatile gEscapeSink;
+inline void escape(void* p) {
+	gEscapeSink = p;
+}
+
+bool frameInside(void* frame, void* sentinel) {
+	uintptr_t f = reinterpret_cast<uintptr_t>(frame);
+	uintptr_t s = reinterpret_cast<uintptr_t>(sentinel);
+	return f >= s && f < s + SENTINEL_FUNC_SIZE;
+}
+
+force_noinline void* triggerOperatorNewSentinel(int n, int k) {
+	for (int i = 0; i < n; i++) {
+		auto* p = new int[k];
+		p[0] = i;
+		escape(p);
+		delete[] p;
+	}
+	return reinterpret_cast<void*>(&triggerOperatorNewSentinel);
+}
+
+force_noinline void* triggerFastAllocSentinel(int n) {
+	for (int i = 0; i < n; i++) {
+		void* p = FastAllocator<32>::allocate();
+		escape(p);
+		FastAllocator<32>::release(p);
+	}
+	return reinterpret_cast<void*>(&triggerFastAllocSentinel);
+}
+
+force_noinline void* triggerArenaSentinel(int n) {
+	// Force ArenaBlock::create by allocating large enough chunks to exceed
+	// the small-block threshold.
+	for (int i = 0; i < n; i++) {
+		Arena a;
+		// One ~512-byte allocation per arena -> goes through allocateAndMaybeKeepalive
+		// path which has the explicit Arena hook.
+		auto* p = new (a) uint8_t[600];
+		escape(p);
+	}
+	return reinterpret_cast<void*>(&triggerArenaSentinel);
+}
+
+// ---------------------------------------------------------------------------
+// Accounting tests: verify byte/block counts come out right per allocation path
+// and there's no double-tracking.
+force_noinline void* allocateArenaMediumSentinel(int n, std::vector<Arena>& arenas) {
+	for (int i = 0; i < n; i++) {
+		arenas.emplace_back();
+		auto* p = new (arenas.back()) uint8_t[600];
+		escape(p);
+	}
+	return reinterpret_cast<void*>(&allocateArenaMediumSentinel);
+}
+
+force_noinline void* allocateArenaHugeSentinel(int n, std::vector<Arena>& arenas) {
+	for (int i = 0; i < n; i++) {
+		arenas.emplace_back();
+		auto* p = new (arenas.back()) uint8_t[100000];
+		escape(p);
+	}
+	return reinterpret_cast<void*>(&allocateArenaHugeSentinel);
+}
+
+force_noinline void* allocateArenaSmallSentinel(int n, std::vector<Arena>& arenas) {
+	for (int i = 0; i < n; i++) {
+		arenas.emplace_back();
+		auto* p = new (arenas.back()) uint8_t[64];
+		escape(p);
+	}
+	return reinterpret_cast<void*>(&allocateArenaSmallSentinel);
+}
+
+force_noinline void* allocateOperatorNewSentinel(int n, int k, std::vector<int*>& ptrs) {
+	for (int i = 0; i < n; i++) {
+		auto* p = new int[k];
+		escape(p);
+		ptrs.push_back(p);
+	}
+	return reinterpret_cast<void*>(&allocateOperatorNewSentinel);
+}
+
+force_noinline void* allocateFastAlloc32Sentinel(int n, std::vector<void*>& ptrs) {
+	for (int i = 0; i < n; i++) {
+		void* p = FastAllocator<32>::allocate();
+		escape(p);
+		ptrs.push_back(p);
+	}
+	return reinterpret_cast<void*>(&allocateFastAlloc32Sentinel);
+}
+
+force_noinline void releaseFastAlloc32(std::vector<void*>& ptrs) {
+	for (void* p : ptrs) {
+		FastAllocator<32>::release(p);
+	}
+	ptrs.clear();
+}
+
+struct AccountingSummary {
+	int sitesWithSentinelFrames = 0;
+	int64_t cumBytesSentinel = 0;
+	int64_t cumAllocsSentinel = 0;
+	int64_t liveBytesSentinel = 0;
+	int64_t liveCountSentinel = 0;
+	int totalSites = 0;
+};
+
+AccountingSummary collectAccounting(void* sentinel) {
+	AccountingSummary acc;
+	memTrackerForEachSite([&](const MemoryTrackerCallSite& s) {
+		acc.totalSites++;
+		bool touches = false;
+		for (int i = 0; i < s.exemplarFrameCount; i++) {
+			if (frameInside(s.exemplarFrames[i], sentinel)) {
+				touches = true;
+				break;
+			}
+		}
+		if (touches && s.cumulativeBytes > 0) {
+			acc.sitesWithSentinelFrames++;
+			acc.cumBytesSentinel += s.cumulativeBytes;
+			acc.cumAllocsSentinel += s.cumulativeAllocs;
+			acc.liveBytesSentinel += s.liveBytes;
+			acc.liveCountSentinel += s.liveCount;
+		}
+	});
+	return acc;
+}
+
+void dumpSitesForFailure(const char* tag) {
+	fprintf(stderr, "[%s] dumping all tracker sites:\n", tag);
+	memTrackerForEachSite([&](const MemoryTrackerCallSite& s) {
+		fprintf(stderr,
+		        "  fp=%016llx liveBytes=%lld liveCount=%lld cumBytes=%lld cumAllocs=%lld frames=",
+		        (unsigned long long)s.fingerprint,
+		        (long long)s.liveBytes,
+		        (long long)s.liveCount,
+		        (long long)s.cumulativeBytes,
+		        (long long)s.cumulativeAllocs);
+		for (int i = 0; i < s.exemplarFrameCount; i++) {
+			fprintf(stderr, "%p ", s.exemplarFrames[i]);
+		}
+		fprintf(stderr, "\n");
+	});
+}
+
+class KnobOverride {
+public:
+	explicit KnobOverride(int inverse = 1) : prevInverse(FLOW_KNOBS->MEMORY_TRACKING_SAMPLE_INVERSE) {
+		auto* k = const_cast<FlowKnobs*>(FLOW_KNOBS);
+		k->MEMORY_TRACKING_SAMPLE_INVERSE = inverse;
+	}
+	~KnobOverride() {
+		auto* k = const_cast<FlowKnobs*>(FLOW_KNOBS);
+		k->MEMORY_TRACKING_SAMPLE_INVERSE = prevInverse;
+	}
+
+private:
+	int prevInverse;
+};
+
+} // namespace
+
+TEST_CASE("/flow/MemoryTracker/coverage") {
+#ifndef __linux__
+	// captureFramesFP is a no-op stub on non-Linux (FP walking through libc
+	// can't be made reliable on macOS); tests that inspect captured frames
+	// have nothing to inspect. Skip cleanly. The tracker still compiles
+	// and the non-frame tests (offSwitch, freeOfUntrackedPtrIsNoop) still
+	// run.
+	return Void();
+#endif
+	// Sample everything, reset, run sentinels, check.
+	KnobOverride ko;
+	memTrackerResetForTest();
+
+	void* opNew = triggerOperatorNewSentinel(50, 4);
+	void* fastAlloc = triggerFastAllocSentinel(50);
+	void* arena = triggerArenaSentinel(50);
+
+	bool foundOpNew = false;
+	bool foundFastAlloc = false;
+	bool foundArena = false;
+	int siteCount = 0;
+	memTrackerForEachSite([&](const MemoryTrackerCallSite& s) {
+		siteCount++;
+		for (int i = 0; i < s.exemplarFrameCount; i++) {
+			if (frameInside(s.exemplarFrames[i], opNew)) {
+				foundOpNew = true;
+			}
+			if (frameInside(s.exemplarFrames[i], fastAlloc)) {
+				foundFastAlloc = true;
+			}
+			if (frameInside(s.exemplarFrames[i], arena)) {
+				foundArena = true;
+			}
+		}
+	});
+
+	if (!foundOpNew || !foundFastAlloc || !foundArena) {
+		fprintf(stderr,
+		        "MemoryTracker/coverage: sites=%d opNewSentinel=%p fastAllocSentinel=%p arenaSentinel=%p\n",
+		        siteCount,
+		        opNew,
+		        fastAlloc,
+		        arena);
+		fprintf(stderr,
+		        "MemoryTracker/coverage: foundOpNew=%d foundFastAlloc=%d foundArena=%d\n",
+		        foundOpNew,
+		        foundFastAlloc,
+		        foundArena);
+		memTrackerForEachSite([&](const MemoryTrackerCallSite& s) {
+			fprintf(stderr,
+			        "  site fp=%016llx liveBytes=%lld cumAllocs=%lld frames=",
+			        (unsigned long long)s.fingerprint,
+			        (long long)s.liveBytes,
+			        (long long)s.cumulativeAllocs);
+			for (int i = 0; i < s.exemplarFrameCount; i++) {
+				fprintf(stderr, "%p ", s.exemplarFrames[i]);
+			}
+			fprintf(stderr, "\n");
+		});
+	}
+
+	ASSERT(foundOpNew);
+	ASSERT(foundFastAlloc);
+	ASSERT(foundArena);
+	return Void();
+}
+
+TEST_CASE("/flow/MemoryTracker/offSwitch") {
+	// With sample inverse 0, no allocations are attributed. memTrackerResetForTest
+	// arms this thread's off-latch straight from the knob (as memTrackerInit does
+	// at startup), so even the first allocation short-circuits.
+	auto* k = const_cast<FlowKnobs*>(FLOW_KNOBS);
+	int prev = k->MEMORY_TRACKING_SAMPLE_INVERSE;
+	k->MEMORY_TRACKING_SAMPLE_INVERSE = 0;
+
+	memTrackerResetForTest();
+
+	for (int i = 0; i < 100; i++) {
+		auto* p = new int[4];
+		p[0] = i;
+		delete[] p;
+	}
+
+	int siteCount = 0;
+	memTrackerForEachSite([&](const MemoryTrackerCallSite&) { siteCount++; });
+	ASSERT_EQ(siteCount, 0);
+
+	// The enabled flag gates the free hot path: with sampling off it must be
+	// false, so memTrackerOnFree short-circuits before taking g_mtLock.
+	ASSERT(!g_memTrackerEnabled.value.load(std::memory_order_relaxed));
+
+	k->MEMORY_TRACKING_SAMPLE_INVERSE = prev;
+	return Void();
+}
+
+TEST_CASE("/flow/MemoryTracker/operatorNewHonorsNewHandler") {
+	// The global operator new override (fdbserver/GlobalNewDelete.cpp) must run
+	// the std::new_handler retry loop so an allocation failure reaches FDB's OOM
+	// path instead of throwing straight past it. (Where the override isn't linked,
+	// the standard library's operator new provides the same contract, so this
+	// still passes.)
+	static bool handlerRan;
+	handlerRan = false;
+	std::new_handler prev = std::set_new_handler([]() {
+		handlerRan = true;
+		throw std::bad_alloc(); // break the retry loop
+	});
+
+	bool caught = false;
+	try {
+		// volatile so the compiler can't fold the size and warn (-Walloc-size); malloc
+		// reliably fails for SIZE_MAX, driving the handler loop.
+		volatile std::size_t huge = std::numeric_limits<std::size_t>::max();
+		void* p = ::operator new(huge);
+		escape(p);
+	} catch (const std::bad_alloc&) {
+		caught = true;
+	}
+	std::set_new_handler(prev);
+
+	ASSERT(handlerRan);
+	ASSERT(caught);
+	return Void();
+}
+
+TEST_CASE("/flow/MemoryTracker/samplingRate") {
+	// The reseed gap is uniform on [1, 2N-1] (mean N), so at inverse N the sampled
+	// fraction should be ~1/N. Wide bounds keep it non-flaky across RNG state.
+	constexpr int N = 10;
+	constexpr int ALLOCS = 200000;
+	KnobOverride ko(N);
+	memTrackerResetForTest();
+
+	std::vector<int*> ptrs;
+	ptrs.reserve(ALLOCS);
+	for (int i = 0; i < ALLOCS; i++) {
+		auto* p = new int[4];
+		escape(p);
+		ptrs.push_back(p);
+	}
+
+	int64_t sampled = 0;
+	memTrackerForEachSite([&](const MemoryTrackerCallSite& s) {
+		if (s.forceSampledCount == 0) {
+			sampled += s.cumulativeAllocs;
+		}
+	});
+
+	for (auto* p : ptrs) {
+		delete[] p;
+	}
+	ptrs.clear();
+
+	double frac = double(sampled) / ALLOCS;
+	ASSERT(frac > 0.06 && frac < 0.15); // expect ~0.1
+	memTrackerResetForTest();
+	return Void();
+}
+
+TEST_CASE("/flow/MemoryTracker/freeOfUntrackedPtrIsNoop") {
+	// memTrackerOnFree on a pointer the tracker never recorded must be a no-op.
+	KnobOverride ko;
+	memTrackerResetForTest();
+
+	int x = 0;
+	memTrackerOnFree(&x); // not in any table
+	memTrackerOnFree(nullptr);
+
+	int siteCount = 0;
+	memTrackerForEachSite([&](const MemoryTrackerCallSite&) { siteCount++; });
+	ASSERT_EQ(siteCount, 0);
+	return Void();
+}
+
+TEST_CASE("/flow/MemoryTracker/cumulativeIsMonotonic") {
+#ifndef __linux__
+	return Void(); // see /coverage for rationale
+#endif
+	// liveCount must return to ~0 after we free everything we allocated;
+	// cumulativeAllocs must NOT decrement.
+	KnobOverride ko;
+	memTrackerResetForTest();
+
+	void* sentinel = triggerOperatorNewSentinel(100, 8);
+
+	int64_t maxCumulative = 0;
+	int64_t finalLive = 0;
+	memTrackerForEachSite([&](const MemoryTrackerCallSite& s) {
+		for (int i = 0; i < s.exemplarFrameCount; i++) {
+			if (frameInside(s.exemplarFrames[i], sentinel)) {
+				if (s.cumulativeAllocs > maxCumulative) {
+					maxCumulative = s.cumulativeAllocs;
+				}
+				finalLive += s.liveCount;
+			}
+		}
+	});
+
+	ASSERT(maxCumulative >= 100);
+	ASSERT_EQ(finalLive, 0); // every alloc was paired with delete
+	return Void();
+}
+
+TEST_CASE("/flow/MemoryTracker/estimateScaling") {
+	// End-to-end estimate check. With a fixed inverse N > 1 and no force-sampled
+	// blocks, every sample at a site carries weight N, so the site's estimated
+	// usage must be *exactly* N times its raw sampled counters. This verifies
+	// the reported Est* numbers without depending on which specific allocations
+	// happened to be sampled. Runs on all platforms (no frame inspection).
+	constexpr int N = 8;
+	KnobOverride ko(N);
+	memTrackerResetForTest();
+
+	// Small allocations far below the force-sample threshold, so none
+	// are force-sampled and every sampled block gets weight N.
+	std::vector<int*> ptrs;
+	ptrs.reserve(5000);
+	for (int i = 0; i < 5000; i++) {
+		auto* p = new int[4];
+		escape(p);
+		ptrs.push_back(p);
+	}
+
+	int checked = 0;
+	int64_t rawLiveBefore = 0;
+	memTrackerForEachSite([&](const MemoryTrackerCallSite& s) {
+		if (s.forceSampledCount != 0) {
+			return; // ignore any incidental force-sampled site (weight 1, not N)
+		}
+		ASSERT_EQ(s.estCumulativeBytes, s.cumulativeBytes * N);
+		ASSERT_EQ(s.estCumulativeAllocs, s.cumulativeAllocs * N);
+		ASSERT_EQ(s.estLiveBytes, s.liveBytes * N);
+		ASSERT_EQ(s.estLiveCount, s.liveCount * N);
+		ASSERT_EQ(s.estPeakBytes, s.peakBytes * N);
+		rawLiveBefore += s.liveBytes;
+		checked++;
+	});
+	ASSERT(checked > 0);
+	ASSERT(rawLiveBefore > 0);
+
+	for (auto* p : ptrs) {
+		delete[] p;
+	}
+	ptrs.clear();
+
+	// Symmetric debit: the per-site scaling invariant must still hold after the
+	// frees (each free debits the estimate by exactly weight×size), and the live
+	// total must have dropped. We check the invariant rather than "live == 0"
+	// because incidental still-live allocations (e.g. the ptrs vector's own
+	// backing buffer) legitimately remain tracked.
+	int64_t rawLiveAfter = 0;
+	int64_t estLiveAfter = 0;
+	memTrackerForEachSite([&](const MemoryTrackerCallSite& s) {
+		if (s.forceSampledCount != 0) {
+			return;
+		}
+		ASSERT_EQ(s.estLiveBytes, s.liveBytes * N);
+		rawLiveAfter += s.liveBytes;
+		estLiveAfter += s.estLiveBytes;
+	});
+	ASSERT_EQ(estLiveAfter, rawLiveAfter * N);
+	ASSERT(rawLiveAfter < rawLiveBefore); // the freed blocks were debited
+
+	memTrackerResetForTest();
+	return Void();
+}
+
+// ---------------------------------------------------------------------------
+// Accounting tests. The "sites with the sentinel's frames" assertion is the
+// main check here.
+
+TEST_CASE("/flow/MemoryTracker/fastAlloc32Accounting") {
+#ifndef __linux__
+	return Void(); // see /coverage for rationale
+#endif
+	KnobOverride ko;
+	constexpr int N = 30;
+
+	std::vector<void*> ptrs;
+	ptrs.reserve(N);
+
+	memTrackerResetForTest();
+	void* sentinel = allocateFastAlloc32Sentinel(N, ptrs);
+
+	auto pre = collectAccounting(sentinel);
+	if (pre.sitesWithSentinelFrames != 1) {
+		dumpSitesForFailure("fastAlloc32Accounting/post-alloc");
+	}
+	ASSERT_EQ(pre.sitesWithSentinelFrames, 1);
+	ASSERT_EQ(pre.cumAllocsSentinel, N);
+	ASSERT_EQ(pre.liveCountSentinel, N);
+	ASSERT_EQ(pre.cumBytesSentinel, int64_t(N) * 32);
+	ASSERT_EQ(pre.liveBytesSentinel, pre.cumBytesSentinel);
+	// Global totals are intentionally not asserted: at inverse=1 a foreign-thread
+	// allocation in the window would break a strict global equality (flaky at
+	// Joshua scale); the sentinel-scoped checks above pin the regression.
+
+	releaseFastAlloc32(ptrs);
+
+	auto post = collectAccounting(sentinel);
+	ASSERT_EQ(post.liveBytesSentinel, 0);
+	ASSERT_EQ(post.liveCountSentinel, 0);
+	// Global live totals intentionally not asserted (flaky at inverse=1; see above).
+	ASSERT_EQ(post.cumAllocsSentinel, N); // cumulative never decrements
+	return Void();
+}
+
+TEST_CASE("/flow/MemoryTracker/arenaSmallAccounting") {
+#ifndef __linux__
+	return Void(); // see /coverage for rationale
+#endif
+	KnobOverride ko;
+	constexpr int N = 30;
+
+	std::vector<Arena> arenas;
+	arenas.reserve(N);
+
+	memTrackerResetForTest();
+	void* sentinel = allocateArenaSmallSentinel(N, arenas);
+
+	auto pre = collectAccounting(sentinel);
+	if (pre.sitesWithSentinelFrames != 1) {
+		dumpSitesForFailure("arenaSmallAccounting/post-alloc");
+	}
+	ASSERT_EQ(pre.sitesWithSentinelFrames, 1);
+	ASSERT_EQ(pre.cumAllocsSentinel, N);
+	ASSERT_EQ(pre.liveCountSentinel, N);
+	ASSERT_EQ(pre.liveBytesSentinel, pre.cumBytesSentinel);
+	// Global totals are intentionally not asserted: at inverse=1 a foreign-thread
+	// allocation in the window would break a strict global equality (flaky at
+	// Joshua scale); the sentinel-scoped checks above pin the regression.
+
+	arenas.clear();
+
+	auto post = collectAccounting(sentinel);
+	ASSERT_EQ(post.liveBytesSentinel, 0);
+	ASSERT_EQ(post.liveCountSentinel, 0);
+	// Global live totals intentionally not asserted (flaky at inverse=1; see above).
+	ASSERT_EQ(post.cumAllocsSentinel, N);
+	return Void();
+}
+
+TEST_CASE("/flow/MemoryTracker/arenaMediumAccounting") {
+#ifndef __linux__
+	return Void(); // see /coverage for rationale
+#endif
+	// Make sure arenas aren't counted twice, once due to their direct
+	// instrumentation and a second time due to their use of operator new.
+	KnobOverride ko;
+	constexpr int N = 30;
+
+	std::vector<Arena> arenas;
+	arenas.reserve(N);
+
+	memTrackerResetForTest();
+	void* sentinel = allocateArenaMediumSentinel(N, arenas);
+
+	auto pre = collectAccounting(sentinel);
+	if (pre.sitesWithSentinelFrames != 1) {
+		dumpSitesForFailure("arenaMediumAccounting/post-alloc");
+	}
+	ASSERT_EQ(pre.sitesWithSentinelFrames, 1);
+	ASSERT_EQ(pre.cumAllocsSentinel, N);
+	ASSERT_EQ(pre.liveCountSentinel, N);
+	ASSERT_EQ(pre.liveBytesSentinel, pre.cumBytesSentinel);
+	// Global totals intentionally not asserted (flaky at inverse=1; see above).
+
+	arenas.clear();
+
+	auto post = collectAccounting(sentinel);
+	ASSERT_EQ(post.liveBytesSentinel, 0);
+	ASSERT_EQ(post.liveCountSentinel, 0);
+	// Global live totals intentionally not asserted (flaky at inverse=1; see above).
+	ASSERT_EQ(post.cumAllocsSentinel, N);
+	return Void();
+}
+
+TEST_CASE("/flow/MemoryTracker/arenaHugeAccounting") {
+#ifndef __linux__
+	return Void(); // see /coverage for rationale
+#endif
+	// Verify the huge Arena-block path (reqSize >= LARGE), including that a block is
+	// tracked once (not double-counted by both the explicit Arena hook and the inner
+	// operator new[]). This is the deepest tracked call chain, and under a real
+	// (non-simulation) network its frame-pointer backtrace is unreliable — the
+	// best-effort walker may, run to run and even alloc to alloc, fail to climb to
+	// the test's frame or attribute the blocks to varying fingerprints. So instead of
+	// the sentinel-frame approach the other *Accounting tests use, we identify the
+	// huge blocks by their unmistakable ~100 KB size signature: the recorded size is
+	// correct regardless of which frames were captured, and no incidental or
+	// foreign-thread allocation comes anywhere near this large.
+	KnobOverride ko;
+	constexpr int N = 10;
+	constexpr int64_t BLOCK = 100000;
+	constexpr int64_t HUGE_MIN = 90000; // mean bytes/alloc of a huge site; nothing else is this big
+
+	std::vector<Arena> arenas;
+	arenas.reserve(N);
+
+	memTrackerResetForTest();
+	allocateArenaHugeSentinel(N, arenas);
+
+	int64_t cumAllocs = 0, cumBytes = 0, liveBytes = 0, liveCount = 0;
+	memTrackerForEachSite([&](const MemoryTrackerCallSite& s) {
+		if (s.cumulativeAllocs > 0 && s.cumulativeBytes / s.cumulativeAllocs >= HUGE_MIN) {
+			cumAllocs += s.cumulativeAllocs;
+			cumBytes += s.cumulativeBytes;
+			liveBytes += s.liveBytes;
+			liveCount += s.liveCount;
+		}
+	});
+	// Exactly N huge blocks, each tracked once (double-tracking would show as 2N),
+	// all currently live, with live bytes == cumulative bytes (nothing freed yet).
+	ASSERT_EQ(cumAllocs, N);
+	ASSERT_EQ(liveCount, N);
+	ASSERT_EQ(liveBytes, cumBytes);
+	ASSERT(cumBytes >= int64_t(N) * BLOCK);
+
+	arenas.clear();
+
+	int64_t cumAllocsPost = 0, liveBytesPost = 0, liveCountPost = 0;
+	memTrackerForEachSite([&](const MemoryTrackerCallSite& s) {
+		if (s.cumulativeAllocs > 0 && s.cumulativeBytes / s.cumulativeAllocs >= HUGE_MIN) {
+			cumAllocsPost += s.cumulativeAllocs;
+			liveBytesPost += s.liveBytes;
+			liveCountPost += s.liveCount;
+		}
+	});
+	// After freeing, the huge blocks are debited: live returns to 0, cumulative persists.
+	ASSERT_EQ(liveBytesPost, 0);
+	ASSERT_EQ(liveCountPost, 0);
+	ASSERT_EQ(cumAllocsPost, N);
+	return Void();
+}
+
+TEST_CASE("/flow/MemoryTracker/operatorNewAccounting") {
+#ifndef __linux__
+	return Void(); // see /coverage for rationale
+#endif
+	KnobOverride ko;
+	constexpr int N = 30;
+	constexpr int K = 8; // new int[8] -> 32 bytes; int is trivial so no array cookie
+
+	std::vector<int*> ptrs;
+	ptrs.reserve(N);
+
+	memTrackerResetForTest();
+	void* sentinel = allocateOperatorNewSentinel(N, K, ptrs);
+
+	auto pre = collectAccounting(sentinel);
+	if (pre.sitesWithSentinelFrames != 1) {
+		dumpSitesForFailure("operatorNewAccounting/post-alloc");
+	}
+	ASSERT_EQ(pre.sitesWithSentinelFrames, 1);
+	ASSERT_EQ(pre.cumAllocsSentinel, N);
+	ASSERT_EQ(pre.liveCountSentinel, N);
+	ASSERT_EQ(pre.cumBytesSentinel, static_cast<int64_t>(N) * K * static_cast<int64_t>(sizeof(int)));
+	ASSERT_EQ(pre.liveBytesSentinel, pre.cumBytesSentinel);
+	// Global totals intentionally not asserted (flaky at inverse=1; see above).
+
+	for (auto* p : ptrs) {
+		delete[] p;
+	}
+	ptrs.clear();
+
+	auto post = collectAccounting(sentinel);
+	ASSERT_EQ(post.liveBytesSentinel, 0);
+	ASSERT_EQ(post.liveCountSentinel, 0);
+	// Global live totals intentionally not asserted (flaky at inverse=1; see above).
+	ASSERT_EQ(post.cumAllocsSentinel, N);
+	return Void();
+}
+
+TEST_CASE("/flow/MemoryTracker/failOpenOnMetadataAllocFailure") {
+	// The tracker must fail open: if its own metadata allocation throws, the
+	// underlying user allocation still succeeds and tracking recovers on this
+	// thread afterward (the reentrancy guard is restored, not leaked). Runs on all
+	// platforms — no frame inspection.
+	KnobOverride ko; // inverse = 1: sample every allocation
+	memTrackerResetForTest();
+
+	// Arm the one-shot; it is consumed by the next sampled allocation, which throws
+	// inside the tracker. new/delete must not observe that exception.
+	memTrackerFailNextSampleForTest();
+	int* p = new int[4];
+	ASSERT(p != nullptr);
+	p[0] = 42;
+	int observed = p[0];
+	delete[] p;
+	ASSERT_EQ(observed, 42);
+
+	// Tracking must still work after the injected failure.
+	memTrackerResetForTest();
+	std::vector<int*> ptrs;
+	ptrs.reserve(8);
+	for (int i = 0; i < 8; i++) {
+		auto* q = new int[4];
+		escape(q);
+		ptrs.push_back(q);
+	}
+	int siteCount = 0;
+	memTrackerForEachSite([&](const MemoryTrackerCallSite&) { siteCount++; });
+	for (auto* q : ptrs) {
+		delete[] q;
+	}
+	ASSERT(siteCount > 0);
+	return Void();
+}
+
+TEST_CASE("/flow/MemoryTracker/initEnablesFromKnob") {
+	// Exercises the *production* enablement path (memTrackerInit), not the test-only
+	// reset — the reviewer noted that memTrackerResetForTest masks the startup race.
+	// memTrackerInit must set the global enabled flag and this thread's fast-path
+	// off-latch straight from MEMORY_TRACKING_SAMPLE_INVERSE, and (the regression)
+	// must re-arm a thread that a prior off-configuration had already latched off.
+	auto* k = const_cast<FlowKnobs*>(FLOW_KNOBS);
+	int prev = k->MEMORY_TRACKING_SAMPLE_INVERSE;
+
+	// Sampling off: init publishes disabled and latches this thread off. This is the
+	// state an early startup allocation used to get stuck in before init existed.
+	k->MEMORY_TRACKING_SAMPLE_INVERSE = 0;
+	memTrackerInit();
+	ASSERT(!g_memTrackerEnabled.value.load(std::memory_order_relaxed));
+	ASSERT(gMemTrackerOff); // alloc hot path short-circuits
+
+	// Knobs now configured with sampling on: init must re-arm THIS thread. The bug
+	// was that nothing re-armed the network thread once it latched off before the
+	// knobs were ready, so sampling stayed dead for the life of the process.
+	k->MEMORY_TRACKING_SAMPLE_INVERSE = 8;
+	memTrackerInit();
+	ASSERT(g_memTrackerEnabled.value.load(std::memory_order_relaxed));
+	ASSERT(!gMemTrackerOff); // re-armed: alloc hot path now reaches the sampler
+
+	// And the reverse transition: a subsequent off-configuration re-latches it.
+	k->MEMORY_TRACKING_SAMPLE_INVERSE = 0;
+	memTrackerInit();
+	ASSERT(!g_memTrackerEnabled.value.load(std::memory_order_relaxed));
+	ASSERT(gMemTrackerOff);
+
+	k->MEMORY_TRACKING_SAMPLE_INVERSE = prev;
+	memTrackerInit(); // restore tracker state from the baseline knob for later tests
+	return Void();
+}
+
+#endif // FDB_MEMORY_TRACKER

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -83,6 +83,7 @@
 #include "flow/ProtocolVersion.h"
 #include "SimpleOpt/SimpleOpt.h"
 #include "flow/SystemMonitor.h"
+#include "flow/MemoryTracker.h"
 #include "flow/TLSConfig.actor.h"
 #include "fdbclient/Tracing.h"
 #include "flow/WriteOnlySet.h"
@@ -832,54 +833,9 @@ static void printUsage(const char* name, bool devhelp) {
 
 extern bool g_crashOnError;
 
-#if defined(ALLOC_INSTRUMENTATION) || defined(ALLOC_INSTRUMENTATION_STDOUT)
-void* operator new(std::size_t size) {
-	void* p = malloc(size);
-	if (!p)
-		throw std::bad_alloc();
-	recordAllocation(p, size);
-	return p;
-}
-void operator delete(void* ptr) throw() {
-	recordDeallocation(ptr);
-	free(ptr);
-}
-
-// scalar, nothrow new and it matching delete
-void* operator new(std::size_t size, const std::nothrow_t&) throw() {
-	void* p = malloc(size);
-	recordAllocation(p, size);
-	return p;
-}
-void operator delete(void* ptr, const std::nothrow_t&) throw() {
-	recordDeallocation(ptr);
-	free(ptr);
-}
-
-// array throwing new and matching delete[]
-void* operator new[](std::size_t size) {
-	void* p = malloc(size);
-	if (!p)
-		throw std::bad_alloc();
-	recordAllocation(p, size);
-	return p;
-}
-void operator delete[](void* ptr) throw() {
-	recordDeallocation(ptr);
-	free(ptr);
-}
-
-// array, nothrow new and matching delete[]
-void* operator new[](std::size_t size, const std::nothrow_t&) throw() {
-	void* p = malloc(size);
-	recordAllocation(p, size);
-	return p;
-}
-void operator delete[](void* ptr, const std::nothrow_t&) throw() {
-	recordDeallocation(ptr);
-	free(ptr);
-}
-#endif
+// The global operator new / operator delete replacements (both the legacy
+// ALLOC_INSTRUMENTATION accounting hooks and the sampled memory tracker) live in
+// fdbserver/GlobalNewDelete.cpp.
 
 Optional<bool> checkBuggifyOverride(const char* testFile) {
 	std::ifstream ifs;
@@ -2076,6 +2032,13 @@ int main(int argc, char* argv[]) {
 				flushAndExit(FDB_EXIT_ERROR);
 			}
 		}
+
+		// Knobs are now final; initialize the sampled memory tracker from them on
+		// this (soon-to-be network) thread, before any serving role starts. Reading
+		// the sample-inverse knob explicitly here — rather than inferring it from
+		// the first allocation — keeps early startup allocations from latching the
+		// tracker off before the knobs were configured. See design/memory-tracker.md.
+		memTrackerInit();
 
 		// evictionPolicyStringToEnum will throw an exception if the string is not recognized as a valid
 		EvictablePageCache::evictionPolicyStringToEnum(FLOW_KNOBS->CACHE_EVICTION_POLICY);

--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -41,6 +41,7 @@ void forceLinkJsonWebKeySetTests();
 void forceLinkVersionVectorTests();
 void forceLinkRESTClientTests();
 void forceLinkRESTUtilsTests();
+void forceLinkMemoryTrackerTests();
 void forceLinkRESTKmsConnectorTest();
 void forceLinkCompressionUtilsTest();
 void forceLinkAtomicTests();
@@ -120,6 +121,7 @@ struct UnitTestWorkload : TestWorkload {
 		forceLinkVersionVectorTests();
 		forceLinkRESTClientTests();
 		forceLinkRESTUtilsTests();
+		forceLinkMemoryTrackerTests();
 		forceLinkRESTKmsConnectorTest();
 		forceLinkCompressionUtilsTest();
 		forceLinkAtomicTests();

--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "flow/Arena.h"
+#include "flow/MemoryTracker.h"
 #include "flow/ScopeExit.h"
 #include "flow/SimpleCounter.h"
 #include "flow/UnitTest.h"
@@ -417,36 +418,55 @@ ArenaBlock* ArenaBlock::create(int dataSize, Reference<ArenaBlock>& next) {
 				b = (ArenaBlock*)FastAllocator<256>::allocate();
 				b->bigSize = 256;
 				INSTRUMENT_ALLOCATE("Arena256");
-			} else if (reqSize <= 512) {
-				b = (ArenaBlock*)allocateAndMaybeKeepalive(512);
-				b->bigSize = 512;
-				INSTRUMENT_ALLOCATE("Arena512");
-			} else if (reqSize <= 1024) {
-				b = (ArenaBlock*)allocateAndMaybeKeepalive(1024);
-				b->bigSize = 1024;
-				INSTRUMENT_ALLOCATE("Arena1024");
-			} else if (reqSize <= 2048) {
-				b = (ArenaBlock*)allocateAndMaybeKeepalive(2048);
-				b->bigSize = 2048;
-				INSTRUMENT_ALLOCATE("Arena2048");
-			} else if (reqSize <= 4096) {
-				b = (ArenaBlock*)allocateAndMaybeKeepalive(4096);
-				b->bigSize = 4096;
-				INSTRUMENT_ALLOCATE("Arena4096");
 			} else {
-				b = (ArenaBlock*)allocateAndMaybeKeepalive(8192);
-				b->bigSize = 8192;
-				INSTRUMENT_ALLOCATE("Arena8192");
+				// Suppress the operator-new[] memory-tracker hook around the
+				// underlying `new uint8_t[]`; the explicit memTrackerOnAlloc
+				// below is the sole hook for these blocks. Without this
+				// guard the same pointer would be tracked twice under two
+				// different fingerprints.
+				MemTrackerSuppress _suppress;
+				if (reqSize <= 512) {
+					b = (ArenaBlock*)allocateAndMaybeKeepalive(512);
+					b->bigSize = 512;
+					INSTRUMENT_ALLOCATE("Arena512");
+				} else if (reqSize <= 1024) {
+					b = (ArenaBlock*)allocateAndMaybeKeepalive(1024);
+					b->bigSize = 1024;
+					INSTRUMENT_ALLOCATE("Arena1024");
+				} else if (reqSize <= 2048) {
+					b = (ArenaBlock*)allocateAndMaybeKeepalive(2048);
+					b->bigSize = 2048;
+					INSTRUMENT_ALLOCATE("Arena2048");
+				} else if (reqSize <= 4096) {
+					b = (ArenaBlock*)allocateAndMaybeKeepalive(4096);
+					b->bigSize = 4096;
+					INSTRUMENT_ALLOCATE("Arena4096");
+				} else {
+					b = (ArenaBlock*)allocateAndMaybeKeepalive(8192);
+					b->bigSize = 8192;
+					INSTRUMENT_ALLOCATE("Arena8192");
+				}
 			}
 			b->totalSizeEstimate = b->bigSize;
 			b->tinySize = b->tinyUsed = NOT_TINY;
 			b->bigUsed = sizeof(ArenaBlock);
 			b->secure = 0;
+			// Block-level attribution for >256 sizes (sizes <=256 use FastAllocator,
+			// which fires its own memTrackerOnAlloc hook).
+			if (b->bigSize > 256) {
+				memTrackerOnAlloc(b, b->bigSize);
+			}
 		} else {
 #ifdef ALLOC_INSTRUMENTATION
 			allocInstr["ArenaHugeKB"].alloc((reqSize + 1023) >> 10);
 #endif
-			b = (ArenaBlock*)allocateAndMaybeKeepalive(reqSize);
+			{
+				// Suppress the operator-new[] hook so the explicit
+				// memTrackerOnAlloc below is the sole tracker for huge
+				// arena blocks (see comment in the small-block branch).
+				MemTrackerSuppress _suppress;
+				b = (ArenaBlock*)allocateAndMaybeKeepalive(reqSize);
+			}
 			b->tinySize = b->tinyUsed = NOT_TINY;
 			b->bigSize = reqSize;
 			b->totalSizeEstimate = b->bigSize;
@@ -462,6 +482,9 @@ ArenaBlock* ArenaBlock::create(int dataSize, Reference<ArenaBlock>& next) {
 			}
 #endif
 			g_hugeArenaMemory.fetch_add(reqSize);
+			// Block-level attribution for huge arena blocks. allocateAndMaybeKeepalive
+			// bypasses FastAllocator, so this is the only hook for these blocks.
+			memTrackerOnAlloc(b, reqSize);
 
 			// If the new block has less free space than the old block, make the old block depend on it
 			if (next && !next->isTiny() && next->unused() >= reqSize - dataSize) {
@@ -542,26 +565,50 @@ void ArenaBlock::destroyLeaf() {
 			FastAllocator<256>::release(this);
 			INSTRUMENT_RELEASE("Arena256");
 		} else if (bigSize <= 512) {
-			freeOrMaybeKeepalive(this);
+			memTrackerOnFree(this);
+			{
+				MemTrackerSuppress _suppress;
+				freeOrMaybeKeepalive(this);
+			}
 			INSTRUMENT_RELEASE("Arena512");
 		} else if (bigSize <= 1024) {
-			freeOrMaybeKeepalive(this);
+			memTrackerOnFree(this);
+			{
+				MemTrackerSuppress _suppress;
+				freeOrMaybeKeepalive(this);
+			}
 			INSTRUMENT_RELEASE("Arena1024");
 		} else if (bigSize <= 2048) {
-			freeOrMaybeKeepalive(this);
+			memTrackerOnFree(this);
+			{
+				MemTrackerSuppress _suppress;
+				freeOrMaybeKeepalive(this);
+			}
 			INSTRUMENT_RELEASE("Arena2048");
 		} else if (bigSize <= 4096) {
-			freeOrMaybeKeepalive(this);
+			memTrackerOnFree(this);
+			{
+				MemTrackerSuppress _suppress;
+				freeOrMaybeKeepalive(this);
+			}
 			INSTRUMENT_RELEASE("Arena4096");
 		} else if (bigSize <= 8192) {
-			freeOrMaybeKeepalive(this);
+			memTrackerOnFree(this);
+			{
+				MemTrackerSuppress _suppress;
+				freeOrMaybeKeepalive(this);
+			}
 			INSTRUMENT_RELEASE("Arena8192");
 		} else {
 #ifdef ALLOC_INSTRUMENTATION
 			allocInstr["ArenaHugeKB"].dealloc((bigSize + 1023) >> 10);
 #endif
 			g_hugeArenaMemory.fetch_sub(bigSize);
-			freeOrMaybeKeepalive(this);
+			memTrackerOnFree(this);
+			{
+				MemTrackerSuppress _suppress;
+				freeOrMaybeKeepalive(this);
+			}
 		}
 	}
 }

--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -20,6 +20,7 @@
 
 #include "flow/FastAlloc.h"
 
+#include "flow/MemoryTracker.h"
 #include "flow/ThreadPrimitives.h"
 #include "flow/Trace.h"
 #include "flow/Error.h"
@@ -432,6 +433,7 @@ void* FastAllocator<Size>::allocate() {
 #if defined(ALLOC_INSTRUMENTATION) || defined(ALLOC_INSTRUMENTATION_STDOUT)
 	recordAllocation(p, Size);
 #endif
+	memTrackerOnAlloc(p, Size);
 	return p;
 }
 
@@ -509,6 +511,7 @@ void FastAllocator<Size>::release(void* ptr) {
 #if defined(ALLOC_INSTRUMENTATION) || defined(ALLOC_INSTRUMENTATION_STDOUT)
 	recordDeallocation(ptr);
 #endif
+	memTrackerOnFree(ptr);
 }
 
 template <int Size>

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -81,6 +81,15 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 
 	init( MEMORY_USAGE_CHECK_INTERVAL,                         1.0 );
 
+	// Per-call-site sampled memory tracker. See design/memory-tracker.md.
+	// Initial rollout: prod default off (=0). Simulation defaults to 1-in-10 sampling so the path is exercised.
+	init( MEMORY_TRACKING_SAMPLE_INVERSE,                        0 ); if( isSimulated ) MEMORY_TRACKING_SAMPLE_INVERSE = 10;
+	init( MEMORY_TRACKING_FORCE_SAMPLE_BYTES,               100000 );
+	init( MEMORY_TRACKING_LIVE_TRACKING,                      true );
+	init( MEMORY_TRACKING_REPORT_INTERVAL,                   600.0 ); if( isSimulated ) MEMORY_TRACKING_REPORT_INTERVAL = 30.0;
+	init( MEMORY_TRACKING_REPORT_BYTES_THRESHOLD,         80000000 ); if( isSimulated ) MEMORY_TRACKING_REPORT_BYTES_THRESHOLD = 1000000;
+	init( MEMORY_TRACKING_FRAMES,                                6 );
+
 	// Chaos testing - enabled for simulation by default
 	init( ENABLE_CHAOS_FEATURES,                       isSimulated );
 	init( CHAOS_LOGGING_INTERVAL,                              5.0 );

--- a/flow/MemoryTracker.cpp
+++ b/flow/MemoryTracker.cpp
@@ -1,0 +1,695 @@
+/*
+ * MemoryTracker.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Implementation of the sampled per-call-site memory tracker.
+// See design/memory-tracker.md and flow/include/flow/MemoryTracker.h.
+//
+// What this is for: finding memory LEAKS and untuned / oversized allocations
+// that drive RSS growth. FDB effectively never sees a real malloc / operator new
+// failure — a process is killed by fdbmonitor when its RSS crosses a configured
+// ceiling (typically ~12-16 GB against an ~8 GB target), i.e. "OOM" here is a
+// self-imposed RSS threshold, not an allocator failure. So the interesting range
+// is memory growth well SHORT of any allocation failure, and the tracker's
+// behaviour under an actual malloc/new failure is not a scenario we optimize for:
+// the hooks fail open (drop the sample; see memTrackerSampleAlloc). The sampled
+// path is nonetheless ordered so its table growth happens before any counter
+// update, so even that never-in-practice case leaves the accounting consistent.
+
+#include "flow/MemoryTracker.h"
+
+#include "flow/Knobs.h"
+#include "flow/Platform.h"
+#include "flow/ThreadPrimitives.h"
+#include "flow/Trace.h"
+#include "flow/flow.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <new>
+#include <unordered_map>
+#include <vector>
+
+#ifdef __linux__
+#include <pthread.h>
+#endif
+
+#if FDB_MEMORY_TRACKER
+
+// Thread-local sampling state.
+// gMemTrackerCounter starts at 1 so the first allocation per thread is
+// sampled (and the slow path then reseeds from the knob).
+// gForceSampleBytes initialized to ~0 so force-sample never fires before we've
+// loaded the knob value at least once.
+thread_local bool gInMemTracker = false;
+thread_local int gMemTrackerCounter = 1;
+thread_local std::size_t gForceSampleBytes = static_cast<std::size_t>(-1);
+// Starts false so the first allocation on each thread reaches the slow path to
+// read the knob; set true there if sampling is off (see memTrackerSampleAlloc).
+thread_local bool gMemTrackerOff = false;
+
+// Test-only one-shot: when set, the next sampled allocation throws to simulate a
+// tracker metadata-allocation failure (see memTrackerFailNextSampleForTest).
+static thread_local bool gFailNextSampleForTest = false;
+
+// Definition of the cache-line-isolated enabled flag declared in the header.
+MemTrackerEnabledFlag g_memTrackerEnabled;
+// Same initial seed for every thread; cheap and adequate. Threads in
+// production start at different times and call into the slow path at
+// uncorrelated rates, so any phase correlation washes out within the
+// first handful of samples. If profiling ever shows correlated bursts
+// at startup, mix in a thread-id-derived value here.
+thread_local uint32_t gMemTrackerSeed = 0x9E3779B9u;
+
+namespace {
+
+// FNV-1a 64-bit over the captured frame array.
+uint64_t fnv64(const void* data, std::size_t len) {
+	uint64_t h = 0xcbf29ce484222325ULL;
+	const auto* p = static_cast<const std::uint8_t*>(data);
+	for (std::size_t i = 0; i < len; i++) {
+		h ^= p[i];
+		h *= 0x100000001b3ULL;
+	}
+	return h;
+}
+
+inline std::uint32_t xorshift32(std::uint32_t& s) {
+	std::uint32_t x = s ? s : 0x9E3779B9u;
+	x ^= x << 13;
+	x ^= x >> 17;
+	x ^= x << 5;
+	s = x;
+	return x;
+}
+
+// Per-thread stack bounds, populated lazily on first use of captureFramesFP.
+// Used by captureFramesFP to terminate the FP walk when it crosses into
+// FP-elided code (notably glibc's pthread shutdown / TLS-destructor
+// machinery). Without this guard, the FP-elided frame leaves an
+// uninitialized saved-FP slot and the walk dereferences garbage. See
+// design/memory-tracker.md, "Side-thread safety".
+//
+// You've heard of optimistic concurrency control in database systems? This is
+// basically *optimistic segfault avoidance* to enable fast stack unwinding.
+// Caveat: the heuristics here aren't perfect. They seem pretty effective
+// so far.
+thread_local uintptr_t gStackLow = 0;
+thread_local uintptr_t gStackHigh = 0;
+
+#ifdef __linux__
+
+void initStackBoundsForThread() {
+	pthread_attr_t attr;
+	if (pthread_getattr_np(pthread_self(), &attr) == 0) {
+		void* base = nullptr;
+		size_t size = 0;
+		if (pthread_attr_getstack(&attr, &base, &size) == 0) {
+			gStackLow = reinterpret_cast<uintptr_t>(base);
+			gStackHigh = gStackLow + size;
+		}
+		pthread_attr_destroy(&attr);
+	}
+}
+
+// Manual frame-pointer walk. Captures the return-address chain starting at
+// the caller of this function (and up). Relies on -fno-omit-frame-pointer.
+// Annotated noinline + no_instrument_function so the compiler can't fold the
+// frame chain in unexpected ways.
+//
+// Bounds the walk by the current thread's stack range so that crossing into
+// FP-elided code (which leaves the saved-FP slot uninitialized rather than
+// NULL) terminates cleanly instead of dereferencing garbage (see above).
+__attribute__((no_instrument_function, noinline)) int captureFramesFP(void** out, int max) {
+	if (!gStackLow) {
+		initStackBoundsForThread();
+	}
+	void** fp = static_cast<void**>(__builtin_frame_address(0));
+	// Fallback for threads where pthread_getattr_np failed: ±8 MB around
+	// the initial frame.
+	// Caveat: this may need to be constrained more tightly to deal with
+	// smaller stacks.
+	uintptr_t lo = gStackLow ? gStackLow : reinterpret_cast<uintptr_t>(fp);
+	uintptr_t hi = gStackHigh ? gStackHigh : reinterpret_cast<uintptr_t>(fp) + (8u << 20);
+	int n = 0;
+	while (fp && n < max) {
+		uintptr_t a = reinterpret_cast<uintptr_t>(fp);
+		// Reject out-of-stack or misaligned fp before dereferencing.
+		if (a < lo || a + 16 > hi) {
+			break;
+		}
+		if (a & (sizeof(void*) - 1)) {
+			break;
+		}
+		void* ra = fp[1];
+		if (!ra) {
+			break;
+		}
+		out[n++] = ra;
+		void** next = static_cast<void**>(fp[0]);
+		// Sanity: stack grows down, so each next frame address must be larger.
+		if (next <= fp) {
+			break;
+		}
+		fp = next;
+	}
+	return n;
+}
+
+#else // !__linux__
+
+// NOTE: We (Apple) do not maintain a local facility to build FDB with
+// MSVC on Windows. The code in this file **may** have issues. We are
+// doing a best-effort attempt not to break the build.  Support for
+// this memory tracking feature by community users of Windows would be
+// welcome.
+
+// macOS / non-Linux: stack walking is unreliable here (system runtime
+// has -fomit-frame-pointer in places we can't avoid, and pthread_getattr_np
+// is Linux-specific). FDB is required to compile on macOS/Windows but is not run
+// in production there, so we just no-op the walker. The rest of the
+// tracker still compiles and runs; per-call-site reports will simply
+// lack stack attribution.
+force_noinline int captureFramesFP(void**, int) {
+	return 0;
+}
+
+#endif // __linux__
+
+// TODO: when memory tracking is enabled, regardless of the sampling
+// rate, every deallocation has to acquire this mutex. At O(1M)
+// frees/second this is noticeable overhead.  This could be sped up by
+// sharding the mutex and the global state protected by the mutex
+// (the global state is the 2 maps and ~10 scalars defined below).
+// Presumably hash of the malloc buffer address itself could direct
+// the sharding.  Consumers of the global state would have to merge
+// across shards but that is intended only to be the periodic log
+// reporter so making it do costly work is fine since it only runs
+// O(1/minute).
+
+ThreadSpinLock g_mtLock;
+
+struct LiveEntry {
+	std::uint64_t fingerprint;
+	std::uint64_t size;
+	std::int64_t weight; // inverse inclusion probability at sample time (≈ SampleInverse, or 1 if
+	                     // force-sampled); estimated contribution of this block is size * weight.
+	                     // Stored so free debits the estimate by exactly what alloc credited, even
+	                     // if the sampling knob changed in between.
+};
+
+// Lazily-constructed maps. Allocated under the spinlock the first time we
+// reach the sampled path. Heap allocations from the maps' internals go
+// through our overridden operator new, which short-circuits (gInMemTracker
+// is true on the sampled path) and falls through to std::malloc — so map
+// growth never recurses into tracking.
+std::unordered_map<std::uint64_t, MemoryTrackerCallSite>* g_aggMap = nullptr;
+std::unordered_map<std::uintptr_t, LiveEntry>* g_liveMap = nullptr;
+
+// Sampled-totals (i.e. across what we actually saw, not population estimates).
+std::int64_t g_liveBytesTotal = 0;
+std::int64_t g_liveBlocksTotal = 0;
+std::int64_t g_cumulativeBytesTotal = 0;
+std::int64_t g_cumulativeAllocsTotal = 0;
+std::int64_t g_samplesEmitted = 0;
+
+// Estimated population totals (sampling correction applied; see LiveEntry::weight).
+std::int64_t g_estLiveBytesTotal = 0;
+std::int64_t g_estLiveBlocksTotal = 0;
+std::int64_t g_estCumulativeBytesTotal = 0;
+std::int64_t g_estCumulativeAllocsTotal = 0;
+
+void ensureMaps() {
+	if (!g_aggMap) {
+		g_aggMap = new std::unordered_map<std::uint64_t, MemoryTrackerCallSite>();
+	}
+	if (!g_liveMap) {
+		g_liveMap = new std::unordered_map<std::uintptr_t, LiveEntry>();
+	}
+}
+
+} // namespace
+
+// Publish the enabled flag and arm the calling thread from the current
+// MEMORY_TRACKING_SAMPLE_INVERSE. Shared by memTrackerInit (once, at startup)
+// and memTrackerResetForTest. Reading the knob explicitly here — rather than
+// inferring the enabled state from the first sampled allocation — is what keeps
+// an early main-thread allocation from latching the tracker off before the
+// knobs are configured.
+static void memTrackerArmFromKnobs() {
+	int inverse = FLOW_KNOBS ? FLOW_KNOBS->MEMORY_TRACKING_SAMPLE_INVERSE : 0;
+	bool enabled = (inverse > 0);
+	g_memTrackerEnabled.value.store(enabled, std::memory_order_relaxed);
+	// If enabled, clear this thread's off-latch and force its next allocation onto
+	// the slow path (counter==1) to seed the reseed; if disabled, latch off so the
+	// alloc hot path short-circuits on a single TLS load.
+	gMemTrackerOff = !enabled;
+	gMemTrackerCounter = 1;
+	gForceSampleBytes = FLOW_KNOBS ? static_cast<std::size_t>(FLOW_KNOBS->MEMORY_TRACKING_FORCE_SAMPLE_BYTES)
+	                               : static_cast<std::size_t>(-1);
+}
+
+void memTrackerInit() {
+	memTrackerArmFromKnobs();
+}
+
+static void memTrackerSampleAllocImpl(void* p, std::size_t n) {
+	if (gFailNextSampleForTest) {
+		gFailNextSampleForTest = false;
+		throw std::bad_alloc(); // simulate a tracker metadata-allocation failure (test only)
+	}
+	int inverse = 0;
+	int frames = 6;
+	bool liveTracking = true;
+	if (FLOW_KNOBS) {
+		inverse = FLOW_KNOBS->MEMORY_TRACKING_SAMPLE_INVERSE;
+		frames = FLOW_KNOBS->MEMORY_TRACKING_FRAMES;
+		liveTracking = FLOW_KNOBS->MEMORY_TRACKING_LIVE_TRACKING;
+		gForceSampleBytes = static_cast<std::size_t>(FLOW_KNOBS->MEMORY_TRACKING_FORCE_SAMPLE_BYTES);
+	}
+	if (frames < 1) {
+		frames = 1;
+	}
+	if (frames > MEMORY_TRACKER_MAX_FRAMES) {
+		frames = MEMORY_TRACKER_MAX_FRAMES;
+	}
+	// Bound the reseed's `2 * inverse` arithmetic to int range for absurd knob
+	// values; 1-in-256M sampling is already effectively off.
+	if (inverse > (1 << 28)) {
+		inverse = 1 << 28;
+	}
+
+	if (inverse <= 0) {
+		// Off (knob is startup-only). Flag this thread so the alloc hot path
+		// short-circuits on one TLS load, without touching the counter again.
+		gMemTrackerOff = true;
+		return;
+	}
+	if (inverse == 1) {
+		// Sample every allocation — keep counter at 1 so the next decrement
+		// drops it to 0 and re-enters the slow path. Bypass the random
+		// reseed below, which would otherwise leave counter==2 half the
+		// time and cause us to miss every other allocation.
+		gMemTrackerCounter = 1;
+	} else if (gMemTrackerCounter <= 0) {
+		// The random countdown actually expired: draw a fresh gap uniformly from
+		// [1, 2*inverse-1], whose mean is exactly `inverse` — so the 1-in-inverse
+		// sampling rate is unbiased and the integer `weight` below is exact.
+		std::uint32_t r = xorshift32(gMemTrackerSeed);
+		gMemTrackerCounter = 1 + static_cast<int>(r % static_cast<std::uint32_t>(2 * inverse - 1));
+	}
+
+	bool isForceSampled = (n >= gForceSampleBytes);
+
+	// Weight = inverse inclusion probability of this sample, i.e. how many
+	// allocations in the population it stands in for. A randomly-sampled block
+	// (1-in-inverse) represents ~inverse allocations; a force-sampled block was
+	// captured with certainty and represents only itself. The reseed draws
+	// uniformly from [1, 2*inverse-1] (mean exactly `inverse`), so this integer
+	// weight matches the true mean sampling gap with no bias.
+	std::int64_t weight = (isForceSampled || inverse <= 1) ? 1 : inverse;
+
+	// Capture frames; skip the topmost two (this function and captureFramesFP
+	// itself) so the recorded stack starts at the caller of memTrackerOnAlloc.
+	// The strip count of 2 assumes memTrackerOnAlloc is inlined into its
+	// caller (it's declared `inline` and the body is trivial). Production
+	// builds run at -O3 and the inliner cooperates; at -O0 the inline hint
+	// can be ignored and the recorded stack starts one frame too deep
+	// (frame 0 = memTrackerOnAlloc body rather than the user's
+	// allocation site). Acceptable: -O0 builds are not load-bearing for
+	// memory attribution; the off-by-one is harmless for that workflow.
+	void* tmp[MEMORY_TRACKER_MAX_FRAMES + 4];
+	int captured = captureFramesFP(tmp, frames + 2);
+	int kept = 0;
+	void* keep[MEMORY_TRACKER_MAX_FRAMES];
+	for (int i = 2; i < captured && kept < frames; i++) {
+		keep[kept++] = tmp[i];
+	}
+
+	std::uint64_t fp = (kept == 0) ? 0 : fnv64(keep, static_cast<std::size_t>(kept) * sizeof(void*));
+
+	ThreadSpinLockHolder lk(g_mtLock);
+	ensureMaps();
+
+	auto nBytes = static_cast<std::int64_t>(n);
+	auto estBytes = nBytes * weight;
+
+	// Do both node-allocating map operations up front, before mutating any
+	// counter, so that if one throws (a bad_alloc while a table grows) the
+	// exception unwinds with all per-site and global totals still consistent and
+	// the fail-open catch in memTrackerSampleAlloc simply drops the sample. FDB
+	// never sees a real malloc/new failure in practice (see the file header), so
+	// this is cheap hygiene rather than a hot path.
+	auto& site = (*g_aggMap)[fp]; // inserts a node for a new fingerprint; may throw
+	if (site.fingerprint == 0 && site.cumulativeAllocs == 0) {
+		site.fingerprint = fp;
+		site.exemplarFrameCount = static_cast<std::uint8_t>(kept);
+		for (int i = 0; i < kept; i++) {
+			site.exemplarFrames[i] = keep[i];
+		}
+	}
+
+	// Reserve the live-block slot before crediting anything. A brand-new key
+	// allocates a node here (may throw); an existing key — a stale entry whose
+	// free was suppressed (e.g. during memTrackerDump or a memTrackerForEachSite
+	// callback) so it was never debited — reuses its slot and cannot throw. We
+	// capture the stale value so it can be debited below; otherwise its live
+	// credit would leak once the address is reused and live totals would creep up.
+	bool hadStale = false;
+	LiveEntry stalePrev{};
+	if (liveTracking) {
+		auto key = reinterpret_cast<std::uintptr_t>(p);
+		auto res = g_liveMap->try_emplace(key, LiveEntry{ fp, static_cast<std::uint64_t>(n), weight });
+		if (!res.second) {
+			hadStale = true;
+			stalePrev = res.first->second;
+			res.first->second = LiveEntry{ fp, static_cast<std::uint64_t>(n), weight };
+		}
+	}
+
+	// ---- Nothing below allocates or throws; per-site and global totals move in lockstep. ----
+
+	if (hadStale) {
+		auto oldBytes = static_cast<std::int64_t>(stalePrev.size);
+		auto oldEst = oldBytes * stalePrev.weight;
+		auto oldSite = g_aggMap->find(stalePrev.fingerprint);
+		if (oldSite != g_aggMap->end()) {
+			oldSite->second.liveBytes -= oldBytes;
+			oldSite->second.liveCount -= 1;
+			oldSite->second.estLiveBytes -= oldEst;
+			oldSite->second.estLiveCount -= stalePrev.weight;
+		}
+		g_liveBytesTotal -= oldBytes;
+		g_liveBlocksTotal -= 1;
+		g_estLiveBytesTotal -= oldEst;
+		g_estLiveBlocksTotal -= stalePrev.weight;
+	}
+
+	site.cumulativeAllocs += 1;
+	site.cumulativeBytes += nBytes;
+	site.estCumulativeAllocs += weight;
+	site.estCumulativeBytes += estBytes;
+	if (isForceSampled) {
+		site.forceSampledCount += 1;
+	}
+
+	if (liveTracking) {
+		site.liveBytes += nBytes;
+		site.liveCount += 1;
+		if (site.liveBytes > site.peakBytes) {
+			site.peakBytes = site.liveBytes;
+		}
+		site.estLiveBytes += estBytes;
+		site.estLiveCount += weight;
+		if (site.estLiveBytes > site.estPeakBytes) {
+			site.estPeakBytes = site.estLiveBytes;
+		}
+		g_liveBytesTotal += nBytes;
+		g_liveBlocksTotal += 1;
+		g_estLiveBytesTotal += estBytes;
+		g_estLiveBlocksTotal += weight;
+	}
+	g_cumulativeBytesTotal += nBytes;
+	g_cumulativeAllocsTotal += 1;
+	g_estCumulativeBytesTotal += estBytes;
+	g_estCumulativeAllocsTotal += weight;
+	g_samplesEmitted += 1;
+}
+
+void memTrackerSampleAlloc(void* p, std::size_t n) {
+	// Fail open: the tracker is a diagnostic; a std::bad_alloc from its own map
+	// growth (or the test injection) must never propagate into the caller's
+	// allocation path, which has already handed out the underlying block.
+	try {
+		memTrackerSampleAllocImpl(p, n);
+	} catch (...) {
+	}
+}
+
+static void memTrackerSampleFreeImpl(void* p) {
+	bool liveTracking = FLOW_KNOBS ? FLOW_KNOBS->MEMORY_TRACKING_LIVE_TRACKING : true;
+	if (!liveTracking) {
+		return;
+	}
+
+	ThreadSpinLockHolder lk(g_mtLock);
+	if (!g_liveMap) {
+		return;
+	}
+	auto it = g_liveMap->find(reinterpret_cast<std::uintptr_t>(p));
+	if (it == g_liveMap->end()) {
+		return;
+	}
+
+	LiveEntry e = it->second;
+	g_liveMap->erase(it);
+
+	auto eBytes = static_cast<std::int64_t>(e.size);
+	auto eEstBytes = eBytes * e.weight;
+	if (g_aggMap) {
+		auto sit = g_aggMap->find(e.fingerprint);
+		if (sit != g_aggMap->end()) {
+			sit->second.liveBytes -= eBytes;
+			sit->second.liveCount -= 1;
+			sit->second.estLiveBytes -= eEstBytes;
+			sit->second.estLiveCount -= e.weight;
+		}
+	}
+	g_liveBytesTotal -= eBytes;
+	g_liveBlocksTotal -= 1;
+	g_estLiveBytesTotal -= eEstBytes;
+	g_estLiveBlocksTotal -= e.weight;
+}
+
+void memTrackerSampleFree(void* p) {
+	// Fail open (see memTrackerSampleAlloc): operator delete is noexcept, so the
+	// tracker must never let an exception escape the free path.
+	try {
+		memTrackerSampleFreeImpl(p);
+	} catch (...) {
+	}
+}
+
+void memTrackerForEachSite(std::function<void(const MemoryTrackerCallSite&)> cb) {
+	// Suppress for the entire call so callbacks that allocate (e.g.
+	// fprintf or std::vector growth in test failure paths) don't
+	// re-enter the tracker and pollute the agg map mid-iteration.
+	MemTrackerSuppress _suppress;
+	std::vector<MemoryTrackerCallSite> snapshot;
+	{
+		ThreadSpinLockHolder lk(g_mtLock);
+		if (g_aggMap) {
+			snapshot.reserve(g_aggMap->size());
+			for (auto& kv : *g_aggMap) {
+				snapshot.push_back(kv.second);
+			}
+		}
+	}
+	for (auto& s : snapshot) {
+		cb(s);
+	}
+}
+
+void memTrackerResetForTest() {
+	MemTrackerSuppress _suppress;
+	{
+		ThreadSpinLockHolder lk(g_mtLock);
+		if (g_aggMap) {
+			g_aggMap->clear();
+		}
+		if (g_liveMap) {
+			g_liveMap->clear();
+		}
+		g_liveBytesTotal = 0;
+		g_liveBlocksTotal = 0;
+		g_cumulativeBytesTotal = 0;
+		g_cumulativeAllocsTotal = 0;
+		g_samplesEmitted = 0;
+		g_estLiveBytesTotal = 0;
+		g_estLiveBlocksTotal = 0;
+		g_estCumulativeBytesTotal = 0;
+		g_estCumulativeAllocsTotal = 0;
+	}
+	// Publish the enabled flag and arm this thread from the current knob value
+	// (a test typically sets MEMORY_TRACKING_SAMPLE_INVERSE via KnobOverride just
+	// before calling this), mirroring memTrackerInit at process startup.
+	gFailNextSampleForTest = false;
+	memTrackerArmFromKnobs();
+}
+
+void memTrackerFailNextSampleForTest() {
+	gFailNextSampleForTest = true;
+}
+
+static void memTrackerDumpImpl(int64_t bytesThreshold) {
+	MemTrackerSuppress _suppress;
+
+	std::vector<MemoryTrackerCallSite> sites;
+	int aggSize = 0;
+	int liveSize = 0;
+	std::int64_t liveBytesTotalSnap = 0;
+	std::int64_t liveBlocksTotalSnap = 0;
+	std::int64_t cumBytesSnap = 0;
+	std::int64_t cumAllocsSnap = 0;
+	std::int64_t samplesEmittedSnap = 0;
+	std::int64_t estLiveBytesTotalSnap = 0;
+	std::int64_t estLiveBlocksTotalSnap = 0;
+	std::int64_t estCumBytesSnap = 0;
+	std::int64_t estCumAllocsSnap = 0;
+	{
+		ThreadSpinLockHolder lk(g_mtLock);
+		if (g_aggMap) {
+			sites.reserve(g_aggMap->size());
+			for (auto& kv : *g_aggMap) {
+				sites.push_back(kv.second);
+			}
+			aggSize = static_cast<int>(g_aggMap->size());
+		}
+		liveSize = g_liveMap ? static_cast<int>(g_liveMap->size()) : 0;
+		liveBytesTotalSnap = g_liveBytesTotal;
+		liveBlocksTotalSnap = g_liveBlocksTotal;
+		cumBytesSnap = g_cumulativeBytesTotal;
+		cumAllocsSnap = g_cumulativeAllocsTotal;
+		samplesEmittedSnap = g_samplesEmitted;
+		estLiveBytesTotalSnap = g_estLiveBytesTotal;
+		estLiveBlocksTotalSnap = g_estLiveBlocksTotal;
+		estCumBytesSnap = g_estCumulativeBytesTotal;
+		estCumAllocsSnap = g_estCumulativeAllocsTotal;
+	}
+
+	bool liveTracking = FLOW_KNOBS ? FLOW_KNOBS->MEMORY_TRACKING_LIVE_TRACKING : true;
+	// Rank and threshold on the *estimated* usage, since that is the real
+	// per-site cost the report is about; the threshold knob is expressed in
+	// real bytes (~1% of target RSS), not sampled bytes.
+	// std::sort is unstable and unordered_map iteration is bucket-order, so
+	// MemoryTrackerSite events for sites with tied byte values may appear in
+	// different orders across same-seed sim2 runs. The R5 determinism
+	// requirement is on aggregate counts, not event ordering — those are
+	// unaffected — so we don't pay for stable_sort here.
+	auto byLive = [](const MemoryTrackerCallSite& a, const MemoryTrackerCallSite& b) {
+		return a.estLiveBytes > b.estLiveBytes;
+	};
+	auto byCum = [](const MemoryTrackerCallSite& a, const MemoryTrackerCallSite& b) {
+		return a.estCumulativeBytes > b.estCumulativeBytes;
+	};
+	if (liveTracking) {
+		std::sort(sites.begin(), sites.end(), byLive);
+	} else {
+		std::sort(sites.begin(), sites.end(), byCum);
+	}
+
+	// Filter: a site qualifies when its estimated currently-live bytes (or
+	// estimated cumulative bytes in degraded mode) exceed the threshold. Sites
+	// are already sorted descending, so we can stop at the first non-qualifier.
+	std::vector<MemoryTrackerCallSite> qualifying;
+	qualifying.reserve(sites.size());
+	for (const auto& s : sites) {
+		int64_t v = liveTracking ? s.estLiveBytes : s.estCumulativeBytes;
+		if (v < bytesThreshold) {
+			break;
+		}
+		qualifying.push_back(s);
+	}
+
+	// Build addr2line prefix once per dump. Built directly here rather
+	// than via platform::format_backtrace, which deliberately drops index
+	// 0 of its input (its single-site use case treats that as the helper's
+	// caller); we want every captured frame including the leaf.
+	std::string addrCmdPrefix;
+	uintptr_t pieOffset = 0;
+	if (!qualifying.empty()) {
+		platform::ImageInfo img = platform::getImageInfo();
+#ifdef __clang__
+		const char* addr2lineTool = "/usr/local/bin/llvm-addr2line";
+#else
+		const char* addr2lineTool = "/usr/bin/addr2line";
+#endif
+		addrCmdPrefix = format("%s -e %s -p -C -f -i", addr2lineTool, img.symbolFileName.c_str());
+		pieOffset = reinterpret_cast<uintptr_t>(img.offset);
+	}
+
+	for (const auto& s : qualifying) {
+		std::string addrCmd = addrCmdPrefix;
+		for (int i = 0; i < s.exemplarFrameCount; i++) {
+			uintptr_t pieRelative = reinterpret_cast<uintptr_t>(s.exemplarFrames[i]) - pieOffset;
+			addrCmd += format(" 0x%lx", pieRelative);
+		}
+		TraceEvent("MemoryTrackerSite")
+		    .detail("Fingerprint", format("%016llx", static_cast<unsigned long long>(s.fingerprint)))
+		    .detail("EstLiveBytes", s.estLiveBytes)
+		    .detail("EstLiveCount", s.estLiveCount)
+		    .detail("EstPeakBytes", s.estPeakBytes)
+		    .detail("EstCumulativeBytes", s.estCumulativeBytes)
+		    .detail("EstCumulativeAllocs", s.estCumulativeAllocs)
+		    .detail("LiveBytes", s.liveBytes)
+		    .detail("LiveCount", s.liveCount)
+		    .detail("PeakBytes", s.peakBytes)
+		    .detail("CumulativeBytes", s.cumulativeBytes)
+		    .detail("CumulativeAllocs", s.cumulativeAllocs)
+		    .detail("ForceSampledCount", s.forceSampledCount)
+		    .detail("AddrCmd", addrCmd);
+	}
+
+	TraceEvent("MemoryTrackerSummary")
+	    .detail("SitesTracked", aggSize)
+	    .detail("SitesReported", static_cast<int>(qualifying.size()))
+	    .detail("EstLiveBytesTotal", estLiveBytesTotalSnap)
+	    .detail("EstLiveBlocksTotal", estLiveBlocksTotalSnap)
+	    .detail("EstCumulativeBytes", estCumBytesSnap)
+	    .detail("EstCumulativeAllocs", estCumAllocsSnap)
+	    .detail("LiveBlocks", liveSize)
+	    .detail("LiveBytesTotal", liveBytesTotalSnap)
+	    .detail("LiveBlocksTotal", liveBlocksTotalSnap)
+	    .detail("CumulativeAllocs", cumAllocsSnap)
+	    .detail("CumulativeBytes", cumBytesSnap)
+	    .detail("SamplesEmitted", samplesEmittedSnap)
+	    .detail("SampleInverse", FLOW_KNOBS ? FLOW_KNOBS->MEMORY_TRACKING_SAMPLE_INVERSE : 0)
+	    .detail("ForceSampleBytes",
+	            FLOW_KNOBS ? FLOW_KNOBS->MEMORY_TRACKING_FORCE_SAMPLE_BYTES : static_cast<std::int64_t>(-1))
+	    .detail("ReportBytesThreshold", bytesThreshold)
+	    // Caveat: Est* values are statistical estimates. Each randomly-sampled block is
+	    // scaled by SampleInverse; force-sampled blocks (>= ForceSampleBytes) count once.
+	    // Accuracy improves with SamplesEmitted; a site with few samples is noisy.
+	    .detail("EstimateBasis", "Est*=sampled*SampleInverse; force-sampled weight 1; statistical estimate");
+}
+
+void memTrackerDump(int64_t bytesThreshold) {
+	// Disabled: nothing is sampled, so skip the dump entirely rather than emit an
+	// empty MemoryTrackerSummary every report interval (the production default is
+	// off, and SystemMonitor calls this on a fixed cadence regardless).
+	if (!g_memTrackerEnabled.value.load(std::memory_order_relaxed)) {
+		return;
+	}
+	// Fail open (see memTrackerSampleAlloc): a diagnostic dump must never crash the
+	// server, e.g. on an allocation failure while building the report.
+	try {
+		memTrackerDumpImpl(bytesThreshold);
+	} catch (...) {
+	}
+}
+
+// The global operator new / operator delete replacements that route through
+// memTrackerOnAlloc/OnFree live in fdbserver/GlobalNewDelete.cpp, not here, so
+// the interposition is confined to the fdbserver executable and never ships in
+// libfdb_c / client bindings. This TU provides only the tracker machinery those
+// overrides (and the FastAllocator / ArenaBlock hooks) call into.
+
+#endif // FDB_MEMORY_TRACKER

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -25,6 +25,8 @@
 #include "flow/Platform.h"
 #include "flow/TDMetric.actor.h"
 #include "flow/SystemMonitor.h"
+#include "flow/Knobs.h"
+#include "flow/MemoryTracker.h"
 
 #if defined(ALLOC_INSTRUMENTATION) && defined(__linux__)
 #include <cxxabi.h>
@@ -456,6 +458,20 @@ SystemStatistics customSystemMonitor(std::string const& eventName, StatisticsSta
 #endif
 	statState->networkMetricsState = g_network->networkInfo.metrics;
 	statState->networkState = netData;
+
+	// Periodic dump of the per-call-site memory tracker; cadence from the
+	// MEMORY_TRACKING_REPORT_INTERVAL knob (<=0 disables). In simulation the
+	// tracker's tables and this static are shared across all simulated
+	// processes, so one dump fires per interval cluster-wide and its site
+	// numbers blend every process — correct only in a real single-process server.
+	if (FLOW_KNOBS && FLOW_KNOBS->MEMORY_TRACKING_REPORT_INTERVAL > 0) {
+		static double lastMemTrackerDump = 0;
+		if (now() - lastMemTrackerDump >= FLOW_KNOBS->MEMORY_TRACKING_REPORT_INTERVAL) {
+			memTrackerDump(FLOW_KNOBS->MEMORY_TRACKING_REPORT_BYTES_THRESHOLD);
+			lastMemTrackerDump = now();
+		}
+	}
+
 	return currentStats;
 }
 

--- a/flow/include/flow/Knobs.h
+++ b/flow/include/flow/Knobs.h
@@ -141,6 +141,17 @@ public:
 
 	double MEMORY_USAGE_CHECK_INTERVAL;
 
+	// Per-call-site sampled memory tracker. See design/memory-tracker.md and flow/MemoryTracker.h.
+	// All of these are startup-only: they are read once and not meant to change at runtime
+	// (dynamic enable/disable is a Non-requirement -- edit the config and restart).
+	int MEMORY_TRACKING_SAMPLE_INVERSE; // 0=off, N=1-in-N
+	int64_t MEMORY_TRACKING_FORCE_SAMPLE_BYTES; // always sample allocations >= this many bytes; -1 disables
+	bool MEMORY_TRACKING_LIVE_TRACKING; // when false, skip the pointer-keyed live-block table
+	double MEMORY_TRACKING_REPORT_INTERVAL; // seconds between dumps; 0 disables reporting
+	int64_t MEMORY_TRACKING_REPORT_BYTES_THRESHOLD; // sites with live bytes >= this are reported each dump (~1% of an 8
+	                                                // GB target RSS)
+	int MEMORY_TRACKING_FRAMES; // captured stack depth (1..MEMORY_TRACKER_MAX_FRAMES)
+
 	// Chaos testing
 	bool ENABLE_CHAOS_FEATURES;
 	double CHAOS_LOGGING_INTERVAL;

--- a/flow/include/flow/MemoryTracker.h
+++ b/flow/include/flow/MemoryTracker.h
@@ -1,0 +1,223 @@
+/*
+ * MemoryTracker.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Sampled per-call-site memory attribution.
+//
+// See design/memory-tracker.md for the full design.
+//
+// Hot path: memTrackerOnAlloc is header-inlined; when the feature is disabled
+// (the common production default) it short-circuits on a single per-thread TLS
+// load + branch. memTrackerOnFree is header-inlined, one relaxed read of a
+// cache-line-isolated enabled flag + one branch when disabled -- no lock, no
+// table probe.
+//
+// Sampled path delegates to memTrackerSampleAlloc / memTrackerSampleFree,
+// which take a private spinlock, capture a frame-pointer-walk backtrace, and
+// update two tables (aggregation by fingerprint, and an optional pointer-
+// keyed live-block table).
+//
+// Reentrancy: the gInMemTracker thread-local guard is set to true while the
+// tracker is doing its own work. Any allocator hook called recursively
+// during that window observes the guard and bails out, leaving the
+// underlying allocation un-tracked. Higher-level hooks (e.g. ArenaBlock::create)
+// may also set this guard to suppress an inner allocator hook so the same
+// block is attributed at exactly one level.
+
+#ifndef FLOW_MEMORY_TRACKER_H
+#define FLOW_MEMORY_TRACKER_H
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+
+// FDB_MEMORY_TRACKER gates the whole feature at compile time; on (1) by default.
+// Build with -DFDB_MEMORY_TRACKER=0 (cmake -DFDB_MEMORY_TRACKER=OFF) to compile it
+// out entirely: the hooks become no-ops and the global operator new/delete override
+// (fdbserver/GlobalNewDelete.cpp) is not defined, so libc++'s allocator is used.
+#ifndef FDB_MEMORY_TRACKER
+#define FDB_MEMORY_TRACKER 1
+#endif
+
+#if FDB_MEMORY_TRACKER
+
+// Maximum number of stack frames the tracker can capture per sample.
+// MEMORY_TRACKING_FRAMES knob controls the runtime depth (1..MEMORY_TRACKER_MAX_FRAMES).
+constexpr int MEMORY_TRACKER_MAX_FRAMES = 10;
+
+// Per-site aggregate, exposed for tests via memTrackerForEachSite.
+//
+// Two families of numbers are kept per site:
+//   * Est* — the estimated *population* usage, i.e. what the site is really
+//     costing. Each sampled block is weighted by its inverse inclusion
+//     probability (≈ SampleInverse for randomly-sampled blocks, 1 for
+//     force-sampled blocks) at sample time, so these already have the sampling
+//     math applied — a consumer (logging, etc) reads them directly, no scaling required.
+//   * the raw sampled counters (liveBytes, cumulativeAllocs, …) — the
+//     uninterpreted "what we actually observed" numbers, kept for auditing the
+//     estimate and gauging its confidence (few samples ⇒ noisy estimate).
+struct MemoryTrackerCallSite {
+	uint64_t fingerprint;
+
+	int64_t estLiveBytes;
+	int64_t estLiveCount;
+	int64_t estPeakBytes;
+	int64_t estCumulativeBytes;
+	int64_t estCumulativeAllocs;
+
+	int64_t liveBytes;
+	int64_t liveCount;
+	int64_t peakBytes;
+	int64_t cumulativeAllocs;
+	int64_t cumulativeBytes;
+	int64_t forceSampledCount;
+
+	void* exemplarFrames[MEMORY_TRACKER_MAX_FRAMES];
+	uint8_t exemplarFrameCount;
+};
+
+extern thread_local bool gInMemTracker;
+extern thread_local int gMemTrackerCounter;
+extern thread_local std::size_t gForceSampleBytes;
+// Set true (per thread) once this thread's slow path observes sampling is off,
+// so the alloc hot path then short-circuits on a single TLS load instead of
+// decrementing the counter and reading gForceSampleBytes every call. Per-thread
+// (not global) so an early main-thread allocation before FLOW_KNOBS is ready
+// can't disable sampling on worker threads that bootstrap later. Cleared by
+// memTrackerResetForTest.
+extern thread_local bool gMemTrackerOff;
+
+// Global "is the tracker enabled" flag, kept in its own cache line. Published
+// once, from the first slow-path visit, and thereafter constant: the sample-
+// inverse knob is read at startup only (dynamic enable/disable is a
+// Non-requirement -- see design/memory-tracker.md). The flag stays in MESI
+// shared state across cores, so the free hot path's relaxed read is cached:
+// when disabled, a free is one read + one branch, no lock. This is the
+// free-path off switch (a free has no per-thread sampling counter to gate on,
+// unlike an alloc).
+//
+// Relaxed ordering is sufficient: a free of a sampled pointer is always
+// preceded (via the pointer handoff that let the freeing thread learn the
+// pointer at all) by the sampling alloc that inserted it, and that alloc set
+// this flag true before inserting -- so the happens-before edge guarantees the
+// freeing thread observes the flag as true.
+struct alignas(64) MemTrackerEnabledFlag {
+	std::atomic<bool> value{ false };
+	char pad[64 - sizeof(std::atomic<bool>)];
+};
+extern MemTrackerEnabledFlag g_memTrackerEnabled;
+
+// RAII suppressor: while alive, allocator hooks short-circuit. Used by code
+// paths that call into a lower-level allocator (e.g. ArenaBlock wrapping
+// `new uint8_t[]`) and want their explicit memTrackerOnAlloc/OnFree call to
+// be the sole tracker for the block — without this guard the inner
+// allocator's hook fires too and the same pointer is double-tracked under
+// two different fingerprints. Nest-safe: saves and restores prev.
+class MemTrackerSuppress {
+	bool prev;
+
+public:
+	MemTrackerSuppress() : prev(gInMemTracker) { gInMemTracker = true; }
+	~MemTrackerSuppress() { gInMemTracker = prev; }
+	MemTrackerSuppress(const MemTrackerSuppress&) = delete;
+	MemTrackerSuppress& operator=(const MemTrackerSuppress&) = delete;
+};
+
+// Initialize the tracker from the current knob values. Call once, from process
+// startup, AFTER all knobs are finalized and BEFORE any serving role starts (see
+// fdbserver.cpp). Publishes the enabled state and arms the calling (network)
+// thread from MEMORY_TRACKING_SAMPLE_INVERSE, so early startup allocations on the
+// main thread cannot latch the tracker off before the knob is configured. The
+// sample-inverse knob is read here (and in memTrackerResetForTest) rather than
+// inferred from the first allocation; dynamic runtime enable/disable is a
+// Non-requirement (see design/memory-tracker.md).
+void memTrackerInit();
+
+void memTrackerSampleAlloc(void* p, std::size_t n);
+void memTrackerSampleFree(void* p);
+
+inline void memTrackerOnAlloc(void* p, std::size_t n) {
+	if (gMemTrackerOff) [[likely]] {
+		return;
+	}
+	if (gInMemTracker || !p) {
+		return;
+	}
+	if (--gMemTrackerCounter > 0 && n < gForceSampleBytes) {
+		return;
+	}
+	MemTrackerSuppress _suppress;
+	memTrackerSampleAlloc(p, n);
+}
+
+inline void memTrackerOnFree(void* p) {
+	if (gInMemTracker || !p) {
+		return;
+	}
+	// Cheap cache-line-shared read: when the tracker is disabled there is no
+	// live-block table to debit, so skip all lock/table work.
+	if (!g_memTrackerEnabled.value.load(std::memory_order_relaxed)) {
+		return;
+	}
+	MemTrackerSuppress _suppress;
+	memTrackerSampleFree(p);
+}
+
+// Periodic dump — emits one TraceEvent("MemoryTrackerSite") per site whose
+// estLiveBytes (or estCumulativeBytes when MEMORY_TRACKING_LIVE_TRACKING is off)
+// exceeds bytesThreshold. The threshold is compared against the sampling-corrected
+// estimate, not the raw sampled bytes. Each site event carries an "AddrCmd"
+// detail: a ready-to-paste addr2line invocation covering just that site's frames.
+// A final TraceEvent("MemoryTrackerSummary") reports aggregate totals.
+void memTrackerDump(int64_t bytesThreshold);
+
+// Snapshot iteration for tests. The callback runs while a copy of the
+// aggregation table is held; the spinlock is not held during the callback.
+void memTrackerForEachSite(std::function<void(const MemoryTrackerCallSite&)> cb);
+
+// Reset all state. Tests only — not safe for production use.
+void memTrackerResetForTest();
+
+// Test only: arm a one-shot so the next sampled allocation simulates a tracker
+// metadata-allocation failure (the sampled path throws std::bad_alloc, which the
+// tracker swallows). Lets tests verify the tracker fails open — the underlying
+// allocation still succeeds and tracking recovers afterward. Never used in
+// production.
+void memTrackerFailNextSampleForTest();
+
+#else // !FDB_MEMORY_TRACKER — compiled out: hooks are no-ops, no operator new override.
+
+inline void memTrackerInit() {}
+inline void memTrackerOnAlloc(void*, std::size_t) {}
+inline void memTrackerOnFree(void*) {}
+inline void memTrackerDump(int64_t) {}
+inline void memTrackerResetForTest() {}
+class MemTrackerSuppress {
+public:
+	MemTrackerSuppress() {}
+	~MemTrackerSuppress() {}
+	MemTrackerSuppress(const MemTrackerSuppress&) = delete;
+	MemTrackerSuppress& operator=(const MemTrackerSuppress&) = delete;
+};
+
+#endif // FDB_MEMORY_TRACKER
+
+#endif // FLOW_MEMORY_TRACKER_H

--- a/flow/include/flow/Platform.h
+++ b/flow/include/flow/Platform.h
@@ -95,6 +95,20 @@
 #error Missing force inline
 #endif
 
+// Keep a function un-inlined and (on GCC) un-cloned so its address stays stable
+// for return-address matching in tests. GCC -O3 IPA cloning (.constprop/.isra)
+// otherwise runs the code under a synthetic clone symbol at a different address
+// than &fn, so a captured frame won't fall in [&fn, &fn+size); noclone disables
+// it. clang lacks noclone and doesn't clone this way, so it gets noinline only;
+// empty elsewhere (e.g. MSVC, which we cannot compile-test).
+#if defined(__clang__)
+#define force_noinline __attribute__((noinline))
+#elif defined(__GNUC__)
+#define force_noinline __attribute__((noinline, noclone))
+#else
+#define force_noinline
+#endif
+
 /*
  * Visual Studio (.NET 2003 and beyond) has an __assume compiler
  * intrinsic to hint to the compiler that a given condition is true


### PR DESCRIPTION
Backport of PR #13344 ("call-site aware memory tracking", main commit aa705c8c02) to the release-7.4 line.

Adds a sampled, always-compiled, knob-controlled per-call-site memory tracker (flow/MemoryTracker.{cpp,h}) hooked into the three FDB-owned allocation paths: the global operator new/delete set, FastAllocator<Size>, and ArenaBlock::create/destroyLeaf. A periodic dump from SystemMonitor emits MemoryTrackerSite / MemoryTrackerSummary TraceEvents. Prod default is off; simulation samples 1-in-10 so the path is exercised. The whole feature is gated at compile time by FDB_MEMORY_TRACKER (on by default; build with -DFDB_MEMORY_TRACKER=OFF to compile it out).

The replaced global operator new / operator delete (and the legacy ALLOC_INSTRUMENTATION accounting variants) are moved into fdbserver/GlobalNewDelete.cpp so the interposition is compiled into the fdbserver executable only, never into flow / libfdb_c / the client bindings. Verified with nm: the strong operator-new/delete definitions are present in the fdbserver binary and absent from libfdb_c.so and libflow.a.

Differences from the main-branch PR, due to release-7.4 divergence:
  - operator-new removal and memTrackerInit() wiring applied to fdbserver/fdbserver.actor.cpp (main: fdbserver.cpp); knob re-init uses g_knobs.initialize() rather than initializeServerKnobs().
  - forceLinkMemoryTrackerTests() wired into fdbserver/workloads/UnitTests.actor.cpp (main: UnitTests.cpp).
  - AGENTS.md added, adapted to 7.4 (flat fdbserver/ layout, ServerKnobs under fdbclient/, fdbserver -r unittests, absent design docs dropped).
  - Omitted: design/memory-tracker.md, the fdbserver/bench microbenchmark (needs main's benchmark harness, absent from 7.4), and the two contrib/mako_ab_*.py scripts (need contrib/mako_storage_bench.sh, absent from 7.4).

Testing, correctness:
  - All 14 /flow/MemoryTracker/ unit tests pass; ran 1000x with randomized seeds, 1000/1000 passed, 0 failures.
  - 100K Joshua correctness run, clean:
    20260805-213736-gglass-36215d1242f71327            compressed=True data_size=41598074 duration=4226513 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:41:34 sanity=False started=100000 stopped=20260805-221910 submitted=20260805-213736 timeout=5400 username=gglass

Testing, performance:

Attachments show **saturation throughput** of {{*compiled out* vs *compiled-in but disabled*},  {*compiled in, disabled* vs *compiled in, enabled at 1% sampling*}}; and **p50 latency** of {{*compiled out* vs *compiled-in but disabled*}, {{*compiled-in, disabled* vs *compiled-in, enabled at 1% sampling*}}. 

Summary:
 - Throughput reduction: O(1%) (compiled out --> compiled in) and O(10%) (disabled --> enabled at 1% sampling).
 - Latency increase at p50: O(1%) (compiled out --> compiled in) and O(7%) (disabled --> enabled at 1% sampling).

The intent is to be able to compile in by default and ship that, and only enable when needed (e.g. interesting end to end test scenarios, or for leak debugging as a last resort in actual production).
 
[FDB Memory Tracker A_B_ release-7.4 tracker compiled out vs in (tracking off).pdf](https://github.com/user-attachments/files/30765125/FDB.Memory.Tracker.A_B_.release-7.4.tracker.compiled.out.vs.in.tracking.off.pdf)

[FDB Memory Tracker A_B_ off vs 1_100 sampling.pdf](https://github.com/user-attachments/files/30765129/FDB.Memory.Tracker.A_B_.off.vs.1_100.sampling.pdf)

[FDB Memory Tracker A_B_ compiled-out vs compiled-in-disabled latency @ 2500 tps.pdf](https://github.com/user-attachments/files/30768955/FDB.Memory.Tracker.A_B_.compiled-out.vs.compiled-in-disabled.latency.%40.2500.tps.pdf)

[FDB Memory Tracker A_B_ latency @ 2500 tps (sub-saturation, 3 runs_arm).pdf](https://github.com/user-attachments/files/30766774/FDB.Memory.Tracker.A_B_.latency.%40.2500.tps.sub-saturation.3.runs_arm.pdf)

**EDIT**: subsequent testing on real clusters shows higher overhead -- incremental CPU usage for (compiled out) vs (compiled in, disabled).  We may want to put this in but compiled off per the cmake flag.