### PR TITLE
Docker: Allow `fdb.bash` to use existing clusterfile

### DIFF
--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -39,9 +39,6 @@ function create_cluster_file() {
             echo "Overwriting existing clusterfile." 1>&2
         fi
         echo "$FDB_CLUSTER_FILE_CONTENTS" > "$FDB_CLUSTER_FILE"
-    elif [[ ! -r "$FDB_CLUSTER_FILE" ]]; then
-        echo "FDB_CLUSTER_FILE_CONTENTS and FDB_COORDINATOR are not set, and no clusterfile at \"$FDB_CLUSTER_FILE\"." 1>&2
-        exit 1
     elif [[ ! -w "$FDB_CLUSTER_FILE" ]]; then
         # fdbserver requires write permissions to clusterfile, or it may *eventually* fail due to cluster migrations.
         # https://apple.github.io/foundationdb/administration.html#required-permissions

--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -27,7 +27,7 @@ function create_cluster_file() {
 
     if [[ -n "$FDB_CLUSTER_FILE_CONTENTS" || -n "$FDB_COORDINATOR" ]]; then
         if [[ -f "$FDB_CLUSTER_FILE" && (! -w  "$FDB_CLUSTER_FILE") ]]; then
-            echo "Clusterfile to be overwritten at \"$FDB_CLUSTER_FILE\" already exists but is read-only." 1>&2
+            echo "Clusterfile to be overwritten at \"$FDB_CLUSTER_FILE\" is read-only." 1>&2
             exit 1
         elif [[ -r "$FDB_CLUSTER_FILE" ]]; then
             echo "Overwriting existing clusterfile." 1>&2

--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -42,6 +42,11 @@ function create_cluster_file() {
     elif [[ ! -r "$FDB_CLUSTER_FILE" ]]; then
         echo "FDB_CLUSTER_FILE_CONTENTS and FDB_COORDINATOR are not set, and no clusterfile at \"$FDB_CLUSTER_FILE\"." 1>&2
         exit 1
+    elif [[ ! -w "$FDB_CLUSTER_FILE" ]]; then
+        # fdbserver requires write permissions to clusterfile, or it may *eventually* fail due to cluster migrations.
+        # https://apple.github.io/foundationdb/administration.html#required-permissions
+        echo "Clusterfile at \"$FDB_CLUSTER_FILE\" is not writable." 1>&2
+        exit 1
     else
         echo "Using existing clusterfile at \"$FDB_CLUSTER_FILE\"." 1>&2
     fi

--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -27,10 +27,10 @@ function create_cluster_file() {
 
     if [[ -n "$FDB_CLUSTER_FILE_CONTENTS" || -n "$FDB_COORDINATOR" ]]; then
         if [[ ! -w  "$FDB_CLUSTER_FILE" ]]; then
-            echo "Clusterfile to be overwritten at \"$FDB_CLUSTER_FILE\" already exists but is read-only."
+            echo "Clusterfile to be overwritten at \"$FDB_CLUSTER_FILE\" already exists but is read-only." 1>&2
             exit 1
         elif [[ -r "$FDB_CLUSTER_FILE" ]]; then
-            echo "Overwriting existing clusterfile."
+            echo "Overwriting existing clusterfile." 1>&2
         fi
     fi
 
@@ -48,7 +48,7 @@ function create_cluster_file() {
         echo "FDB_CLUSTER_FILE_CONTENTS and FDB_COORDINATOR are not set, and no clusterfile at \"$FDB_CLUSTER_FILE\"." 1>&2
         exit 1
     else
-        echo "Using existing clusterfile at \"$FDB_CLUSTER_FILE\"."
+        echo "Using existing clusterfile at \"$FDB_CLUSTER_FILE\"." 1>&2
     fi
 
     if (( $? != 0 )); then
@@ -72,7 +72,7 @@ function create_server_environment() {
     echo "export PUBLIC_IP=$public_ip" > $env_file
     # Set default cluster file contents only if no other configuration is specified.
     if [[ (! -s "$FDB_CLUSTER_FILE") && -z "$FDB_CLUSTER_FILE_CONTENTS" && -z "$FDB_COORDINATOR" ]]; then
-        echo "Warning: No configuration available, falling back to self-coordinated."
+        echo "Warning: No configuration available, falling back to self-coordinated." 1>&2
         FDB_CLUSTER_FILE_CONTENTS="docker:docker@$public_ip:$FDB_PORT"
     fi
 

--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -24,6 +24,16 @@ function create_cluster_file() {
     FDB_CLUSTER_FILE=${FDB_CLUSTER_FILE:-/etc/foundationdb/fdb.cluster}
     mkdir -p "$(dirname $FDB_CLUSTER_FILE)"
 
+
+    if [[ -n "$FDB_CLUSTER_FILE_CONTENTS" || -n "$FDB_COORDINATOR" ]]; then
+        if [[ ! -w  "$FDB_CLUSTER_FILE" ]]; then
+            echo "Clusterfile to be overwritten at \"$FDB_CLUSTER_FILE\" already exists but is read-only."
+            exit 1
+        elif [[ -r "$FDB_CLUSTER_FILE" ]]; then
+            echo "Overwriting existing clusterfile."
+        fi
+    fi
+
     if [[ -n "$FDB_CLUSTER_FILE_CONTENTS" ]]; then
         echo "$FDB_CLUSTER_FILE_CONTENTS" > "$FDB_CLUSTER_FILE"
     elif [[ -n $FDB_COORDINATOR ]]; then
@@ -34,8 +44,15 @@ function create_cluster_file() {
         fi
         coordinator_port=${FDB_COORDINATOR_PORT:-4500}
         echo "docker:docker@$coordinator_ip:$coordinator_port" > "$FDB_CLUSTER_FILE"
+    elif [[ ! -r "$FDB_CLUSTER_FILE" ]]; then
+        echo "FDB_CLUSTER_FILE_CONTENTS and FDB_COORDINATOR are not set, and no clusterfile at \"$FDB_CLUSTER_FILE\"." 1>&2
+        exit 1
     else
-        echo "FDB_COORDINATOR environment variable not defined" 1>&2
+        echo "Using existing clusterfile at \"$FDB_CLUSTER_FILE\"."
+    fi
+
+    if (( $? != 0 )); then
+        echo "An unexpected error occurred while setting configuration." 1>&2
         exit 1
     fi
 }
@@ -53,7 +70,9 @@ function create_server_environment() {
     fi
 
     echo "export PUBLIC_IP=$public_ip" > $env_file
-    if [[ -z $FDB_COORDINATOR && -z "$FDB_CLUSTER_FILE_CONTENTS" ]]; then
+    # Set default cluster file contents only if no other configuration is specified.
+    if [[ (! -s "$FDB_CLUSTER_FILE") && -z "$FDB_CLUSTER_FILE_CONTENTS" && -z "$FDB_COORDINATOR" ]]; then
+        echo "Warning: No configuration available, falling back to self-coordinated."
         FDB_CLUSTER_FILE_CONTENTS="docker:docker@$public_ip:$FDB_PORT"
     fi
 

--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -26,7 +26,7 @@ function create_cluster_file() {
 
 
     if [[ -n "$FDB_CLUSTER_FILE_CONTENTS" || -n "$FDB_COORDINATOR" ]]; then
-        if [[ ! -w  "$FDB_CLUSTER_FILE" ]]; then
+        if [[ -f "$FDB_CLUSTER_FILE" && (! -w  "$FDB_CLUSTER_FILE") ]]; then
             echo "Clusterfile to be overwritten at \"$FDB_CLUSTER_FILE\" already exists but is read-only." 1>&2
             exit 1
         elif [[ -r "$FDB_CLUSTER_FILE" ]]; then

--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -24,26 +24,21 @@ function create_cluster_file() {
     FDB_CLUSTER_FILE=${FDB_CLUSTER_FILE:-/etc/foundationdb/fdb.cluster}
     mkdir -p "$(dirname $FDB_CLUSTER_FILE)"
 
-
-    if [[ -n "$FDB_CLUSTER_FILE_CONTENTS" || -n "$FDB_COORDINATOR" ]]; then
-        if [[ -f "$FDB_CLUSTER_FILE" && (! -w  "$FDB_CLUSTER_FILE") ]]; then
-            echo "Clusterfile to be overwritten at \"$FDB_CLUSTER_FILE\" is read-only." 1>&2
-            exit 1
-        elif [[ -r "$FDB_CLUSTER_FILE" ]]; then
-            echo "Overwriting existing clusterfile." 1>&2
-        fi
-    fi
-
-    if [[ -n "$FDB_CLUSTER_FILE_CONTENTS" ]]; then
-        echo "$FDB_CLUSTER_FILE_CONTENTS" > "$FDB_CLUSTER_FILE"
-    elif [[ -n $FDB_COORDINATOR ]]; then
+    if [[ -n $FDB_COORDINATOR ]]; then
         coordinator_ip=$(dig +short "$FDB_COORDINATOR")
         if [[ -z "$coordinator_ip" ]]; then
             echo "Failed to look up coordinator address for $FDB_COORDINATOR" 1>&2
             exit 1
         fi
         coordinator_port=${FDB_COORDINATOR_PORT:-4500}
-        echo "docker:docker@$coordinator_ip:$coordinator_port" > "$FDB_CLUSTER_FILE"
+        FDB_CLUSTER_FILE_CONTENTS="docker:docker@$coordinator_ip:$coordinator_port"
+    fi
+
+    if [[ -n "$FDB_CLUSTER_FILE_CONTENTS" ]]; then
+        if [[ -w "$FDB_CLUSTER_FILE" ]]; then
+            echo "Overwriting existing clusterfile." 1>&2
+        fi
+        echo "$FDB_CLUSTER_FILE_CONTENTS" > "$FDB_CLUSTER_FILE"
     elif [[ ! -r "$FDB_CLUSTER_FILE" ]]; then
         echo "FDB_CLUSTER_FILE_CONTENTS and FDB_COORDINATOR are not set, and no clusterfile at \"$FDB_CLUSTER_FILE\"." 1>&2
         exit 1
@@ -52,7 +47,7 @@ function create_cluster_file() {
     fi
 
     if (( $? != 0 )); then
-        echo "An unexpected error occurred while setting configuration." 1>&2
+        echo "Unable to write to FDB_CLUSTER_FILE." 1>&2
         exit 1
     fi
 }


### PR DESCRIPTION
The final split up part of #13822, huzzah.

# Changes
## `fdb.bash` will use an existing clusterfile under certain conditions
### Issue
Every time the docker image is launched, the clusterfile specified at `FDB_CLUSTER_FILE` is always written to (whether by the `FDB_COORDINATOR` name resolution or the `FDB_CLUSTER_FILE_CONTENTS` env variable.) This means the file cannot be externally managed, nor mounted from a secret directly if desired.

### New Behavior
If neither `FDB_COORDINATOR` nor `FDB_CLUSTER_FILE_CONTENTS` are not set, _and_ the clusterfile at `FDB_CLUSTER_FILE` is nonempty, the existing clusterfile will be used.

Otherwise, the clusterfile will be overwritten with the result of `FDB_COORDINATOR` resolution or with `FDB_CLUSTER_FILE_CONTENTS` as before. This should preserve the functionality of existing deployments.

## New error or warning messages
### Rationale
In line with the new behavior, new status messages were added!
### New Messages
- If no configuration was specified (empty `FDB_CLUSTER_FILE`, unset `FDB_CLUSTER_FILE_CONTENTS` and `FDB_COORDINATOR`), a warning is displayed before setting `FDB_CLUSTER_FILE_CONTENTS` to the fallback `docker:docker@$public_ip:$FDB_PORT`
- If an existing clusterfile is being overwritten, a warning is displayed.
- If an existing clusterfile _would_ be overwritten, but is unwritable, an error saying such is displayed.
- If `create_cluster_file` would end with a nonzero exit code from the last command, an error is displayed.
  - I would expect that this could happen if bash's `-w` test doesn't consider SELinux labels. An improperly labeled volume could conceivably have write permissions but be labeled as private.