### PR TITLE
Replay tool: make colors readable on a light terminal background

### DIFF
--- a/contrib/replay/README.md
+++ b/contrib/replay/README.md
@@ -79,6 +79,25 @@ replay -h | --help         # Show help
 alias r=replay
 ```
 
+### Colors on a light terminal
+
+The palette has a light and a dark variant, and by default the right one is
+picked by asking the terminal what its background is. That query does not
+survive every environment - notably it is unreliable through `tmux` and over
+`ssh` - and when it fails the assumption is a dark background, which renders
+poorly on a light terminal.
+
+If the colors look washed out, invisible, or overly contrasty, say what the
+background actually is:
+
+```bash
+REPLAY_THEME=light replay    # force the light-background palette
+REPLAY_THEME=dark replay     # force the dark-background palette
+```
+
+Setting `REPLAY_THEME` also skips the terminal query altogether, which is
+useful because that query can hang in environments with nothing to answer it.
+
 ## Why
 
 The main motivation is to be **fast in debugging simulation issues**, as well as **understanding how FDB works**.

--- a/contrib/replay/main.go
+++ b/contrib/replay/main.go
@@ -15,6 +15,8 @@ func main() {
 }
 
 func run() error {
+	applyTheme()
+
 	var traceFile string
 
 	// Check for help flag

--- a/contrib/replay/palette.go
+++ b/contrib/replay/palette.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Every color the UI uses is defined here once, with a variant for light and a
+// variant for dark terminal backgrounds. lipgloss resolves an AdaptiveColor at
+// render time, picking the variant that matches the detected background, so
+// none of this depends on package initialization order.
+//
+// This used to be a single set of 256-color indices picked against a dark
+// background, spread across the UI code. On a light background the brighter
+// half of that palette - near-white body text, saturated green and yellow, the
+// dark olive highlight - lands somewhere between low contrast and invisible.
+//
+// The rule for the two variants: on a dark background prominence comes from
+// being brighter, on a light background from being darker. The gray ramp below
+// is therefore inverted between the two.
+var (
+	// Body text, most to least prominent.
+	colText          = lipgloss.AdaptiveColor{Light: "235", Dark: "252"}
+	colTextSecondary = lipgloss.AdaptiveColor{Light: "239", Dark: "243"}
+	colTextMuted     = lipgloss.AdaptiveColor{Light: "243", Dark: "241"}
+	colTextDim       = lipgloss.AdaptiveColor{Light: "245", Dark: "240"}
+
+	// Accents.
+	colAccent   = lipgloss.AdaptiveColor{Light: "26", Dark: "39"}   // titles, popup borders
+	colDCHeader = lipgloss.AdaptiveColor{Light: "25", Dark: "33"}   // data center headers
+	colTester   = lipgloss.AdaptiveColor{Light: "91", Dark: "135"}  // tester headers
+	colCurrent  = lipgloss.AdaptiveColor{Light: "30", Dark: "51"}   // current worker/role
+	colOk       = lipgloss.AdaptiveColor{Light: "28", Dark: "46"}   // section headers, valid input
+	colSelected = lipgloss.AdaptiveColor{Light: "130", Dark: "226"} // selected entry
+	colError    = lipgloss.AdaptiveColor{Light: "160", Dark: "196"} // errors
+	colRPC      = lipgloss.AdaptiveColor{Light: "130", Dark: "220"} // RPC label under the topology
+
+	// colHighlightBg backs the current line and search matches. It sets no
+	// foreground of its own, so it has to stay readable against the terminal's
+	// default text color: a light wash on a light background, a dark one on a
+	// dark background.
+	colHighlightBg = lipgloss.AdaptiveColor{Light: "229", Dark: "58"}
+
+	// The network-message highlight sets its own foreground, and black on
+	// yellow reads on either background, so both variants are the same.
+	colNetworkBg = lipgloss.AdaptiveColor{Light: "220", Dark: "220"}
+	colOnNetwork = lipgloss.AdaptiveColor{Light: "0", Dark: "0"}
+)
+
+// applyTheme honors an explicit REPLAY_THEME=light|dark, overriding detection.
+//
+// lipgloss works out the background by querying the terminal (OSC 11). That
+// query is unreliable through tmux and over ssh, and when it fails lipgloss
+// assumes a dark background - which is precisely the case that renders
+// unreadably on a light terminal. So detection is the default, but there has to
+// be a way to say what the background actually is.
+func applyTheme() {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("REPLAY_THEME"))) {
+	case "light":
+		lipgloss.SetHasDarkBackground(false)
+	case "dark":
+		lipgloss.SetHasDarkBackground(true)
+	}
+}

--- a/contrib/replay/palette_test.go
+++ b/contrib/replay/palette_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// These tests drive global lipgloss renderer state (color profile and
+// background), so they deliberately do not use t.Parallel().
+
+// render returns the escape sequence lipgloss emits for a foreground color,
+// with the profile pinned so the output is deterministic.
+func render(c lipgloss.TerminalColor) string {
+	lipgloss.SetColorProfile(termenv.ANSI256)
+	return lipgloss.NewStyle().Foreground(c).Render("x")
+}
+
+func TestPaletteFollowsBackground(t *testing.T) {
+	cases := []struct {
+		name              string
+		c                 lipgloss.TerminalColor
+		wantDark, wantLgt string
+	}{
+		{"colText", colText, "252", "235"},
+		{"colTextDim", colTextDim, "240", "245"},
+		{"colOk", colOk, "46", "28"},
+		{"colSelected", colSelected, "226", "130"},
+		{"colHighlightBg", colHighlightBg, "58", "229"},
+		{"colRPC", colRPC, "220", "130"},
+		{"colAccent", colAccent, "39", "26"},
+	}
+
+	for _, tc := range cases {
+		lipgloss.SetHasDarkBackground(true)
+		gotDark := render(tc.c)
+		lipgloss.SetHasDarkBackground(false)
+		gotLgt := render(tc.c)
+
+		if !strings.Contains(gotDark, "38;5;"+tc.wantDark) {
+			t.Errorf("%s on dark bg: want index %s, got %q", tc.name, tc.wantDark, gotDark)
+		}
+		if !strings.Contains(gotLgt, "38;5;"+tc.wantLgt) {
+			t.Errorf("%s on light bg: want index %s, got %q", tc.name, tc.wantLgt, gotLgt)
+		}
+		if gotDark == gotLgt && tc.wantDark != tc.wantLgt {
+			t.Errorf("%s did not change with background", tc.name)
+		}
+	}
+}
+
+// The two deliberately background-independent colors must NOT change.
+func TestNetworkHighlightIsBackgroundIndependent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		c    lipgloss.TerminalColor
+	}{{"colNetworkBg", colNetworkBg}, {"colOnNetwork", colOnNetwork}} {
+		lipgloss.SetHasDarkBackground(true)
+		d := render(tc.c)
+		lipgloss.SetHasDarkBackground(false)
+		l := render(tc.c)
+		if d != l {
+			t.Errorf("%s should be identical on both backgrounds, got %q vs %q", tc.name, d, l)
+		}
+	}
+}
+
+func TestReplayThemeOverride(t *testing.T) {
+	// REPLAY_THEME=light must win even though detection would say dark.
+	lipgloss.SetHasDarkBackground(true)
+	os.Setenv("REPLAY_THEME", "light")
+	applyTheme()
+	if lipgloss.HasDarkBackground() {
+		t.Errorf("REPLAY_THEME=light did not take effect")
+	}
+
+	lipgloss.SetHasDarkBackground(false)
+	os.Setenv("REPLAY_THEME", "DARK  ") // case and whitespace tolerant
+	applyTheme()
+	if !lipgloss.HasDarkBackground() {
+		t.Errorf("REPLAY_THEME=DARK (padded) did not take effect")
+	}
+
+	// An unset or bogus value must leave detection alone.
+	lipgloss.SetHasDarkBackground(true)
+	os.Setenv("REPLAY_THEME", "chartreuse")
+	applyTheme()
+	if !lipgloss.HasDarkBackground() {
+		t.Errorf("bogus REPLAY_THEME should not have changed detection")
+	}
+	os.Unsetenv("REPLAY_THEME")
+}
+
+// Renders the real UI and confirms the emitted color codes actually change
+// with the background setting.
+func TestRenderedViewChangesWithTheme(t *testing.T) {
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<Trace>
+<Event Severity="10" Time="1.000000" Type="Role" Machine="2.0.1.0:1" ID="1111111111111111" Transition="Begin" As="StorageServer"/>
+<Event Severity="10" Time="1.010000" Type="Role" Machine="2.0.1.0:1" ID="2222222222222222" Transition="Begin" As="TLog"/>
+<Event Severity="10" Time="1.100000" Type="StorageMetrics" Machine="2.0.1.0:1" ID="1111111111111111" Version="1234567"/>
+<Event Severity="10" Time="1.200000" Type="TLogMetrics" Machine="2.0.1.0:1" ID="2222222222222222" Version="7654321" Generation="5"/>
+<Event Severity="10" Time="1.300000" Type="StorageServerSourceTLogID" Machine="2.0.1.0:1" ID="1111111111111111" SourceTLogID="2222222222222222"/>
+</Trace>`
+	p := t.TempDir() + "/trace.xml"
+	if err := os.WriteFile(p, []byte(xml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	td, err := parseTraceFile(p)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	lipgloss.SetColorProfile(termenv.ANSI256)
+	codes := func() map[string]bool {
+		m := newModel(td)
+		m.width, m.height = 200, 50
+		out := m.View()
+		found := map[string]bool{}
+		for _, f := range strings.Split(out, "\x1b[") {
+			if strings.HasPrefix(f, "38;5;") {
+				found[strings.SplitN(f, "m", 2)[0]] = true
+			}
+		}
+		return found
+	}
+
+	lipgloss.SetHasDarkBackground(true)
+	dark := codes()
+	lipgloss.SetHasDarkBackground(false)
+	light := codes()
+
+	if len(dark) == 0 || len(light) == 0 {
+		t.Fatalf("no color codes rendered (dark=%d light=%d)", len(dark), len(light))
+	}
+	onlyDark, onlyLight := []string{}, []string{}
+	for c := range dark {
+		if !light[c] {
+			onlyDark = append(onlyDark, c)
+		}
+	}
+	for c := range light {
+		if !dark[c] {
+			onlyLight = append(onlyLight, c)
+		}
+	}
+	sort.Strings(onlyDark)
+	sort.Strings(onlyLight)
+	t.Logf("dark-only codes : %v", onlyDark)
+	t.Logf("light-only codes: %v", onlyLight)
+	if len(onlyDark) == 0 || len(onlyLight) == 0 {
+		t.Errorf("rendered view did not change with background")
+	}
+	// The near-white body text must not survive on a light background.
+	if light["38;5;252"] {
+		t.Errorf("near-white 252 still used on light background")
+	}
+}

--- a/contrib/replay/ui.go
+++ b/contrib/replay/ui.go
@@ -1091,10 +1091,10 @@ func formatTraceEvent(event *TraceEvent, isCurrent bool, searchPattern string) s
 	}
 
 	// Color styles
