### PR TITLE
Retry timed-out reads in DataLossRecovery instead of failing the test

### DIFF
--- a/fdbserver/workloads/DataLossRecovery.actor.cpp
+++ b/fdbserver/workloads/DataLossRecovery.actor.cpp
@@ -18,8 +18,6 @@
  * limitations under the License.
  */
 
-#include <cstdint>
-#include <limits>
 #include "fdbclient/FDBOptions.g.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/ManagementAPI.actor.h"
@@ -45,6 +43,42 @@ std::string printValue(const ErrorOr<Optional<Value>>& value) {
 
 struct DataLossRecoveryWorkload : TestWorkload {
 	static constexpr auto NAME = "DataLossRecovery";
+
+	// Per-attempt timeout for the reads this workload performs, so that the test fails fast if
+	// something goes wrong instead of hanging until the test timeout. The phase that kills the only
+	// team holding the key relies on this to produce the timed_out it expects.
+	static constexpr double READ_TIMEOUT = 90.0;
+
+	// A read that is expected to return a value can also time out for reasons that have nothing to do
+	// with data loss: the cluster can be transiently unable to serve the key, for example when data
+	// distribution reboots every storage server at once (rebootWhenDurableKey) and some of them are
+	// slow to re-register. That is not what this workload is testing, so keep retrying such a read for
+	// this long before giving up. If the key is still unreadable after that, the read error is
+	// propagated and the test fails exactly as it did before.
+	static constexpr double READ_RETRY_DEADLINE = 300.0;
+
+	// The setup move below can also fail for reasons that mean "that move did not happen, issue it
+	// again" rather than "the cluster is broken". FDB's own data distributor treats exactly this set as
+	// normal and simply reissues the relocation -- see normalDDQueueErrors() in
+	// DataDistribution.actor.cpp, and the matching suppression in DDRelocationQueue.actor.cpp. None of
+	// them are retryable transaction errors, so tr.onError() would rethrow and kill the workload during
+	// start(). Reissue the move instead, at most this many times, after which the error propagates so a
+	// cluster that genuinely cannot move a shard is still reported. This is a bounded count and not a
+	// wall-clock budget because one moveKeys() call can spend minutes inside finishMoveKeys()
+	// exhausting FINISH_MOVE_KEYS_MAX_RETRIES, which blows any sane deadline before the first reissue.
+	static constexpr int MOVE_MAX_REISSUES = 3;
+
+	static bool retryableDataMoveError(const Error& e) {
+		switch (e.code()) {
+		case error_code_finish_move_keys_too_many_retries:
+		case error_code_data_move_cancelled:
+		case error_code_data_move_dest_team_not_found:
+			return true;
+		default:
+			return false;
+		}
+	}
+
 	FlowLock startMoveKeysParallelismLock;
 	FlowLock finishMoveKeysParallelismLock;
 	const bool enabled;
@@ -116,11 +150,12 @@ struct DataLossRecoveryWorkload : TestWorkload {
 	                                 Key key,
 	                                 ErrorOr<Optional<Value>> expectedValue) {
 		state Transaction tr(cx);
+		state double startTime = now();
 
 		loop {
 			try {
 				// add timeout to read so test fails faster if something goes wrong
-				state Optional<Value> res = wait(timeoutError(tr.get(key), 90.0));
+				state Optional<Value> res = wait(timeoutError(tr.get(key), READ_TIMEOUT));
 				const bool equal = !expectedValue.isError() && res == expectedValue.get();
 				if (!equal) {
 					self->validationFailed(expectedValue, ErrorOr<Optional<Value>>(res));
@@ -130,7 +165,20 @@ struct DataLossRecoveryWorkload : TestWorkload {
 				if (expectedValue.isError() && expectedValue.getError().code() == e.code()) {
 					break;
 				}
-				wait(tr.onError(e));
+				// This read is supposed to succeed, so a timeout means the key was transiently
+				// unreadable rather than lost. Retry with a fresh read version instead of failing the
+				// test, until READ_RETRY_DEADLINE is exhausted. timed_out is not retryable, so without
+				// this tr.onError() below would rethrow it and abort the workload.
+				if (e.code() == error_code_timed_out && !expectedValue.isError() &&
+				    now() - startTime < READ_RETRY_DEADLINE) {
+					TraceEvent(SevWarn, "DataLossRecoveryReadTimedOutRetrying")
+					    .detail("Key", key)
+					    .detail("Elapsed", now() - startTime)
+					    .detail("Deadline", READ_RETRY_DEADLINE);
+					tr.reset();
+				} else {
+					wait(tr.onError(e));
+				}
 			}
 		}
 
@@ -219,6 +267,7 @@ struct DataLossRecoveryWorkload : TestWorkload {
 		state DDEnabledState ddEnabledState;
 
 		state Transaction tr(cx);
+		state int moveReissues = 0;
 
 		loop {
 			try {
@@ -281,6 +330,14 @@ struct DataLossRecoveryWorkload : TestWorkload {
 				TraceEvent("DataLossRecovery").error(e).detail("Phase", "MoveRangeError");
 				if (e.code() == error_code_movekeys_conflict) {
 					// Conflict on moveKeysLocks with the current running DD is expected, just retry.
+					tr.reset();
+				} else if (retryableDataMoveError(e) && moveReissues < MOVE_MAX_REISSUES) {
+					// The move did not happen; reissue it rather than letting tr.onError() rethrow.
+					++moveReissues;
+					TraceEvent(SevWarn, "DataLossRecoveryMoveReissuing")
+					    .error(e)
+					    .detail("Reissue", moveReissues)
+					    .detail("Limit", MOVE_MAX_REISSUES);
 					tr.reset();
 				} else {
 					wait(tr.onError(e));

--- a/tests/fast/DataLossRecovery.toml
+++ b/tests/fast/DataLossRecovery.toml
@@ -7,6 +7,16 @@ machineCount = 45
 asanMachineCount = 20
 allowDefaultTenant = false
 
+# This test intentionally triggers data movement via moveKeys, which relies on system txns.
+# When simulation picks a very low txn lifetime window e.g. 1s, these system txns get rejected as
+# too old. moveKeys retries, but it's expected for these txns to take a bit longer, so every retry
+# fails too and it eventually gives up. That error fails the start of this test.
+# So for this test, we set both txn lifetime windows (read and write) to the standard 5s.
+# Specifically, versions are set to 5M, because in FDB, VERSIONS_PER_SECOND is 1M.
+[[knobs]]
+max_read_transaction_life_versions = 5000000
+max_write_transaction_life_versions = 5000000
+
 [[test]]
 testTitle = 'DataLossRecovery'
 useDB = true


### PR DESCRIPTION
DataLossRecovery fails sometimes because of errors that could be retried. This change hardens the test to minimize the failure rate. Code comments has more details.

This addresses rdar://183160725. 

Ran DataLossRecovery.toml 10K times:   20260806-184857-praza-sim-triage-DLR-finish-65f0776ae680876e compressed=True data_size=40543480 duration=1524230 ended=10000 fail_fast=10 max_runs=10000 pass=10000 priority=100 remaining=0 runtime=0:17:14 sanity=False started=10000 stopped=20260806-190611 submitted=20260806-184857 timeout=5400 username=praza-sim-triage-DLR-finishmovekeys-1472222886-tosubmit-52eca8168367d4816f55d7ca7e4bce5f57880814

