### PR TITLE
[main] Retry timed-out reads in DataLossRecovery instead of failing the test

### DIFF
--- a/fdbserver/workloads/DataLossRecovery.cpp
+++ b/fdbserver/workloads/DataLossRecovery.cpp
@@ -331,6 +331,10 @@ struct DataLossRecoveryWorkload : TestWorkload {
 			TraceEvent("DataLossRecovery").error(err).detail("Phase", "MoveRangeError");
 			if (err.code() == error_code_movekeys_conflict) {
 				// Conflict on moveKeysLocks with the current running DD is expected, just retry.
+				// Deliberately not folded into the bounded branch below: this error means the move never
+				// started, so retrying is cheap, and the workload has to keep trying until DD notices it
+				// has been disabled and stops taking the lock. Bounding it would fail the test whenever
+				// DD is merely slow to notice.
 				tr.reset();
 			} else if (retryableDataMoveError(err) && moveReissues < MOVE_MAX_REISSUES) {
 				// The move did not happen; reissue it rather than letting tr.onError() rethrow.

--- a/fdbserver/workloads/DataLossRecovery.cpp
+++ b/fdbserver/workloads/DataLossRecovery.cpp
@@ -18,8 +18,6 @@
  * limitations under the License.
  */
 
-#include <cstdint>
-#include <limits>
 #include "fdbclient/FDBOptions.g.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/ManagementAPI.h"
@@ -44,6 +42,42 @@ std::string printValue(const ErrorOr<Optional<Value>>& value) {
 
 struct DataLossRecoveryWorkload : TestWorkload {
 	static constexpr auto NAME = "DataLossRecovery";
+
+	// Per-attempt timeout for the reads this workload performs, so that the test fails fast if
+	// something goes wrong instead of hanging until the test timeout. The phase that kills the only
+	// team holding the key relies on this to produce the timed_out it expects.
+	static constexpr double READ_TIMEOUT = 90.0;
+
+	// A read that is expected to return a value can also time out for reasons that have nothing to do
+	// with data loss: the cluster can be transiently unable to serve the key, for example when data
+	// distribution reboots every storage server at once (rebootWhenDurableKey) and some of them are
+	// slow to re-register. That is not what this workload is testing, so keep retrying such a read for
+	// this long before giving up. If the key is still unreadable after that, the read error is
+	// propagated and the test fails exactly as it did before.
+	static constexpr double READ_RETRY_DEADLINE = 300.0;
+
+	// The setup move below can also fail for reasons that mean "that move did not happen, issue it
+	// again" rather than "the cluster is broken". FDB's own data distributor treats exactly this set as
+	// normal and simply reissues the relocation -- see normalDDQueueErrors() in
+	// DataDistribution.actor.cpp, and the matching suppression in DDRelocationQueue.actor.cpp. None of
+	// them are retryable transaction errors, so tr.onError() would rethrow and kill the workload during
+	// start(). Reissue the move instead, at most this many times, after which the error propagates so a
+	// cluster that genuinely cannot move a shard is still reported. This is a bounded count and not a
+	// wall-clock budget because one moveKeys() call can spend minutes inside finishMoveKeys()
+	// exhausting FINISH_MOVE_KEYS_MAX_RETRIES, which blows any sane deadline before the first reissue.
+	static constexpr int MOVE_MAX_REISSUES = 3;
+
+	static bool retryableDataMoveError(const Error& e) {
+		switch (e.code()) {
+		case error_code_finish_move_keys_too_many_retries:
+		case error_code_data_move_cancelled:
+		case error_code_data_move_dest_team_not_found:
+			return true;
+		default:
+			return false;
+		}
+	}
+
 	FlowLock startMoveKeysParallelismLock;
 	FlowLock finishMoveKeysParallelismLock;
 	const bool enabled;
@@ -113,12 +147,13 @@ struct DataLossRecoveryWorkload : TestWorkload {
 	                           Key key,
 	                           ErrorOr<Optional<Value>> expectedValue) {
 		Transaction tr(cx);
+		double startTime = now();
 
 		while (true) {
 			Error err;
 			try {
 				// add timeout to read so test fails faster if something goes wrong
-				Optional<Value> res = co_await timeoutError(tr.get(key), 90.0);
+				Optional<Value> res = co_await timeoutError(tr.get(key), READ_TIMEOUT);
 				const bool equal = !expectedValue.isError() && res == expectedValue.get();
 				if (!equal) {
 					self->validationFailed(expectedValue, ErrorOr<Optional<Value>>(res));
@@ -130,7 +165,20 @@ struct DataLossRecoveryWorkload : TestWorkload {
 			if (expectedValue.isError() && expectedValue.getError().code() == err.code()) {
 				break;
 			}
-			co_await tr.onError(err);
+			// This read is supposed to succeed, so a timeout means the key was transiently
+			// unreadable rather than lost. Retry with a fresh read version instead of failing the
+			// test, until READ_RETRY_DEADLINE is exhausted. timed_out is not retryable, so without
+			// this tr.onError() below would rethrow it and abort the workload.
+			if (err.code() == error_code_timed_out && !expectedValue.isError() &&
+			    now() - startTime < READ_RETRY_DEADLINE) {
+				TraceEvent(SevWarn, "DataLossRecoveryReadTimedOutRetrying")
+				    .detail("Key", key)
+				    .detail("Elapsed", now() - startTime)
+				    .detail("Deadline", READ_RETRY_DEADLINE);
+				tr.reset();
+			} else {
+				co_await tr.onError(err);
+			}
 		}
 	}
 
@@ -217,6 +265,7 @@ struct DataLossRecoveryWorkload : TestWorkload {
 		DDEnabledState ddEnabledState;
 
 		Transaction tr(cx);
+		int moveReissues = 0;
 
 		while (true) {
 			Error err;
@@ -280,10 +329,16 @@ struct DataLossRecoveryWorkload : TestWorkload {
 				err = e;
 			}
 			TraceEvent("DataLossRecovery").error(err).detail("Phase", "MoveRangeError");
-			if (err.code() == error_code_movekeys_conflict ||
-			    err.code() == error_code_finish_move_keys_too_many_retries) {
-				// Conflicts on moveKeysLocks with the current running DD and finishMoveKeys retry exhaustion are both
-				// expected transient move outcomes, so retry the move from a fresh transaction.
+			if (err.code() == error_code_movekeys_conflict) {
+				// Conflict on moveKeysLocks with the current running DD is expected, just retry.
+				tr.reset();
+			} else if (retryableDataMoveError(err) && moveReissues < MOVE_MAX_REISSUES) {
+				// The move did not happen; reissue it rather than letting tr.onError() rethrow.
+				++moveReissues;
+				TraceEvent(SevWarn, "DataLossRecoveryMoveReissuing")
+				    .error(err)
+				    .detail("Reissue", moveReissues)
+				    .detail("Limit", MOVE_MAX_REISSUES);
 				tr.reset();
 			} else {
 				co_await tr.onError(err);

--- a/tests/fast/DataLossRecovery.toml
+++ b/tests/fast/DataLossRecovery.toml
@@ -1,17 +1,20 @@
 [configuration]
-# Disable buggify for this test. The workload disables DD and manually moves
-# shards via startMoveKeys. With buggify enabled, injected delays cause
-# transaction_too_old on every retry (transaction body exceeds the 5-second
-# read version window), while BUGGIFY also reduces START_MOVE_KEYS_MAX_RETRIES
-# from 50 to 10. The combination is self-defeating: the test exhausts retries
-# before DD recognizes it has been disabled and releases the move keys lock.
-buggify = false
 generateFearless = false
 config = 'triple'
 processesPerMachine = 2
 coordinators = 3
 machineCount = 45
 asanMachineCount = 20
+
+# This test intentionally triggers data movement via moveKeys, which relies on system txns.
+# When simulation picks a very low txn lifetime window e.g. 1s, these system txns get rejected as
+# too old. moveKeys retries, but it's expected for these txns to take a bit longer, so every retry
+# fails too and it eventually gives up. That error fails the start of this test.
+# So for this test, we set both txn lifetime windows (read and write) to the standard 5s.
+# Specifically, versions are set to 5M, because in FDB, VERSIONS_PER_SECOND is 1M.
+[[knobs]]
+max_read_transaction_life_versions = 5000000
+max_write_transaction_life_versions = 5000000
 
 [[test]]
 testTitle = 'DataLossRecovery'


### PR DESCRIPTION
Forward port of https://github.com/apple/foundationdb/pull/13819. 

Also reverts https://github.com/apple/foundationdb/pull/13260, see https://github.com/apple/foundationdb/pull/13819#issuecomment-5209029543 for context.

Ran DataLossRecovery.toml 10K times: 20260807-175138-praza-port-main-pr13819-rev-e239a7e852cea8bc compressed=True data_size=37403129 duration=1024208 ended=10000 fail_fast=100 max_runs=10000 pass=10000 priority=100 remaining=0 runtime=0:24:27 sanity=False started=10000 stopped=20260807-181605 submitted=20260807-175138 timeout=5400 username=praza-port-main-pr13819-revert13260-7f7b86df9f6a2e500aede95703033a0dbbec4ab1