-	fieldNameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240")) // Dim
-	fieldValueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("46"))  // Green
-	currentLineStyle := lipgloss.NewStyle().Background(lipgloss.Color("58")) // Dark yellowish highlight
-	searchHighlightStyle := lipgloss.NewStyle().Background(lipgloss.Color("58")) // Same as current line highlight
+	fieldNameStyle := lipgloss.NewStyle().Foreground(colTextDim) // Dim
+	fieldValueStyle := lipgloss.NewStyle().Foreground(colOk)  // Green
+	currentLineStyle := lipgloss.NewStyle().Background(colHighlightBg) // Dark yellowish highlight
+	searchHighlightStyle := lipgloss.NewStyle().Background(colHighlightBg) // Same as current line highlight
 
 	var parts []string
 
@@ -1219,7 +1219,7 @@ func formatTraceEvent(event *TraceEvent, isCurrent bool, searchPattern string) s
 
 	for _, key := range attrKeys {
 		value := event.Attrs[key]
-		parts = append(parts, fieldNameStyle.Render(key+"=")+lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Render(applySearchHighlight(value)))
+		parts = append(parts, fieldNameStyle.Render(key+"=")+lipgloss.NewStyle().Foreground(colText).Render(applySearchHighlight(value)))
 	}
 
 	line := strings.Join(parts, " ")
