### PR TITLE
Docker: Pass args to `fdb.bash` through to `fdbserver`

### DIFF
--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -65,4 +65,5 @@ source /var/fdb/.fdbenv
 echo "Starting FDB server on $PUBLIC_IP:$FDB_PORT"
 fdbserver --listen-address 0.0.0.0:"$FDB_PORT" --public-address "$PUBLIC_IP:$FDB_PORT" \
     --datadir /var/fdb/data --logdir /var/fdb/logs \
-    --locality-zoneid="$(hostname)" --locality-machineid="$(hostname)" --class "$FDB_PROCESS_CLASS" --knob_disable_posix_kernel_aio=1
+    --locality-zoneid="$(hostname)" --locality-machineid="$(hostname)" --class "$FDB_PROCESS_CLASS" --knob_disable_posix_kernel_aio=1 \
+    "$@"


### PR DESCRIPTION
Arguments given to `fdb.bash` were previously discarded, preventing knobs on `fdbserver` from being tuned. This adds the full list of args to `fdb.bash` to the call for `fdbserver`.