### PR TITLE
[release-7.4] Downgrade RocksDB from 8.11.5 to 8.11.4

### DIFF
--- a/cmake/RocksDBVersion.cmake
+++ b/cmake/RocksDBVersion.cmake
@@ -16,8 +16,8 @@
 # OPTION 1: RocksDB Release Number
 # If you use this option, make sure Option 2 below is commented out.
 ###############################################################################
-set(ROCKSDB_VERSION "8.11.5")
-set(ROCKSDB_VERSION_SHA256 "2641eb63ee2d691c0e96de0a55edfcc4cab181d9b6c31fa4a33c478423062196")
+set(ROCKSDB_VERSION "8.11.4")
+set(ROCKSDB_VERSION_SHA256 "1b84c7d7214360fd536349917c57ebd5030d5b4fc214a343ba628b0c6e3d2711")
 
 ###############################################################################
 # OPTION 2: RocksDB Git Commit Hash


### PR DESCRIPTION
As title.

Tarball SHA256 verified with:
  curl -sL https://github.com/facebook/rocksdb/archive/refs/tags/v8.11.4.tar.gz | sha256sum
  1b84c7d7214360fd536349917c57ebd5030d5b4fc214a343ba628b0c6e3d2711

Ran 100K simulation tests:

  20260807-233630-praza-rocksdb-8.11.4-7.4-13-874c04563f5558af compressed=True data_size=40517322 duration=3722072 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:44:44 sanity=False started=100000 stopped=20260808-002114 submitted=20260807-233630 timeout=5400 username=praza-rocksdb-8.11.4-7.4-13208e111c432b48824d200a2dd112e25084349d