@@ -1894,7 +1894,7 @@ func (m model) buildEventListPane(availableHeight int, paneWidth int, searchPatt
 	lines = append(lines, linesAbove...)
 
 	// Add current event with highlight (only first line)
-	highlightStyle := lipgloss.NewStyle().Background(lipgloss.Color("58"))
+	highlightStyle := lipgloss.NewStyle().Background(colHighlightBg)
 	for i, line := range currentWrappedLines {
 		if i == 0 {
 			// Highlight only the first line (where Time= appears)
@@ -1976,47 +1976,47 @@ func (m model) View() string {
 	// Styles
 	dcHeaderStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("33")).
+		Foreground(colDCHeader).
 		Underline(true).
 		MarginTop(0).
 		MarginBottom(0)
 
 	testerHeaderStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("135")).
+		Foreground(colTester).
 		Underline(true).
 		MarginTop(0).
 		MarginBottom(0)
 
 	workerStyleGray := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
+		Foreground(colTextDim).
 		PaddingLeft(2)
 
 	workerStyleGreen := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("46")).
+		Foreground(colOk).
 		Bold(true).
 		PaddingLeft(2)
 
 	// Style for current machine (event source) - cyan with arrow
 	workerStyleCurrent := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("51")).
+		Foreground(colCurrent).
 		Bold(true).
 		PaddingLeft(0)
 
 	roleStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("252")) // Normal gray color
