### PR TITLE
Docker packaging fdb.bash enhancements

### DIFF
--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -31,8 +31,13 @@ function create_cluster_file() {
             exit 1
         fi
     elif [[ -n $FDB_COORDINATOR ]]; then
-        coordinator_ip=$(dig +short "$FDB_COORDINATOR")
-        if [[ -z "$coordinator_ip" ]]; then
+        if (( $public_ip_stack == 4 )); then
+            coordinator_ip=$(getent ahostsv4 "$FDB_COORDINATOR" | awk 'END{ print $1 }')
+        else
+            coordinator_ip='['$(getent ahostsv6 "$FDB_COORDINATOR" | awk 'END{ print $1 }')']'
+        fi
+
+        if (( $? != 0 )); then
             echo "Failed to look up coordinator address for $FDB_COORDINATOR" 1>&2
             exit 1
         fi
@@ -50,11 +55,14 @@ function create_server_environment() {
         public_ip=127.0.0.1
     elif [[ "$FDB_NETWORKING_MODE" == "container" ]]; then
         public_ip=$(hostname -i | awk '{print $1}')
-        
+        public_ip_stack=4
         # IPv6 addresses need to be enclosed in brackets
         if [[ $public_ip == *":"* ]]; then
+            public_ip_stack=6
             public_ip="[$public_ip]"
         fi
+
+        echo "The server is currently running on an IPv$public_ip_stack stack!"
     else
         echo "Unknown FDB Networking mode \"$FDB_NETWORKING_MODE\"" 1>&2
         exit 1

--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -56,8 +56,10 @@ function create_server_environment() {
     elif [[ "$FDB_NETWORKING_MODE" == "container" ]]; then
         public_ip=$(hostname -i | awk '{print $1}')
         public_ip_stack=4
+        listen_addr=0.0.0.0
         # IPv6 addresses need to be enclosed in brackets
         if [[ $public_ip == *":"* ]]; then
+            listen_addr='[::]'
             public_ip_stack=6
             public_ip="[$public_ip]"
         fi
@@ -69,6 +71,7 @@ function create_server_environment() {
     fi
 
     export PUBLIC_IP=$public_ip
+    export LISTEN_ADDR=$listen_addr
     # Set default cluster file contents only if no configuration exists already.
     if [[ (! -s "$FDB_CLUSTER_FILE") && -z $FDB_COORDINATOR && -z "$FDB_CLUSTER_FILE_CONTENTS" ]]; then
         FDB_CLUSTER_FILE_CONTENTS="docker:docker@$public_ip:$FDB_PORT"
@@ -78,8 +81,8 @@ function create_server_environment() {
 }
 
 create_server_environment
-echo "Starting FDB server on $PUBLIC_IP:$FDB_PORT"
-fdbserver --listen-address 0.0.0.0:"$FDB_PORT" --public-address "$PUBLIC_IP:$FDB_PORT" \
+echo "Starting FDB server on $PUBLIC_IP:$FDB_PORT, listening on $LISTEN_ADDR:$FDB_PORT"
+fdbserver --listen-address $LISTEN_ADDR:"$FDB_PORT" --public-address "$PUBLIC_IP:$FDB_PORT" \
     --datadir /var/fdb/data --logdir /var/fdb/logs \
     --locality-zoneid="$(hostname)" --locality-machineid="$(hostname)" --class "$FDB_PROCESS_CLASS" --knob_disable_posix_kernel_aio=1 \
     $@

--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -27,7 +27,7 @@ function create_cluster_file() {
     if [[ -n "$FDB_CLUSTER_FILE_CONTENTS" ]]; then
         echo "$FDB_CLUSTER_FILE_CONTENTS" > "$FDB_CLUSTER_FILE"
         if [[ $? != 0 ]]; then
-            echo "FDB_CLUSTER_FILE_CONTENTS is defined, but cannot write to FDB_CLUSTER_FILE ($FDB_CLUSTER_FILE). Is something mounted read-only there?"
+            echo "FDB_CLUSTER_FILE_CONTENTS is defined, but cannot write to FDB_CLUSTER_FILE ($FDB_CLUSTER_FILE)." 1>&2
             exit 1
         fi
     elif [[ -n $FDB_COORDINATOR ]]; then
@@ -43,7 +43,7 @@ function create_cluster_file() {
         fi
         echo "docker:docker@$coordinator_ip:$FDB_COORDINATOR_PORT" > "$FDB_CLUSTER_FILE"
     elif [[ ! -r "$FDB_CLUSTER_FILE" ]]; then
-        echo "Neither FDB_CLUSTER_FILE_CONTENTS nor FDB_COORDINATOR are set, but no readable cluster file is at FDB_CLUSTER_FILE ($FDB_CLUSTER_FILE)."
+        echo "Neither FDB_CLUSTER_FILE_CONTENTS nor FDB_COORDINATOR are set, but no readable cluster file is at FDB_CLUSTER_FILE ($FDB_CLUSTER_FILE)." 1>&2
         exit 1
     else
         echo "Using existing FDB_CLUSTER_FILE at $FDB_CLUSTER_FILE"

--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -26,34 +26,43 @@ function create_cluster_file() {
 
     if [[ -n "$FDB_CLUSTER_FILE_CONTENTS" ]]; then
         echo "$FDB_CLUSTER_FILE_CONTENTS" > "$FDB_CLUSTER_FILE"
+        if [[ $? != 0 ]]; then
+            echo "FDB_CLUSTER_FILE_CONTENTS is defined, but cannot write to FDB_CLUSTER_FILE ($FDB_CLUSTER_FILE). Is something mounted read-only there?"
+            exit 1
+        fi
     elif [[ -n $FDB_COORDINATOR ]]; then
         coordinator_ip=$(dig +short "$FDB_COORDINATOR")
         if [[ -z "$coordinator_ip" ]]; then
             echo "Failed to look up coordinator address for $FDB_COORDINATOR" 1>&2
             exit 1
         fi
-        coordinator_port=${FDB_COORDINATOR_PORT:-4500}
-        echo "docker:docker@$coordinator_ip:$coordinator_port" > "$FDB_CLUSTER_FILE"
-    else
-        echo "FDB_COORDINATOR environment variable not defined" 1>&2
+        echo "docker:docker@$coordinator_ip:$FDB_COORDINATOR_PORT" > "$FDB_CLUSTER_FILE"
+    elif [[ ! -r "$FDB_CLUSTER_FILE" ]]; then
+        echo "Neither FDB_CLUSTER_FILE_CONTENTS nor FDB_COORDINATOR are set, but no readable cluster file is at FDB_CLUSTER_FILE ($FDB_CLUSTER_FILE)."
         exit 1
+    else
+        echo "Using existing FDB_CLUSTER_FILE at $FDB_CLUSTER_FILE"
     fi
 }
 
 function create_server_environment() {
-    env_file=/var/fdb/.fdbenv
-
     if [[ "$FDB_NETWORKING_MODE" == "host" ]]; then
         public_ip=127.0.0.1
     elif [[ "$FDB_NETWORKING_MODE" == "container" ]]; then
         public_ip=$(hostname -i | awk '{print $1}')
+        
+        # IPv6 addresses need to be enclosed in brackets
+        if [[ $public_ip == *":"* ]]; then
+            public_ip="[$public_ip]"
+        fi
     else
         echo "Unknown FDB Networking mode \"$FDB_NETWORKING_MODE\"" 1>&2
         exit 1
     fi
 
-    echo "export PUBLIC_IP=$public_ip" > $env_file
-    if [[ -z $FDB_COORDINATOR && -z "$FDB_CLUSTER_FILE_CONTENTS" ]]; then
+    export PUBLIC_IP=$public_ip
+    # Set default cluster file contents only if no configuration exists already.
+    if [[ (! -s "$FDB_CLUSTER_FILE") && -z $FDB_COORDINATOR && -z "$FDB_CLUSTER_FILE_CONTENTS" ]]; then
         FDB_CLUSTER_FILE_CONTENTS="docker:docker@$public_ip:$FDB_PORT"
     fi
 
@@ -61,8 +70,8 @@ function create_server_environment() {
 }
 
 create_server_environment
-source /var/fdb/.fdbenv
 echo "Starting FDB server on $PUBLIC_IP:$FDB_PORT"
 fdbserver --listen-address 0.0.0.0:"$FDB_PORT" --public-address "$PUBLIC_IP:$FDB_PORT" \
     --datadir /var/fdb/data --logdir /var/fdb/logs \
-    --locality-zoneid="$(hostname)" --locality-machineid="$(hostname)" --class "$FDB_PROCESS_CLASS" --knob_disable_posix_kernel_aio=1
+    --locality-zoneid="$(hostname)" --locality-machineid="$(hostname)" --class "$FDB_PROCESS_CLASS" --knob_disable_posix_kernel_aio=1 \
+    $@


### PR DESCRIPTION
Hello! I've made some updates to the fdb.bash entrypoint for the foundationdb docker image. I had a couple issues with setting up the image in my environment, so lacking a better idea of how to organize this I'll just enumerate them and the changes I made to resolve them.

I don't _believe_ any of these will break existing deployments, but please let me know if I've done something obviously wrong. This is my first time contributing code to something outside of academic contexts, so I may just lack the experience. This may have also led me to writing this very long description. Thank you for your patience.

# Changes
## `fdb.bash` now passes arguments to the spawned fdbserver process
### Issue
Changes to things such as the memory knobs are not passed to the spawned process!
i.e.
```sh
podman run docker.io/foundationdb/foundationdb:7.3.79 --memory 2048
```
would not spawn a fdbserver process with the `--memory 2048` arg, because arguments to `fdb.bash` were not passed to the spawned fdbserver process.
### Solution
Added `$@` to the args for fdbserver.

## `fdb.bash` now supports using an existing fdb cluster file
### Rationale
As it stands, the fdb cluster file is written every time the server starts. This isn't really an issue so much as me not wanting to store file contents as an environment variable. I'd rather just have a file in a conf directory somewhere. This feature might only be useful for people not using kubernetes clustering tools.

### Old Behavior
If `FDB_CLUSTER_FILE_CONTENTS` and `FDB_COORDINATOR` are both empty, `FDB_CLUSTER_FILE_CONTENTS` will be set to `docker:docker@$public_ip:$FDB_PORT`

### New Behavior
`fdb.bash` will now run using an existing cluster file **only if** all the following are true
- `FDB_CLUSTER_FILE_CONTENTS` is empty
- `FDB_COORDINATOR` is empty
- The file at `FDB_CLUSTER_FILE` is nonempty

otherwise, old behavior occurs. This may result in a mounted file being overwritten, but this ensures legacy behavior.

## `fdb.bash` now properly handles IPv6 networking
### Issue
If the `public_ip` found by `fdb.bash` is IPv6, it does not wrap the address in brackets, causing fdbserver to fail. This occurs on machines with _only_ IPv6 addresses. Additionally, it used `dig` to resolve hostnames, which bypasses `/etc/hosts` and will never return IPv6 addresses, as it does not specify record type to dig for.

### Solution
First, if `public_ip` is IPv6 (if it contains colons), it is wrapped in brackets. Whether or not the public ip is ipv4 or ipv6 is also stored.

If `FDB_COORDINATOR` is set, we now use `getent ahostsv4` to resolve the host if ipv4, `getent ahostsv6` if ipv6.

Finally, the listen address is changed to `[::]` if we're using the ipv6 stack, just in case 0.0.0.0 doesn't imply it.

In host mode, there is no attempt to detect if we're ipv4 or ipv6 out of fear of breaking existing deployments.

## `fdb.bash` directly exports environment variables instead of creating a file to source
### Issue
Sourcing exports should ostensibly be the same as exporting them directly, and doesn't require us to make a temporary file.

### Old Behavior
`export PUBLIC_IP=...` saved to temporary (that is to say, not in a volume) `.fdbenv` and then sourced.

### New Behavior
`PUBLIC_IP` is exported in the script.

## Slightly more detailed status messages, occasionally
### Rationale
With the addition of being able to use an existing file, I felt adding more descriptive status messages for some errors or situations was polite.

### New Messages
New messages occur...
- If `FDB_CLUSTER_FILE` could not be written to.
- If `FDB_CLUSTER_FILE_CONTENTS` and `FDB_COORDINATOR` are unspecified, but an existing `FDB_CLUSTER_FILE` is unreadable
- If an existing `FDB_CLUSTER_FILE` is being used
- Specifying whether IPv4 or IPv6 is being used