### PR TITLE
Mark satellite router placement test workers verified

### DIFF
--- a/fdbserver/clustercontroller/ClusterController.actor.cpp
+++ b/fdbserver/clustercontroller/ClusterController.actor.cpp
@@ -3898,6 +3898,7 @@ TEST_CASE("/fdbserver/clustercontroller/avoidSatelliteTLogRouterColocation") {
 		WorkerInterface worker(locality);
 		worker.initEndpoints();
 		auto& workerInfo = data.id_worker[locality.processId()];
+		workerInfo.verified = true;
 		workerInfo.details.interf = worker;
 		workerInfo.details.processClass = ProcessClass(classType, ProcessClass::CommandLineSource);
 		workerInfo.details.recoveredDiskFiles = true;


### PR DESCRIPTION
## Summary

- Mark synthetic workers in `/fdbserver/clustercontroller/avoidSatelliteTLogRouterColocation` as verified before remote recruitment.
- Preserve verified-worker recruitment and all existing assertions that log routers avoid satellite TLog workers.

## Validation

- Focused cluster-controller regression and the complete `fdbserver_clustercontroller_test` suite passed.
- All four original `tests/rare/SpecificUnitTests.toml` and `tests/fast/RandomUnitTests.toml` configurations passed with fault injection enabled.