+		Foreground(colText) // Normal gray color
 
 	// Style for current role (when ID matches)
 	roleStyleCurrent := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("51")).
+		Foreground(colCurrent).
 		Bold(true)
 
 	scrubberStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("241")).
+		Foreground(colTextMuted).
 		PaddingLeft(1)
 
 	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("241"))
+		Foreground(colTextMuted)
 
 	// Get workers grouped by DC and testers
 	dcWorkers := m.clusterState.GetWorkersByDC()
@@ -2144,12 +2144,12 @@ func (m model) View() string {
 						// Highlight network message src/dst with yellow background and directional arrow
 						if isNetworkSrc {
 							// Source: yellow background with →→→ at end
-							networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+							networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 							workerLine = fmt.Sprintf("● %s →→→", worker.Machine)
 							allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 						} else if isNetworkDst {
 							// Destination: yellow background with ←←← at end
-							networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+							networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 							workerLine = fmt.Sprintf("● %s ←←←", worker.Machine)
 							allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 						} else if worker.HasNonWorkerRoles() {
@@ -2174,11 +2174,11 @@ func (m model) View() string {
 
 						// Network message highlighting takes precedence
 						if isNetworkSrc {
-							networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+							networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 							workerLine = fmt.Sprintf("● %s →→→", worker.Machine)
 							allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 						} else if isNetworkDst {
-							networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+							networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 							workerLine = fmt.Sprintf("● %s ←←←", worker.Machine)
 							allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 						} else {
@@ -2195,11 +2195,11 @@ func (m model) View() string {
 						workerLine := fmt.Sprintf("● %s", worker.Machine)
 
 						if isNetworkSrc {
-							networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+							networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 							workerLine = fmt.Sprintf("● %s →→→", worker.Machine)
 							allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 						} else if isNetworkDst {
-							networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+							networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 							workerLine = fmt.Sprintf("● %s ←←←", worker.Machine)
 							allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 						} else {
@@ -2215,11 +2215,11 @@ func (m model) View() string {
 						workerLine := fmt.Sprintf("● %s", worker.Machine)
 
 						if isNetworkSrc {
-							networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+							networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 							workerLine = fmt.Sprintf("● %s →→→", worker.Machine)
 							allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 						} else if isNetworkDst {
-							networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+							networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 							workerLine = fmt.Sprintf("● %s ←←←", worker.Machine)
 							allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 						} else {
@@ -2270,12 +2270,12 @@ func (m model) View() string {
 					// Highlight network message src/dst with yellow background and directional arrow
 					if isNetworkSrc {
 						// Source: yellow background with →→→ at end
-						networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+						networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 						workerLine = fmt.Sprintf("● %s →→→", worker.Machine)
 						allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 					} else if isNetworkDst {
 						// Destination: yellow background with ←←← at end
-						networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+						networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 						workerLine = fmt.Sprintf("● %s ←←←", worker.Machine)
 						allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 					} else if worker.HasNonWorkerRoles() {
@@ -2300,11 +2300,11 @@ func (m model) View() string {
 
 					// Network message highlighting takes precedence
 					if isNetworkSrc {
-						networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+						networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 						workerLine = fmt.Sprintf("● %s →→→", worker.Machine)
 						allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 					} else if isNetworkDst {
-						networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+						networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 						workerLine = fmt.Sprintf("● %s ←←←", worker.Machine)
 						allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 					} else {
@@ -2321,11 +2321,11 @@ func (m model) View() string {
 					workerLine := fmt.Sprintf("● %s", worker.Machine)
 
 					if isNetworkSrc {
-						networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+						networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 						workerLine = fmt.Sprintf("● %s →→→", worker.Machine)
 						allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 					} else if isNetworkDst {
-						networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+						networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 						workerLine = fmt.Sprintf("● %s ←←←", worker.Machine)
 						allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 					} else {
@@ -2341,11 +2341,11 @@ func (m model) View() string {
 					workerLine := fmt.Sprintf("● %s", worker.Machine)
 
 					if isNetworkSrc {
-						networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+						networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 						workerLine = fmt.Sprintf("● %s →→→", worker.Machine)
 						allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 					} else if isNetworkDst {
-						networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+						networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 						workerLine = fmt.Sprintf("● %s ←←←", worker.Machine)
 						allTopologyLines = append(allTopologyLines, networkStyle.Render(workerLine))
 					} else {
@@ -2366,7 +2366,7 @@ func (m model) View() string {
 	if networkMsg != nil && !networkMsg.SrcExists {
 		// Source not found, show with yellow highlight and →→→ arrow
 		allTopologyLines = append(allTopologyLines, "")
-		networkStyle := lipgloss.NewStyle().Background(lipgloss.Color("220")).Foreground(lipgloss.Color("0")).Bold(true)
+		networkStyle := lipgloss.NewStyle().Background(colNetworkBg).Foreground(colOnNetwork).Bold(true)
 		allTopologyLines = append(allTopologyLines, networkStyle.Render(fmt.Sprintf("● %s →→→", networkMsg.SrcAddr)))
 	}
 
@@ -2374,7 +2374,7 @@ func (m model) View() string {
 	if networkMsg != nil && networkMsg.StrippedRPC != "" {
 		allTopologyLines = append(allTopologyLines, "")
 		rpcStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("220")).
+			Foreground(colRPC).
 			Bold(true).
 			Underline(true)
 		allTopologyLines = append(allTopologyLines, rpcStyle.Render(fmt.Sprintf("  RPC: %s", networkMsg.StrippedRPC)))
@@ -2480,7 +2480,7 @@ func (m model) View() string {
 
 	// If in search mode, add search bar as last line
 	if m.searchMode {
-		searchBarStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+		searchBarStyle := lipgloss.NewStyle().Foreground(colText)
 		var searchBar string
 		if m.searchDirection == "forward" {
 			searchBar = "/" + m.searchInput.View()
@@ -2503,7 +2503,7 @@ func (m model) View() string {
 
 	// Build split view line by line with columnar topology
 	var splitContent strings.Builder
-	borderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	borderStyle := lipgloss.NewStyle().Foreground(colTextDim)
 
 	for lineIdx := 0; lineIdx < maxLines; lineIdx++ {
 		// Render all topology columns for this line
@@ -2538,22 +2538,22 @@ func (m model) View() string {
 
 	// Add separator
 	separator := strings.Repeat("─", m.width)
-	bottomSection.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(separator))
+	bottomSection.WriteString(lipgloss.NewStyle().Foreground(colTextDim).Render(separator))
 	bottomSection.WriteString("\n")
 
 	// DB Configuration section
 	config := m.traceData.GetLatestConfigAtTime(m.currentTime)
 	if config != nil {
 		configStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("243")).
+			Foreground(colTextSecondary).
 			PaddingLeft(1)
 
 		configTitleStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("39")).
+			Foreground(colAccent).
 			Bold(true)
 
 		configValueStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("252"))
+			Foreground(colText)
 
 		configContent := configTitleStyle.Render(fmt.Sprintf("DB Config (t=%.2fs)", config.Time)) + " "
 
@@ -2596,11 +2596,11 @@ func (m model) View() string {
 	recoveryState := m.traceData.GetLatestRecoveryStateAtIndex(m.currentEventIndex)
 	if recoveryState != nil {
 		recoveryStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("243")).
+			Foreground(colTextSecondary).
 			PaddingLeft(1)
 
 		recoveryTitleStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("39")).
+			Foreground(colAccent).
 			Bold(true)
 
 		// Color code based on StatusCode value
@@ -2608,20 +2608,20 @@ func (m model) View() string {
 		if statusCode, err := strconv.Atoi(recoveryState.StatusCode); err == nil {
 			if statusCode < 11 {
 				// Red for < 11
-				recoveryValueStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+				recoveryValueStyle = lipgloss.NewStyle().Foreground(colError)
 			} else if statusCode >= 11 && statusCode < 14 {
 				// Blue for 11 <= statusCode < 14
-				recoveryValueStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("39"))
+				recoveryValueStyle = lipgloss.NewStyle().Foreground(colAccent)
 			} else if statusCode == 14 {
 				// Green for = 14
-				recoveryValueStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("46"))
+				recoveryValueStyle = lipgloss.NewStyle().Foreground(colOk)
 			} else {
 				// Default gray for > 14
-				recoveryValueStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+				recoveryValueStyle = lipgloss.NewStyle().Foreground(colText)
 			}
 		} else {
 			// Default gray if can't parse
-			recoveryValueStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+			recoveryValueStyle = lipgloss.NewStyle().Foreground(colText)
 		}
 
 		recoveryContent := recoveryTitleStyle.Render(fmt.Sprintf("Recovery State (t=%.6fs)", recoveryState.Time)) + " "
@@ -2635,15 +2635,15 @@ func (m model) View() string {
 	epochInfo := m.traceData.GetLatestEpochVersionAtIndex(m.currentEventIndex)
 	if epochInfo != nil {
 		epochStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("243")).
+			Foreground(colTextSecondary).
 			PaddingLeft(1)
 
 		epochTitleStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("39")).
+			Foreground(colAccent).
 			Bold(true)
 
 		epochValueStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("252")) // Same gray/white as config values
+			Foreground(colText) // Same gray/white as config values
 
 		// Format KCV - show "n/a" if not available
 		kcvStr := "n/a"
@@ -2660,7 +2660,7 @@ func (m model) View() string {
 	}
 
 	// Time scrubber
-	separatorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	separatorStyle := lipgloss.NewStyle().Foreground(colTextDim)
 	bottomSection.WriteString(separatorStyle.Render(strings.Repeat("─", 20)))
 	bottomSection.WriteString("\n")
 	scrubberContent := fmt.Sprintf("Time: %.6fs", m.currentTime)
@@ -2725,31 +2725,31 @@ func (m model) View() string {
 func (m model) renderFilterPopup(baseView string) string {
 	popupStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("39")).
+		BorderForeground(colAccent).
 		Padding(1, 2).
 		Width(90)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("39")).
+		Foreground(colAccent).
 		Underline(true)
 
 	categoryStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("46"))
+		Foreground(colOk)
 
 	categorySelectedStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("226"))
+		Foreground(colSelected)
 
 	normalStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("252"))
+		Foreground(colText)
 
 	grayedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240"))
+		Foreground(colTextDim)
 
 	selectedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("226")).
+		Foreground(colSelected).
 		Bold(true)
 
 	var content strings.Builder
@@ -2840,7 +2840,7 @@ func (m model) renderFilterPopup(baseView string) string {
 					if i == m.filterRawSelectedIndex && !m.filterRawInputActive {
 						if m.filterRawDisabled[i] {
 							// Selected but disabled - show in grayed selected style
-							filterStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Bold(true)
+							filterStyle = lipgloss.NewStyle().Foreground(colTextDim).Bold(true)
 						} else {
 							filterStyle = selectedStyle
 						}
@@ -3001,27 +3001,27 @@ func (m model) renderFilterPopup(baseView string) string {
 func (m model) renderFilterTimeRangePopup(baseView string) string {
 	popupStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("39")).
+		BorderForeground(colAccent).
 		Padding(1, 2).
 		Width(60)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("39"))
+		Foreground(colAccent)
 
 	labelStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("252"))
+		Foreground(colText)
 
 	selectedLabelStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("226")).
+		Foreground(colSelected).
 		Bold(true)
 
 	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("241")).
+		Foreground(colTextMuted).
 		MarginTop(1)
 
 	rangeStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("243")).
+		Foreground(colTextSecondary).
 		Italic(true)
 
 	var content strings.Builder
@@ -3063,36 +3063,36 @@ func (m model) renderFilterTimeRangePopup(baseView string) string {
 func (m model) renderMachineSelectionPopup(baseView string) string {
 	popupStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("39")).
+		BorderForeground(colAccent).
 		Padding(1, 2).
 		Width(90).
 		MaxHeight(m.height - 4)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("39")).
+		Foreground(colAccent).
 		Underline(true)
 
 	dcHeaderStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("33"))
+		Foreground(colDCHeader)
 
 	testerHeaderStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("135"))
+		Foreground(colTester)
 
 	normalStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("252"))
+		Foreground(colText)
 
 	selectedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("226")).
+		Foreground(colSelected).
 		Bold(true)
 
 	checkedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("46"))
+		Foreground(colOk)
 
 	roleStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240"))
+		Foreground(colTextDim)
 
 	var content strings.Builder
 	content.WriteString(titleStyle.Render("Select Machines"))
@@ -3250,21 +3250,21 @@ func (m model) renderMachineSelectionPopup(baseView string) string {
 func (m model) renderTypeSearchPopup(baseView string) string {
 	popupStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("39")).
+		BorderForeground(colAccent).
 		Padding(1, 2).
 		Width(70).
 		MaxHeight(m.height - 4)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("39")).
+		Foreground(colAccent).
 		Underline(true)
 
 	normalStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("252"))
+		Foreground(colText)
 
 	selectedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("226")).
+		Foreground(colSelected).
 		Bold(true)
 
 	var content strings.Builder
@@ -3669,34 +3669,34 @@ func (m *model) collectConnectionMetrics() []ConnectionMetric {
 func (m model) renderHealthPopup(baseView string) string {
 	popupStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("39")).
+		BorderForeground(colAccent).
 		Padding(1, 2).
 		MaxWidth(m.width - 4).
 		MaxHeight(m.height - 4)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("39")).
+		Foreground(colAccent).
 		Underline(true)
 
 	sectionStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("46")).
+		Foreground(colOk).
 		MarginTop(1)
 
 	headerStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("33")).
+		Foreground(colDCHeader).
 		Bold(true)
 
 	normalStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("252"))
+		Foreground(colText)
 
 	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("241")).
+		Foreground(colTextMuted).
 		MarginTop(1)
 
 	scrollIndicatorStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
+		Foreground(colTextDim).
 		Italic(true)
 
 	var content strings.Builder
@@ -3927,25 +3927,25 @@ func truncateAddr(addr string, maxLen int) string {
 func (m model) renderHelpPopup(baseView string) string {
 	popupStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("39")).
+		BorderForeground(colAccent).
 		Padding(1, 2).
 		Width(80)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("39")).
+		Foreground(colAccent).
 		Underline(true)
 
 	sectionStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("46")).
+		Foreground(colOk).
 		MarginTop(1)
 
 	commandStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("252"))
+		Foreground(colText)
 
 	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("241")).
+		Foreground(colTextMuted).
 		MarginTop(1)
 
 	var content strings.Builder
@@ -4080,20 +4080,20 @@ func (m model) renderHelpPopup(baseView string) string {
 func (m model) renderNoConfigPopup(baseView string) string {
 	popupStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("39")).
+		BorderForeground(colAccent).
 		Padding(1, 2).
 		Width(50)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("39"))
+		Foreground(colAccent)
 
 	messageStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("243")).
+		Foreground(colTextSecondary).
 		MarginTop(1)
 
 	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("241")).
+		Foreground(colTextMuted).
 		MarginTop(1)
 
 	popupContent := titleStyle.Render("DB Config") + "\n" +
@@ -4110,24 +4110,24 @@ func (m model) renderNoConfigPopup(baseView string) string {
 func (m model) renderConfigPopup(baseView string, config *DBConfig) string {
 	popupStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("39")).
+		BorderForeground(colAccent).
 		Padding(1, 2).
 		MaxWidth(m.width - 10).
 		MaxHeight(m.height - 4)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("39"))
+		Foreground(colAccent)
 
 	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("241")).
+		Foreground(colTextMuted).
 		MarginTop(1)
 
 	jsonStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("252"))
+		Foreground(colText)
 
 	scrollIndicatorStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240")).
+		Foreground(colTextDim).
 		Italic(true)
 
 	// Pretty-print the JSON
@@ -4208,24 +4208,24 @@ func (m model) renderConfigPopup(baseView string, config *DBConfig) string {
 func (m model) renderTimeInputPopup(baseView string) string {
 	popupStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("39")).
+		BorderForeground(colAccent).
 		Padding(1, 2).
 		Width(50)
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("39"))
+		Foreground(colAccent)
 
 	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("241")).
+		Foreground(colTextMuted).
 		MarginTop(1)
 
 	errorStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("196")).
+		Foreground(colError).
 		MarginTop(1)
 
 	rangeStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("243")).
+		Foreground(colTextSecondary).
 		Italic(true)
 
 	// Validate the current input
@@ -4238,7 +4238,7 @@ func (m model) renderTimeInputPopup(baseView string) string {
 		} else if targetTime > m.traceData.MaxTime {
 			validationMsg = errorStyle.Render(fmt.Sprintf("✗ Time must be <= %.2f", m.traceData.MaxTime))
 		} else {
-			validationMsg = lipgloss.NewStyle().Foreground(lipgloss.Color("46")).Render("✓ Valid")
+			validationMsg = lipgloss.NewStyle().Foreground(colOk).Render("✓ Valid")
 		}
 	}
 


### PR DESCRIPTION
The replay tool's colors are unreadable on a light terminal. Screenshot of what it looks like over ssh + tmux on a light background: body text and most attribute values are simply invisible.

The cause is that all 120 color indices in `ui.go` were picked against a dark background. Body text was color 252, a near-white, so on a light background it disappears. Same story for the saturated green and yellow accents, and for the dark olive highlight behind the current line.

So all the colors now live in one place, `palette.go`, as `lipgloss.AdaptiveColor` with a light and a dark variant, named for what they're for instead of what number they are. lipgloss resolves those at render time so there's no init-order concern. The gray ramp is inverted between the two variants, since on a dark background prominence comes from being brighter and on a light one from being darker. Two colors are the same in both variants on purpose - the network highlight sets its own foreground, and black on yellow is fine either way.

Detection alone doesn't fix it. lipgloss figures out the background by asking the terminal (OSC 11), and that query is unreliable through tmux and over ssh. When it fails it assumes dark, which is exactly the broken case. So `REPLAY_THEME=light|dark` overrides it:

```bash
REPLAY_THEME=light replay
```

That also marks the background explicit, which skips the query entirely. Worth having on its own - I watched the tool sit there emitting `\e]10;?` and hang until timeout in an environment with nothing to answer it.

Testing - no core FDB change, so nothing to run in simulation. `go build` and `go vet` clean, `gofmt -l` reports the same files as before (`trace.go` and `ui.go` were already non-conforming on main, I didn't reformat them to keep the diff readable).

Added `palette_test.go`, which is the first test in `contrib/replay`. It checks that each color actually changes with the background, that the two background-independent ones don't, that `REPLAY_THEME` beats detection, and that rendering the real view emits different codes under each setting. That last one is the useful one - it confirms the near-white body text is gone on light:

```
dark-only codes : [38;5;240 38;5;241 38;5;252 38;5;46]
light-only codes: [38;5;235 38;5;243 38;5;245 38;5;28]
```

Note this touches `ui.go` in a lot of places, so it will conflict with #13821. Happy to rebase whichever lands second - #13821 adds no new color call sites, so the overlap is mechanical.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
