### PR TITLE
Convert `ClusterController` actors to standard coroutines

### DIFF
--- a/fdbserver/clustercontroller/ClusterController.cpp
+++ b/fdbserver/clustercontroller/ClusterController.cpp
@@ -320,7 +320,7 @@ Future<Void> recruitFailedLogRouters(ClusterControllerData* cluster,
                                      Reference<LogSystem> logSystem,
                                      LogSystemConfig config) {
 	Optional<Key> targetDcId =
-	    db->recoveryData->remoteDcIds.size() ? db->recoveryData->remoteDcIds[0] : Optional<Key>();
+	    !db->recoveryData->remoteDcIds.empty() ? db->recoveryData->remoteDcIds[0] : Optional<Key>();
 
 	// Use getWorkersForRoleInDatacenter to get workers for all log routers at once
 	std::map<Optional<Standalone<StringRef>>, int> id_used;
@@ -368,7 +368,7 @@ Future<Void> recruitFailedLogRouters(ClusterControllerData* cluster,
 		req.isReplacement = true;
 
 		for (auto& tLogSet : config.tLogs) {
-			if (!tLogSet.isLocal && tLogSet.tLogs.size() > 0) {
+			if (!tLogSet.isLocal && !tLogSet.tLogs.empty()) {
 				req.tLogLocalities = tLogSet.tLogLocalities;
 				req.tLogPolicy = tLogSet.tLogPolicy;
 				break;
@@ -541,7 +541,7 @@ Future<Void> monitorAndRecruitLogRouters(ClusterControllerData* self) {
 		// Find the log set with log routers (should be remote/satellite)
 		int logSetIndex = -1;
 		for (int i = 0; i < config.tLogs.size(); i++) {
-			if (config.tLogs[i].logRouters.size() > 0) {
+			if (!config.tLogs[i].logRouters.empty()) {
 				ASSERT_WE_THINK(logSetIndex == -1); // only one log set should have log routers
 				logSetIndex = i;
 			}
@@ -1909,7 +1909,7 @@ Future<Void> statusServer(FutureStream<StatusRequest> requests,
 
 			for (auto& it : self->id_worker) {
 				workers.push_back(it.second.details);
-				if (it.second.issues.size()) {
+				if (!it.second.issues.empty()) {
 					workerIssues.emplace_back(it.second.details.interf.address(), it.second.issues);
 				}
 			}
@@ -2177,7 +2177,7 @@ Future<Void> monitorGlobalConfig(ClusterControllerData::DBInfo* db) {
 					    co_await tr.getRange(globalConfigHistoryKeys, CLIENT_KNOBS->TOO_MANY);
 					// If the global configuration version key has been set,
 					// the history should contain at least one item.
-					ASSERT(globalConfigHistory.size() > 0);
+					ASSERT(!globalConfigHistory.empty());
 					clientInfo = db->serverInfo->get().client;
 					clientInfo.history.clear();
 
@@ -2210,7 +2210,7 @@ Future<Void> monitorGlobalConfig(ClusterControllerData::DBInfo* db) {
 						clientInfo.history.push_back(std::move(vh));
 					}
 
-					if (clientInfo.history.size() > 0) {
+					if (!clientInfo.history.empty()) {
 						// The first item in the historical list of mutations
 						// is only used to:
 						//   a) Recognize that some historical changes may have
@@ -3134,7 +3134,7 @@ Future<Void> dbInfoUpdater(ClusterControllerData* self) {
 		if (res.index() == 0) {
 			std::vector<Endpoint> notUpdated = std::get<0>(std::move(res));
 			TraceEvent("DBInfoFinishBroadcast", self->id).detail("NotUpdated", notUpdated.size());
-			if (notUpdated.size()) {
+			if (!notUpdated.empty()) {
 				self->updateDBInfoEndpoints.insert(notUpdated.begin(), notUpdated.end());
 				self->updateDBInfo.trigger();
 			}
@@ -3322,102 +3322,6 @@ Future<Void> handleGetEncryptionAtRestMode(ClusterControllerData* self, ClusterC
 	}
 }
 
-Future<Void> handleOpenDatabaseRequests(ClusterControllerData* self, FutureStream<OpenDatabaseRequest> requests) {
-	while (true) {
-		OpenDatabaseRequest req = co_await requests;
-		++self->openDatabaseRequests;
-		self->addActor.send(clusterOpenDatabase(&self->db, req));
-	}
-}
-
-Future<Void> handleRecruitStorageRequests(ClusterControllerData* self, FutureStream<RecruitStorageRequest> requests) {
-	while (true) {
-		RecruitStorageRequest req = co_await requests;
-		clusterRecruitStorage(self, req);
-	}
-}
-
-Future<Void> handleRegisterWorkerRequests(ClusterControllerData* self, FutureStream<RegisterWorkerRequest> requests) {
-	while (true) {
-		RegisterWorkerRequest req = co_await requests;
-		++self->registerWorkerRequests;
-		registerWorker(req, self);
-	}
-}
-
-Future<Void> handleGetWorkersRequests(ClusterControllerData* self, FutureStream<GetWorkersRequest> requests) {
-	while (true) {
-		GetWorkersRequest req = co_await requests;
-		++self->getWorkersRequests;
-		std::vector<WorkerDetails> workers;
-		for (auto const& [id, worker] : self->id_worker) {
-			if ((req.flags & GetWorkersRequest::NON_EXCLUDED_PROCESSES_ONLY) &&
-			    self->db.config.isExcludedServer(worker.details.interf.addresses(), worker.details.interf.locality)) {
-				continue;
-			}
-
-			if ((req.flags & GetWorkersRequest::TESTER_CLASS_ONLY) &&
-			    worker.details.processClass.classType() != ProcessClass::TesterClass) {
-				continue;
-			}
-
-			workers.push_back(worker.details);
-		}
-		req.reply.send(workers);
-	}
-}
-
-Future<Void> handleGetClientWorkersRequests(ClusterControllerData* self,
-                                            FutureStream<GetClientWorkersRequest> requests) {
-	while (true) {
-		GetClientWorkersRequest req = co_await requests;
-		++self->getClientWorkersRequests;
-		std::vector<ClientWorkerInterface> workers;
-		for (auto& it : self->id_worker) {
-			if (it.second.details.processClass.classType() != ProcessClass::TesterClass) {
-				workers.push_back(it.second.details.interf.clientInterface);
-			}
-		}
-		req.reply.send(workers);
-	}
-}
-
-Future<Void> sendCoordinationPings(ClusterControllerData* self, Future<Void> coordinationPingDelay) {
-	uint64_t step = 0;
-	while (true) {
-		co_await coordinationPingDelay;
-		CoordinationPingMessage message(self->id, step++);
-		for (auto& it : self->id_worker)
-			it.second.details.interf.coordinationPing.send(message);
-		coordinationPingDelay = delay(SERVER_KNOBS->WORKER_COORDINATION_PING_DELAY);
-		TraceEvent("CoordinationPingSent", self->id).detail("TimeStep", message.timeStep);
-	}
-}
-
-Future<Void> handleUpdateWorkerHealthRequests(ClusterControllerData* self,
-                                              FutureStream<UpdateWorkerHealthRequest> requests) {
-	while (true) {
-		UpdateWorkerHealthRequest req = co_await requests;
-		if (SERVER_KNOBS->CC_ENABLE_WORKER_HEALTH_MONITOR) {
-			self->updateWorkerHealth(req);
-		}
-	}
-}
-
-Future<Void> handleGetServerDBInfoRequests(ClusterControllerData* self, FutureStream<GetServerDBInfoRequest> requests) {
-	while (true) {
-		GetServerDBInfoRequest req = co_await requests;
-		self->addActor.send(clusterGetServerInfo(&self->db, req.knownServerInfoID, req.reply));
-	}
-}
-
-Future<Void> handleClusterControllerPings(FutureStream<ReplyPromise<Void>> pings) {
-	while (true) {
-		ReplyPromise<Void> ping = co_await pings;
-		ping.send(Void());
-	}
-}
-
 Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
                                    Future<Void> leaderFail,
                                    ServerCoordinators coordinators,
@@ -3425,6 +3329,7 @@ Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
                                    Reference<AsyncVar<Optional<UID>>> clusterId) {
 	ClusterControllerData self(interf, locality, coordinators, clusterId);
 	Future<Void> coordinationPingDelay = delay(SERVER_KNOBS->WORKER_COORDINATION_PING_DELAY);
+	uint64_t step = 0;
 	Future<ErrorOr<Void>> error = errorOr(actorCollection(self.addActor.getFuture()));
 
 	self.addActor.send(clusterWatchDatabase(&self, &self.db, coordinators)); // Start the master database
@@ -3470,34 +3375,92 @@ Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
 		self.addActor.send(monitorAndRecruitLogRouters(&self));
 	}
 
-	// Request-handler failures must propagate from the controller rather than becoming background-actor errors.
-	Future<Void> dispatch = waitForAll(std::vector<Future<Void>>{
-	    handleOpenDatabaseRequests(&self, interf.clientInterface.openDatabase.getFuture()),
-	    handleRecruitStorageRequests(&self, interf.recruitStorage.getFuture()),
-	    handleRegisterWorkerRequests(&self, interf.registerWorker.getFuture()),
-	    handleGetWorkersRequests(&self, interf.getWorkers.getFuture()),
-	    handleGetClientWorkersRequests(&self, interf.clientInterface.getClientWorkers.getFuture()),
-	    sendCoordinationPings(&self, std::move(coordinationPingDelay)),
-	    handleUpdateWorkerHealthRequests(&self, interf.updateWorkerHealth.getFuture()),
-	    handleGetServerDBInfoRequests(&self, interf.getServerDBInfo.getFuture()),
-	    handleClusterControllerPings(interf.clientInterface.ping.getFuture()),
-	});
+	while (true) {
+		auto res = co_await race(error,
+		                         interf.clientInterface.openDatabase.getFuture(),
+		                         interf.recruitStorage.getFuture(),
+		                         interf.registerWorker.getFuture(),
+		                         interf.getWorkers.getFuture(),
+		                         interf.clientInterface.getClientWorkers.getFuture(),
+		                         coordinationPingDelay,
+		                         interf.updateWorkerHealth.getFuture(),
+		                         interf.getServerDBInfo.getFuture(),
+		                         leaderFail,
+		                         interf.clientInterface.ping.getFuture());
+		if (res.index() == 0) {
+			ErrorOr<Void> err = std::get<0>(res);
+			if (err.isError() && err.getError().code() != error_code_restart_cluster_controller) {
+				endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Stop Received Error", false, err.getError());
+			} else {
+				endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Stop Received Signal", true);
+			}
 
-	auto res = co_await race(error, dispatch, leaderFail);
-	if (res.index() == 0) {
-		ErrorOr<Void> err = std::get<0>(std::move(res));
-		if (err.isError() && err.getError().code() != error_code_restart_cluster_controller) {
-			endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Stop Received Error", false, err.getError());
-		} else {
-			endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Stop Received Signal", true);
+			// We shut down normally even if there was a serious error (so this fdbserver may be re-elected
+			// cluster controller)
+			co_return;
+		} else if (res.index() == 1) {
+			OpenDatabaseRequest req = std::get<1>(std::move(res));
+			++self.openDatabaseRequests;
+			self.addActor.send(clusterOpenDatabase(&self.db, req));
+		} else if (res.index() == 2) {
+			RecruitStorageRequest req = std::get<2>(std::move(res));
+			clusterRecruitStorage(&self, req);
+		} else if (res.index() == 3) {
+			RegisterWorkerRequest req = std::get<3>(std::move(res));
+			++self.registerWorkerRequests;
+			registerWorker(req, &self);
+		} else if (res.index() == 4) {
+			GetWorkersRequest req = std::get<4>(std::move(res));
+			++self.getWorkersRequests;
+			std::vector<WorkerDetails> workers;
+			for (auto const& [id, worker] : self.id_worker) {
+				if ((req.flags & GetWorkersRequest::NON_EXCLUDED_PROCESSES_ONLY) &&
+				    self.db.config.isExcludedServer(worker.details.interf.addresses(),
+				                                    worker.details.interf.locality)) {
+					continue;
+				}
+
+				if ((req.flags & GetWorkersRequest::TESTER_CLASS_ONLY) &&
+				    worker.details.processClass.classType() != ProcessClass::TesterClass) {
+					continue;
+				}
+
+				workers.push_back(worker.details);
+			}
+			req.reply.send(workers);
+		} else if (res.index() == 5) {
+			GetClientWorkersRequest req = std::get<5>(std::move(res));
+			++self.getClientWorkersRequests;
+			std::vector<ClientWorkerInterface> workers;
+			for (auto& it : self.id_worker) {
+				if (it.second.details.processClass.classType() != ProcessClass::TesterClass) {
+					workers.push_back(it.second.details.interf.clientInterface);
+				}
+			}
+			req.reply.send(workers);
+		} else if (res.index() == 6) {
+			CoordinationPingMessage message(self.id, step++);
+			for (auto& it : self.id_worker)
+				it.second.details.interf.coordinationPing.send(message);
+			coordinationPingDelay = delay(SERVER_KNOBS->WORKER_COORDINATION_PING_DELAY);
+			TraceEvent("CoordinationPingSent", self.id).detail("TimeStep", message.timeStep);
+		} else if (res.index() == 7) {
+			UpdateWorkerHealthRequest req = std::get<7>(std::move(res));
+			if (SERVER_KNOBS->CC_ENABLE_WORKER_HEALTH_MONITOR) {
+				self.updateWorkerHealth(req);
+			}
+		} else if (res.index() == 8) {
+			GetServerDBInfoRequest req = std::get<8>(std::move(res));
+			self.addActor.send(clusterGetServerInfo(&self.db, req.knownServerInfoID, req.reply));
+		} else if (res.index() == 9) {
+			// We are no longer the leader if this has changed.
+			endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Leader Replaced", true);
+			CODE_PROBE(true, "Leader replaced");
+			co_return;
+		} else if (res.index() == 10) {
+			ReplyPromise<Void> ping = std::get<10>(std::move(res));
+			ping.send(Void());
 		}
-
-		// We shut down normally even if there was a serious error (so this fdbserver may be re-elected
-		// cluster controller)
-	} else if (res.index() == 2) {
-		// We are no longer the leader if this has changed.
-		endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Leader Replaced", true);
-		CODE_PROBE(true, "Leader replaced");
 	}
 }
 
@@ -3548,17 +3511,18 @@ Future<Void> clusterController(ServerCoordinators coordinators,
 				co_await clusterControllerCore(cci, leaderFail, coordinators, locality, clusterId);
 			}
 		} catch (Error& e) {
-			if (inRole)
+			if (inRole) {
 				endRole(Role::CLUSTER_CONTROLLER,
 				        cci.id(),
 				        "Error",
 				        e.code() == error_code_actor_cancelled || e.code() == error_code_coordinators_changed,
 				        e);
-			else
+			} else {
 				TraceEvent(e.code() == error_code_coordinators_changed ? SevInfo : SevError,
 				           "ClusterControllerCandidateError",
 				           cci.id())
 				    .error(e);
+			}
 			throw;
 		}
 	}

--- a/fdbserver/clustercontroller/ClusterController.cpp
+++ b/fdbserver/clustercontroller/ClusterController.cpp
@@ -3323,6 +3323,102 @@ Future<Void> handleGetEncryptionAtRestMode(ClusterControllerData* self, ClusterC
 	}
 }
 
+Future<Void> handleOpenDatabaseRequests(ClusterControllerData* self, FutureStream<OpenDatabaseRequest> requests) {
+	while (true) {
+		OpenDatabaseRequest req = co_await requests;
+		++self->openDatabaseRequests;
+		self->addActor.send(clusterOpenDatabase(&self->db, req));
+	}
+}
+
+Future<Void> handleRecruitStorageRequests(ClusterControllerData* self, FutureStream<RecruitStorageRequest> requests) {
+	while (true) {
+		RecruitStorageRequest req = co_await requests;
+		clusterRecruitStorage(self, req);
+	}
+}
+
+Future<Void> handleRegisterWorkerRequests(ClusterControllerData* self, FutureStream<RegisterWorkerRequest> requests) {
+	while (true) {
+		RegisterWorkerRequest req = co_await requests;
+		++self->registerWorkerRequests;
+		registerWorker(req, self);
+	}
+}
+
+Future<Void> handleGetWorkersRequests(ClusterControllerData* self, FutureStream<GetWorkersRequest> requests) {
+	while (true) {
+		GetWorkersRequest req = co_await requests;
+		++self->getWorkersRequests;
+		std::vector<WorkerDetails> workers;
+		for (auto const& [id, worker] : self->id_worker) {
+			if ((req.flags & GetWorkersRequest::NON_EXCLUDED_PROCESSES_ONLY) &&
+			    self->db.config.isExcludedServer(worker.details.interf.addresses(), worker.details.interf.locality)) {
+				continue;
+			}
+
+			if ((req.flags & GetWorkersRequest::TESTER_CLASS_ONLY) &&
+			    worker.details.processClass.classType() != ProcessClass::TesterClass) {
+				continue;
+			}
+
+			workers.push_back(worker.details);
+		}
+		req.reply.send(workers);
+	}
+}
+
+Future<Void> handleGetClientWorkersRequests(ClusterControllerData* self,
+                                            FutureStream<GetClientWorkersRequest> requests) {
+	while (true) {
+		GetClientWorkersRequest req = co_await requests;
+		++self->getClientWorkersRequests;
+		std::vector<ClientWorkerInterface> workers;
+		for (auto& it : self->id_worker) {
+			if (it.second.details.processClass.classType() != ProcessClass::TesterClass) {
+				workers.push_back(it.second.details.interf.clientInterface);
+			}
+		}
+		req.reply.send(workers);
+	}
+}
+
+Future<Void> sendCoordinationPings(ClusterControllerData* self, Future<Void> coordinationPingDelay) {
+	uint64_t step = 0;
+	while (true) {
+		co_await coordinationPingDelay;
+		CoordinationPingMessage message(self->id, step++);
+		for (auto& it : self->id_worker)
+			it.second.details.interf.coordinationPing.send(message);
+		coordinationPingDelay = delay(SERVER_KNOBS->WORKER_COORDINATION_PING_DELAY);
+		TraceEvent("CoordinationPingSent", self->id).detail("TimeStep", message.timeStep);
+	}
+}
+
+Future<Void> handleUpdateWorkerHealthRequests(ClusterControllerData* self,
+                                              FutureStream<UpdateWorkerHealthRequest> requests) {
+	while (true) {
+		UpdateWorkerHealthRequest req = co_await requests;
+		if (SERVER_KNOBS->CC_ENABLE_WORKER_HEALTH_MONITOR) {
+			self->updateWorkerHealth(req);
+		}
+	}
+}
+
+Future<Void> handleGetServerDBInfoRequests(ClusterControllerData* self, FutureStream<GetServerDBInfoRequest> requests) {
+	while (true) {
+		GetServerDBInfoRequest req = co_await requests;
+		self->addActor.send(clusterGetServerInfo(&self->db, req.knownServerInfoID, req.reply));
+	}
+}
+
+Future<Void> handleClusterControllerPings(FutureStream<ReplyPromise<Void>> pings) {
+	while (true) {
+		ReplyPromise<Void> ping = co_await pings;
+		ping.send(Void());
+	}
+}
+
 Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
                                    Future<Void> leaderFail,
                                    ServerCoordinators coordinators,
@@ -3330,7 +3426,6 @@ Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
                                    Reference<AsyncVar<Optional<UID>>> clusterId) {
 	ClusterControllerData self(interf, locality, coordinators, clusterId);
 	Future<Void> coordinationPingDelay = delay(SERVER_KNOBS->WORKER_COORDINATION_PING_DELAY);
-	uint64_t step = 0;
 	Future<ErrorOr<Void>> error = errorOr(actorCollection(self.addActor.getFuture()));
 
 	self.addActor.send(clusterWatchDatabase(&self, &self.db, coordinators)); // Start the master database
@@ -3376,92 +3471,34 @@ Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
 		self.addActor.send(monitorAndRecruitLogRouters(&self));
 	}
 
-	while (true) {
-		auto res = co_await race(error,
-		                         interf.clientInterface.openDatabase.getFuture(),
-		                         interf.recruitStorage.getFuture(),
-		                         interf.registerWorker.getFuture(),
-		                         interf.getWorkers.getFuture(),
-		                         interf.clientInterface.getClientWorkers.getFuture(),
-		                         coordinationPingDelay,
-		                         interf.updateWorkerHealth.getFuture(),
-		                         interf.getServerDBInfo.getFuture(),
-		                         leaderFail,
-		                         interf.clientInterface.ping.getFuture());
-		if (res.index() == 0) {
-			ErrorOr<Void> err = std::get<0>(res);
-			if (err.isError() && err.getError().code() != error_code_restart_cluster_controller) {
-				endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Stop Received Error", false, err.getError());
-			} else {
-				endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Stop Received Signal", true);
-			}
+	// Request-handler failures must propagate from the controller rather than becoming background-actor errors.
+	Future<Void> dispatch = waitForAll(std::vector<Future<Void>>{
+	    handleOpenDatabaseRequests(&self, interf.clientInterface.openDatabase.getFuture()),
+	    handleRecruitStorageRequests(&self, interf.recruitStorage.getFuture()),
+	    handleRegisterWorkerRequests(&self, interf.registerWorker.getFuture()),
+	    handleGetWorkersRequests(&self, interf.getWorkers.getFuture()),
+	    handleGetClientWorkersRequests(&self, interf.clientInterface.getClientWorkers.getFuture()),
+	    sendCoordinationPings(&self, std::move(coordinationPingDelay)),
+	    handleUpdateWorkerHealthRequests(&self, interf.updateWorkerHealth.getFuture()),
+	    handleGetServerDBInfoRequests(&self, interf.getServerDBInfo.getFuture()),
+	    handleClusterControllerPings(interf.clientInterface.ping.getFuture()),
+	});
 
-			// We shut down normally even if there was a serious error (so this fdbserver may be re-elected
-			// cluster controller)
-			co_return;
-		} else if (res.index() == 1) {
-			OpenDatabaseRequest req = std::get<1>(std::move(res));
-			++self.openDatabaseRequests;
-			self.addActor.send(clusterOpenDatabase(&self.db, req));
-		} else if (res.index() == 2) {
-			RecruitStorageRequest req = std::get<2>(std::move(res));
-			clusterRecruitStorage(&self, req);
-		} else if (res.index() == 3) {
-			RegisterWorkerRequest req = std::get<3>(std::move(res));
-			++self.registerWorkerRequests;
-			registerWorker(req, &self);
-		} else if (res.index() == 4) {
-			GetWorkersRequest req = std::get<4>(std::move(res));
-			++self.getWorkersRequests;
-			std::vector<WorkerDetails> workers;
-			for (auto const& [id, worker] : self.id_worker) {
-				if ((req.flags & GetWorkersRequest::NON_EXCLUDED_PROCESSES_ONLY) &&
-				    self.db.config.isExcludedServer(worker.details.interf.addresses(),
-				                                    worker.details.interf.locality)) {
-					continue;
-				}
-
-				if ((req.flags & GetWorkersRequest::TESTER_CLASS_ONLY) &&
-				    worker.details.processClass.classType() != ProcessClass::TesterClass) {
-					continue;
-				}
-
-				workers.push_back(worker.details);
-			}
-			req.reply.send(workers);
-		} else if (res.index() == 5) {
-			GetClientWorkersRequest req = std::get<5>(std::move(res));
-			++self.getClientWorkersRequests;
-			std::vector<ClientWorkerInterface> workers;
-			for (auto& it : self.id_worker) {
-				if (it.second.details.processClass.classType() != ProcessClass::TesterClass) {
-					workers.push_back(it.second.details.interf.clientInterface);
-				}
-			}
-			req.reply.send(workers);
-		} else if (res.index() == 6) {
-			CoordinationPingMessage message(self.id, step++);
-			for (auto& it : self.id_worker)
-				it.second.details.interf.coordinationPing.send(message);
-			coordinationPingDelay = delay(SERVER_KNOBS->WORKER_COORDINATION_PING_DELAY);
-			TraceEvent("CoordinationPingSent", self.id).detail("TimeStep", message.timeStep);
-		} else if (res.index() == 7) {
-			UpdateWorkerHealthRequest req = std::get<7>(std::move(res));
-			if (SERVER_KNOBS->CC_ENABLE_WORKER_HEALTH_MONITOR) {
-				self.updateWorkerHealth(req);
-			}
-		} else if (res.index() == 8) {
-			GetServerDBInfoRequest req = std::get<8>(std::move(res));
-			self.addActor.send(clusterGetServerInfo(&self.db, req.knownServerInfoID, req.reply));
-		} else if (res.index() == 9) {
-			// We are no longer the leader if this has changed.
-			endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Leader Replaced", true);
-			CODE_PROBE(true, "Leader replaced");
-			co_return;
-		} else if (res.index() == 10) {
-			ReplyPromise<Void> ping = std::get<10>(std::move(res));
-			ping.send(Void());
+	auto res = co_await race(error, dispatch, leaderFail);
+	if (res.index() == 0) {
+		ErrorOr<Void> err = std::get<0>(res);
+		if (err.isError() && err.getError().code() != error_code_restart_cluster_controller) {
+			endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Stop Received Error", false, err.getError());
+		} else {
+			endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Stop Received Signal", true);
 		}
+
+		// We shut down normally even if there was a serious error (so this fdbserver may be re-elected
+		// cluster controller)
+	} else if (res.index() == 2) {
+		// We are no longer the leader if this has changed.
+		endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Leader Replaced", true);
+		CODE_PROBE(true, "Leader replaced");
 	}
 }
 

--- a/fdbserver/clustercontroller/ClusterController.cpp
+++ b/fdbserver/clustercontroller/ClusterController.cpp
@@ -487,7 +487,8 @@ Future<Void> monitorAndRecruitWorkerSet(ClusterControllerData* self,
 	Future<Void> newRecovery = self->db.serverInfo->onChange();
 	while (true) {
 		try {
-			auto res = co_await race(newRecovery, monitor(), recruitment);
+			auto res = co_await race(
+			    newRecovery, newRecovery.isReady() ? Future<std::vector<int>>(Never()) : monitor(), recruitment);
 			if (res.index() == 0) {
 				if (self->db.recoveryData.isValid() &&
 				    self->db.recoveryData->cstate.myDBState.recoveryCount == recoveryCount) {
@@ -3555,6 +3556,39 @@ void addProcessesToSameDC(ClusterControllerData& self, const std::vector<Network
 		const bool added = self.addr_locality.insert({ process, locality }).second;
 		ASSERT(added);
 	}
+}
+
+TEST_CASE("/fdbserver/clustercontroller/stopWorkerMonitoringAfterRecoveryChange") {
+	ClusterControllerData data(ClusterControllerFullInterface(),
+	                           LocalityData(),
+	                           ServerCoordinators(Reference<IClusterConnectionRecord>(
+	                               new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
+	                           makeReference<AsyncVar<Optional<UID>>>());
+
+	int monitorCalls = 0;
+	std::function<Future<std::vector<int>>()> monitor = [&monitorCalls]() -> Future<std::vector<int>> {
+		++monitorCalls;
+		if (monitorCalls == 1) {
+			return std::vector<int>{ 0 };
+		}
+		return Never();
+	};
+	std::function<Future<Void>(std::vector<int>)> recruit = [](std::vector<int> failedWorkers) {
+		ASSERT_EQ(failedWorkers.size(), 1);
+		return Future<Void>(Void());
+	};
+
+	Future<Void> monitoring = monitorAndRecruitWorkerSet(&data, 1, "LogRouter", monitor, recruit);
+	ASSERT_EQ(monitorCalls, 1);
+	ASSERT(!monitoring.isReady());
+
+	ServerDBInfo changedInfo = data.db.serverInfo->get();
+	ASSERT(changedInfo.id != UID(1, 1));
+	changedInfo.id = UID(1, 1);
+	data.db.serverInfo->set(changedInfo);
+
+	co_await monitoring;
+	ASSERT_EQ(monitorCalls, 1);
 }
 
 TEST_CASE("/fdbserver/clustercontroller/rejectUnverifiedWorkerRegistration") {

--- a/fdbserver/clustercontroller/ClusterController.cpp
+++ b/fdbserver/clustercontroller/ClusterController.cpp
@@ -3326,6 +3326,102 @@ Future<Void> handleGetEncryptionAtRestMode(ClusterControllerData* self, ClusterC
 	}
 }
 
+Future<Void> handleOpenDatabaseRequests(ClusterControllerData* self, FutureStream<OpenDatabaseRequest> requests) {
+	while (true) {
+		OpenDatabaseRequest req = co_await requests;
+		++self->openDatabaseRequests;
+		self->addActor.send(clusterOpenDatabase(&self->db, req));
+	}
+}
+
+Future<Void> handleRecruitStorageRequests(ClusterControllerData* self, FutureStream<RecruitStorageRequest> requests) {
+	while (true) {
+		RecruitStorageRequest req = co_await requests;
+		clusterRecruitStorage(self, req);
+	}
+}
+
+Future<Void> handleRegisterWorkerRequests(ClusterControllerData* self, FutureStream<RegisterWorkerRequest> requests) {
+	while (true) {
+		RegisterWorkerRequest req = co_await requests;
+		++self->registerWorkerRequests;
+		registerWorker(req, self);
+	}
+}
+
+Future<Void> handleGetWorkersRequests(ClusterControllerData* self, FutureStream<GetWorkersRequest> requests) {
+	while (true) {
+		GetWorkersRequest req = co_await requests;
+		++self->getWorkersRequests;
+		std::vector<WorkerDetails> workers;
+		for (auto const& [id, worker] : self->id_worker) {
+			if ((req.flags & GetWorkersRequest::NON_EXCLUDED_PROCESSES_ONLY) &&
+			    self->db.config.isExcludedServer(worker.details.interf.addresses(), worker.details.interf.locality)) {
+				continue;
+			}
+
+			if ((req.flags & GetWorkersRequest::TESTER_CLASS_ONLY) &&
+			    worker.details.processClass.classType() != ProcessClass::TesterClass) {
+				continue;
+			}
+
+			workers.push_back(worker.details);
+		}
+		req.reply.send(workers);
+	}
+}
+
+Future<Void> handleGetClientWorkersRequests(ClusterControllerData* self,
+                                            FutureStream<GetClientWorkersRequest> requests) {
+	while (true) {
+		GetClientWorkersRequest req = co_await requests;
+		++self->getClientWorkersRequests;
+		std::vector<ClientWorkerInterface> workers;
+		for (auto& it : self->id_worker) {
+			if (it.second.details.processClass.classType() != ProcessClass::TesterClass) {
+				workers.push_back(it.second.details.interf.clientInterface);
+			}
+		}
+		req.reply.send(workers);
+	}
+}
+
+Future<Void> sendCoordinationPings(ClusterControllerData* self, Future<Void> coordinationPingDelay) {
+	uint64_t step = 0;
+	while (true) {
+		co_await coordinationPingDelay;
+		CoordinationPingMessage message(self->id, step++);
+		for (auto& it : self->id_worker)
+			it.second.details.interf.coordinationPing.send(message);
+		coordinationPingDelay = delay(SERVER_KNOBS->WORKER_COORDINATION_PING_DELAY);
+		TraceEvent("CoordinationPingSent", self->id).detail("TimeStep", message.timeStep);
+	}
+}
+
+Future<Void> handleUpdateWorkerHealthRequests(ClusterControllerData* self,
+                                              FutureStream<UpdateWorkerHealthRequest> requests) {
+	while (true) {
+		UpdateWorkerHealthRequest req = co_await requests;
+		if (SERVER_KNOBS->CC_ENABLE_WORKER_HEALTH_MONITOR) {
+			self->updateWorkerHealth(req);
+		}
+	}
+}
+
+Future<Void> handleGetServerDBInfoRequests(ClusterControllerData* self, FutureStream<GetServerDBInfoRequest> requests) {
+	while (true) {
+		GetServerDBInfoRequest req = co_await requests;
+		self->addActor.send(clusterGetServerInfo(&self->db, req.knownServerInfoID, req.reply));
+	}
+}
+
+Future<Void> handleClusterControllerPings(FutureStream<ReplyPromise<Void>> pings) {
+	while (true) {
+		ReplyPromise<Void> ping = co_await pings;
+		ping.send(Void());
+	}
+}
+
 Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
                                    Future<Void> leaderFail,
                                    ServerCoordinators coordinators,
@@ -3333,7 +3429,6 @@ Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
                                    Reference<AsyncVar<Optional<UID>>> clusterId) {
 	ClusterControllerData self(interf, locality, coordinators, clusterId);
 	Future<Void> coordinationPingDelay = delay(SERVER_KNOBS->WORKER_COORDINATION_PING_DELAY);
-	uint64_t step = 0;
 	Future<ErrorOr<Void>> error = errorOr(actorCollection(self.addActor.getFuture()));
 
 	self.addActor.send(clusterWatchDatabase(&self, &self.db, coordinators)); // Start the master database
@@ -3379,94 +3474,36 @@ Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
 		self.addActor.send(monitorAndRecruitLogRouters(&self));
 	}
 
-	while (true) {
-		auto res = co_await race(error,
-		                         interf.clientInterface.openDatabase.getFuture(),
-		                         interf.recruitStorage.getFuture(),
-		                         interf.registerWorker.getFuture(),
-		                         interf.getWorkers.getFuture(),
-		                         interf.clientInterface.getClientWorkers.getFuture(),
-		                         coordinationPingDelay,
-		                         interf.updateWorkerHealth.getFuture(),
-		                         interf.getServerDBInfo.getFuture(),
-		                         leaderFail,
-		                         interf.clientInterface.ping.getFuture());
-		if (res.index() == 0) {
-			ErrorOr<Void> err = std::get<0>(std::move(res));
-			if (err.isError() && err.getError().code() != error_code_restart_cluster_controller) {
-				endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Stop Received Error", false, err.getError());
-			} else {
-				endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Stop Received Signal", true);
-			}
+	// Request-handler failures must propagate from the controller rather than becoming background-actor errors.
+	Future<Void> dispatch = waitForAll(std::vector<Future<Void>>{
+	    handleOpenDatabaseRequests(&self, interf.clientInterface.openDatabase.getFuture()),
+	    handleRecruitStorageRequests(&self, interf.recruitStorage.getFuture()),
+	    handleRegisterWorkerRequests(&self, interf.registerWorker.getFuture()),
+	    handleGetWorkersRequests(&self, interf.getWorkers.getFuture()),
+	    handleGetClientWorkersRequests(&self, interf.clientInterface.getClientWorkers.getFuture()),
+	    sendCoordinationPings(&self, std::move(coordinationPingDelay)),
+	    handleUpdateWorkerHealthRequests(&self, interf.updateWorkerHealth.getFuture()),
+	    handleGetServerDBInfoRequests(&self, interf.getServerDBInfo.getFuture()),
+	    handleClusterControllerPings(interf.clientInterface.ping.getFuture()),
+	});
 
-			// We shut down normally even if there was a serious error (so this fdbserver may be re-elected
-			// cluster controller)
-			co_return;
-		} else if (res.index() == 1) {
-			OpenDatabaseRequest req = std::get<1>(std::move(res));
-			++self.openDatabaseRequests;
-			self.addActor.send(clusterOpenDatabase(&self.db, req));
-		} else if (res.index() == 2) {
-			RecruitStorageRequest req = std::get<2>(std::move(res));
-			clusterRecruitStorage(&self, req);
-		} else if (res.index() == 3) {
-			RegisterWorkerRequest req = std::get<3>(std::move(res));
-			++self.registerWorkerRequests;
-			registerWorker(req, &self);
-		} else if (res.index() == 4) {
-			GetWorkersRequest req = std::get<4>(std::move(res));
-			++self.getWorkersRequests;
-			std::vector<WorkerDetails> workers;
-			for (auto const& [id, worker] : self.id_worker) {
-				if ((req.flags & GetWorkersRequest::NON_EXCLUDED_PROCESSES_ONLY) &&
-				    self.db.config.isExcludedServer(worker.details.interf.addresses(),
-				                                    worker.details.interf.locality)) {
-					continue;
-				}
-
-				if ((req.flags & GetWorkersRequest::TESTER_CLASS_ONLY) &&
-				    worker.details.processClass.classType() != ProcessClass::TesterClass) {
-					continue;
-				}
-
-				workers.push_back(worker.details);
-			}
-			req.reply.send(workers);
-		} else if (res.index() == 5) {
-			GetClientWorkersRequest req = std::get<5>(std::move(res));
-			++self.getClientWorkersRequests;
-			std::vector<ClientWorkerInterface> workers;
-			for (auto& it : self.id_worker) {
-				if (it.second.details.processClass.classType() != ProcessClass::TesterClass) {
-					workers.push_back(it.second.details.interf.clientInterface);
-				}
-			}
-			req.reply.send(workers);
-		} else if (res.index() == 6) {
-			CoordinationPingMessage message(self.id, step++);
-			for (auto& it : self.id_worker)
-				it.second.details.interf.coordinationPing.send(message);
-			coordinationPingDelay = delay(SERVER_KNOBS->WORKER_COORDINATION_PING_DELAY);
-			TraceEvent("CoordinationPingSent", self.id).detail("TimeStep", message.timeStep);
-		} else if (res.index() == 7) {
-			UpdateWorkerHealthRequest req = std::get<7>(std::move(res));
-			if (SERVER_KNOBS->CC_ENABLE_WORKER_HEALTH_MONITOR) {
-				self.updateWorkerHealth(req);
-			}
-		} else if (res.index() == 8) {
-			GetServerDBInfoRequest req = std::get<8>(std::move(res));
-			self.addActor.send(clusterGetServerInfo(&self.db, req.knownServerInfoID, req.reply));
-		} else if (res.index() == 9) {
-			// We are no longer the leader if this has changed.
-			endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Leader Replaced", true);
-			CODE_PROBE(true, "Leader replaced");
-			co_return;
-		} else if (res.index() == 10) {
-			ReplyPromise<Void> ping = std::get<10>(std::move(res));
-			ping.send(Void());
+	auto res = co_await race(error, dispatch, leaderFail);
+	if (res.index() == 0) {
+		ErrorOr<Void> err = std::get<0>(std::move(res));
+		if (err.isError() && err.getError().code() != error_code_restart_cluster_controller) {
+			endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Stop Received Error", false, err.getError());
 		} else {
-			UNREACHABLE();
+			endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Stop Received Signal", true);
 		}
+
+		// We shut down normally even if there was a serious error (so this fdbserver may be re-elected
+		// cluster controller)
+	} else if (res.index() == 2) {
+		// We are no longer the leader if this has changed.
+		endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Leader Replaced", true);
+		CODE_PROBE(true, "Leader replaced");
+	} else {
+		UNREACHABLE();
 	}
 }
 

--- a/fdbserver/clustercontroller/ClusterController.cpp
+++ b/fdbserver/clustercontroller/ClusterController.cpp
@@ -1,5 +1,5 @@
 /*
- * ClusterController.actor.cpp
+ * ClusterController.cpp
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -71,9 +71,8 @@
 #include "flow/CoroUtils.h"
 #include "flow/Error.h"
 #include "flow/Trace.h"
+#include "flow/UnitTest.h"
 #include "flow/Util.h"
-
-#include "flow/actorcompiler.h" // This must be the last #include.
 
 ClusterControllerData::DBInfo::DBInfo()
   : clientInfo(new AsyncVar<ClientDBInfo>()), serverInfo(new AsyncVar<ServerDBInfo>()), masterRegistrationCount(0),
@@ -476,41 +475,41 @@ Future<std::vector<int>> monitorLogRouters(Reference<LogSystem> logSystem, int l
 // When in fully_recovered state, the cluster controller will monitor log routers
 // and backup workers, and re-recruit any failed log routers or backup workers.
 // This actor will be restarted in each recovery and will exit when a new recovery is detected.
-ACTOR Future<Void> monitorAndRecruitWorkerSet(ClusterControllerData* self,
-                                              uint64_t recoveryCount,
-                                              const char* workerName,
-                                              std::function<Future<std::vector<int>>()> monitor,
-                                              std::function<Future<Void>(std::vector<int>)> recruit) {
+Future<Void> monitorAndRecruitWorkerSet(ClusterControllerData* self,
+                                        uint64_t recoveryCount,
+                                        const char* workerName,
+                                        std::function<Future<std::vector<int>>()> monitor,
+                                        std::function<Future<Void>(std::vector<int>)> recruit) {
 	TraceEvent((std::string(workerName) + "MonitoringStart").c_str(), self->id).detail("RecoveryCount", recoveryCount);
 
-	state double failedRecruitDelay = 1.0;
-	state Future<Void> recruitment = Never();
-	state Future<Void> newRecovery = self->db.serverInfo->onChange();
-	loop {
+	double failedRecruitDelay = 1.0;
+	Future<Void> recruitment = Never();
+	Future<Void> newRecovery = self->db.serverInfo->onChange();
+	while (true) {
 		try {
-			choose {
-				when(wait(newRecovery)) {
-					if (self->db.recoveryData.isValid() &&
-					    self->db.recoveryData->cstate.myDBState.recoveryCount == recoveryCount) {
-						newRecovery = self->db.serverInfo->onChange();
-						continue; // no recovery change, keep monitoring
-					}
-					TraceEvent((std::string(workerName) + "MonitoringEnded").c_str(), self->id)
-					    .detail("Reason", "RecoveryChanged")
-					    .detail("RecoveryCount", recoveryCount);
-					return Void();
+			auto res = co_await race(newRecovery, monitor(), recruitment);
+			if (res.index() == 0) {
+				if (self->db.recoveryData.isValid() &&
+				    self->db.recoveryData->cstate.myDBState.recoveryCount == recoveryCount) {
+					newRecovery = self->db.serverInfo->onChange();
+					continue; // no recovery change, keep monitoring
 				}
-				when(std::vector<int> failedWorkers = wait(monitor())) {
-					recruitment = recruit(failedWorkers);
-					TraceEvent((std::string(workerName) + "FailureDetected").c_str(), self->id)
-					    .detail("FailedCount", failedWorkers.size());
-				}
-				when(wait(recruitment)) {
-					failedRecruitDelay = 1.0; // Reset backoff on success
-					TraceEvent((std::string(workerName) + "ReRecruitmentSuccess").c_str(), self->id)
-					    .detail("RecoveryCount", recoveryCount);
-					recruitment = Never();
-				}
+				TraceEvent((std::string(workerName) + "MonitoringEnded").c_str(), self->id)
+				    .detail("Reason", "RecoveryChanged")
+				    .detail("RecoveryCount", recoveryCount);
+				co_return;
+			} else if (res.index() == 1) {
+				std::vector<int> failedWorkers = std::get<1>(std::move(res));
+				recruitment = recruit(failedWorkers);
+				TraceEvent((std::string(workerName) + "FailureDetected").c_str(), self->id)
+				    .detail("FailedCount", failedWorkers.size());
+			} else if (res.index() == 2) {
+				failedRecruitDelay = 1.0; // Reset backoff on success
+				TraceEvent((std::string(workerName) + "ReRecruitmentSuccess").c_str(), self->id)
+				    .detail("RecoveryCount", recoveryCount);
+				recruitment = Never();
+			} else {
+				UNREACHABLE();
 			}
 		} catch (Error& e) {
 			if (strcmp(workerName, "LogRouter") == 0) {
@@ -525,7 +524,7 @@ ACTOR Future<Void> monitorAndRecruitWorkerSet(ClusterControllerData* self,
 			recruitment = Never();
 		}
 
-		wait(delay(failedRecruitDelay));
+		co_await delay(failedRecruitDelay);
 	}
 }
 
@@ -728,25 +727,29 @@ Future<Void> monitorAndRecruitCDCProxies(ClusterControllerData* self) {
 	}
 }
 
-ACTOR Future<Void> clusterWatchDatabase(ClusterControllerData* cluster,
-                                        ClusterControllerData::DBInfo* db,
-                                        ServerCoordinators coordinators) {
-	state MasterInterface iMaster;
-	state PromiseStream<Future<Void>> addActor;
-	state Future<Void> recoveryCore;
+Future<Void> clusterWatchDatabase(ClusterControllerData* cluster,
+                                  ClusterControllerData::DBInfo* db,
+                                  ServerCoordinators coordinators) {
+	MasterInterface iMaster;
+	PromiseStream<Future<Void>> addActor;
+	Future<Void> recoveryCore;
+	MasterInterface newMaster;
+	Future<Void> collection;
+	Future<Void> spinDelay;
 
 	// SOMEDAY: If there is already a non-failed master referenced by zkMasterInfo, use that one until it fails
 	// When this someday is implemented, make sure forced failures still cause the master to be recruited again
 
-	loop {
+	while (true) {
 		TraceEvent("CCWDB", cluster->id).log();
+		Error err;
 		try {
-			state double recoveryStart = now();
-			state MasterInterface newMaster;
-			state Future<Void> collection;
+			double recoveryStart = now();
+			newMaster = MasterInterface();
+			collection = Future<Void>();
 
 			TraceEvent("CCWDB", cluster->id).detail("Recruiting", "Master");
-			wait(recruitNewMaster(cluster, db, std::addressof(newMaster)));
+			co_await recruitNewMaster(cluster, db, std::addressof(newMaster));
 
 			iMaster = newMaster;
 
@@ -779,7 +782,7 @@ ACTOR Future<Void> clusterWatchDatabase(ClusterControllerData* cluster,
 			    .detail("ChangeID", dbInfo.id);
 			db->serverInfo->set(dbInfo);
 
-			state Future<Void> spinDelay = delay(
+			spinDelay = delay(
 			    SERVER_KNOBS
 			        ->MASTER_SPIN_DELAY); // Don't retry cluster recovery more than once per second, but don't delay
 			                              // the "first" recovery after more than a second of normal operation
@@ -801,9 +804,9 @@ ACTOR Future<Void> clusterWatchDatabase(ClusterControllerData* cluster,
 
 			// Master failure detection is pretty sensitive, but if we are in the middle of a very long recovery we
 			// really don't want to have to start over
-			loop choose {
-				when(wait(recoveryCore)) {}
-				when(wait(
+			while (true) {
+				auto res = co_await race(
+				    recoveryCore,
 				    traceAfter(waitFailureClient(
 				                   iMaster.waitFailure,
 				                   db->masterRegistrationCount
@@ -813,20 +816,22 @@ ACTOR Future<Void> clusterWatchDatabase(ClusterControllerData* cluster,
 				                                                     SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY
 				                                               : SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY),
 				               "CCWDBMasterFailed") ||
-				    traceAfter(db->forceMasterFailure.onTrigger(), "CCWDBForceMasterFailureTriggered"))) {
+				        traceAfter(db->forceMasterFailure.onTrigger(), "CCWDBForceMasterFailureTriggered"),
+				    db->serverInfo->onChange(),
+				    db->serverInfo->get().clusterInterface.notifyBackupWorkerDone.getFuture(),
+				    collection);
+				if (res.index() == 1) {
 					break;
 				}
-				when(wait(db->serverInfo->onChange())) {}
-				when(BackupWorkerDoneRequest req =
-				         waitNext(db->serverInfo->get().clusterInterface.notifyBackupWorkerDone.getFuture())) {
+				if (res.index() == 3) {
+					BackupWorkerDoneRequest req = std::get<3>(std::move(res));
 					if (db->recoveryData->logSystem.isValid() && db->recoveryData->logSystem->removeBackupWorker(req)) {
 						db->recoveryData->registrationTrigger.trigger();
 					}
 					++db->recoveryData->backupWorkerDoneRequests;
 					req.reply.send(Void());
 					TraceEvent(SevDebug, "BackupWorkerDoneRequest", cluster->id).log();
-				}
-				when(wait(collection)) {
+				} else if (res.index() == 4) {
 					throw internal_error();
 				}
 			}
@@ -837,54 +842,56 @@ ACTOR Future<Void> clusterWatchDatabase(ClusterControllerData* cluster,
 			}
 
 			recoveryCore.cancel();
-			wait(cleanupRecoveryActorCollection(db->recoveryData));
+			co_await cleanupRecoveryActorCollection(db->recoveryData);
 			ASSERT(addActor.isEmpty());
 
-			wait(spinDelay);
+			co_await spinDelay;
 
 			CODE_PROBE(true, "clusterWatchDatabase() master failed");
 			TraceEvent(SevWarn, "DetectedFailedRecovery", cluster->id).detail("OldMaster", iMaster.id());
+			continue;
 		} catch (Error& e) {
-			state Error err = e;
-			TraceEvent("CCWDB", cluster->id).errorUnsuppressed(e).detail("Master", iMaster.id());
-			if (e.code() != error_code_actor_cancelled)
-				wait(delay(0.0));
-
-			recoveryCore.cancel();
-			wait(cleanupRecoveryActorCollection(db->recoveryData));
-			ASSERT(addActor.isEmpty());
-			if (cluster->outstandingRemoteRequestChecker.isValid()) {
-				cluster->outstandingRemoteRequestChecker.cancel();
-			}
-
-			if (cluster->outstandingRequestChecker.isValid()) {
-				cluster->outstandingRequestChecker.cancel();
-			}
-
-			CODE_PROBE(err.code() == error_code_tlog_failed, "Terminated due to tLog failure");
-			CODE_PROBE(err.code() == error_code_commit_proxy_failed, "Terminated due to commit proxy failure");
-			CODE_PROBE(err.code() == error_code_grv_proxy_failed, "Terminated due to GRV proxy failure");
-			CODE_PROBE(err.code() == error_code_resolver_failed, "Terminated due to resolver failure");
-			CODE_PROBE(err.code() == error_code_backup_worker_failed, "Terminated due to backup worker failure");
-			CODE_PROBE(err.code() == error_code_operation_failed,
-			           "Terminated due to failed operation",
-			           probe::decoration::rare);
-			CODE_PROBE(err.code() == error_code_restart_cluster_controller,
-			           "Terminated due to cluster-controller restart.");
-
-			if (cluster->shouldCommitSuicide || err.code() == error_code_coordinators_changed) {
-				TraceEvent("ClusterControllerTerminate", cluster->id).errorUnsuppressed(err);
-				throw restart_cluster_controller();
-			}
-
-			if (isNormalClusterRecoveryError(err)) {
-				TraceEvent(SevWarn, "ClusterRecoveryRetrying", cluster->id).error(err);
-			} else {
-				TraceEvent(SevError, "ClusterWatchDatabaseRetrying", cluster->id).error(err);
-				throw err;
-			}
-			wait(delay(SERVER_KNOBS->ATTEMPT_RECRUITMENT_DELAY));
+			err = e;
 		}
+
+		TraceEvent("CCWDB", cluster->id).errorUnsuppressed(err).detail("Master", iMaster.id());
+		if (err.code() != error_code_actor_cancelled) {
+			co_await delay(0.0);
+		}
+
+		recoveryCore.cancel();
+		co_await cleanupRecoveryActorCollection(db->recoveryData);
+		ASSERT(addActor.isEmpty());
+		if (cluster->outstandingRemoteRequestChecker.isValid()) {
+			cluster->outstandingRemoteRequestChecker.cancel();
+		}
+
+		if (cluster->outstandingRequestChecker.isValid()) {
+			cluster->outstandingRequestChecker.cancel();
+		}
+
+		CODE_PROBE(err.code() == error_code_tlog_failed, "Terminated due to tLog failure");
+		CODE_PROBE(err.code() == error_code_commit_proxy_failed, "Terminated due to commit proxy failure");
+		CODE_PROBE(err.code() == error_code_grv_proxy_failed, "Terminated due to GRV proxy failure");
+		CODE_PROBE(err.code() == error_code_resolver_failed, "Terminated due to resolver failure");
+		CODE_PROBE(err.code() == error_code_backup_worker_failed, "Terminated due to backup worker failure");
+		CODE_PROBE(
+		    err.code() == error_code_operation_failed, "Terminated due to failed operation", probe::decoration::rare);
+		CODE_PROBE(err.code() == error_code_restart_cluster_controller,
+		           "Terminated due to cluster-controller restart.");
+
+		if (cluster->shouldCommitSuicide || err.code() == error_code_coordinators_changed) {
+			TraceEvent("ClusterControllerTerminate", cluster->id).errorUnsuppressed(err);
+			throw restart_cluster_controller();
+		}
+
+		if (isNormalClusterRecoveryError(err)) {
+			TraceEvent(SevWarn, "ClusterRecoveryRetrying", cluster->id).error(err);
+		} else {
+			TraceEvent(SevError, "ClusterWatchDatabaseRetrying", cluster->id).error(err);
+			throw err;
+		}
+		co_await delay(SERVER_KNOBS->ATTEMPT_RECRUITMENT_DELAY);
 	}
 }
 
@@ -1293,20 +1300,20 @@ void processRegisteredSingletons(ClusterControllerData* self,
                                  Optional<RatekeeperInterface> const& ratekeeperInterf,
                                  Optional<ConsistencyScanInterface> const& consistencyScanInterf);
 
-ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
-                                           ProcessClass startingClass,
-                                           ClusterControllerData* cluster) {
-	state Future<Void> failed = (worker.address() == g_network->getLocalAddress())
-	                                ? Never()
-	                                : waitFailureClient(worker.waitFailure, SERVER_KNOBS->WORKER_FAILURE_TIME);
-	state LoadedPingRequest registrationPing;
-	state Future<Optional<ErrorOr<LoadedReply>>> registrationPingReply;
+Future<Void> workerAvailabilityWatch(WorkerInterface worker,
+                                     ProcessClass startingClass,
+                                     ClusterControllerData* cluster) {
+	Future<Void> failed = (worker.address() == g_network->getLocalAddress())
+	                          ? Never()
+	                          : waitFailureClient(worker.waitFailure, SERVER_KNOBS->WORKER_FAILURE_TIME);
+	LoadedPingRequest registrationPing;
+	Future<Optional<ErrorOr<LoadedReply>>> registrationPingReply;
 	cluster->updateWorkerList.set(
 	    worker.locality.processId(),
 	    ProcessData(worker.locality, startingClass, worker.stableAddress(), worker.grpcAddress()));
 	// This switching avoids a race where the worker can be added to id_worker map after the workerAvailabilityWatch
 	// fails for the worker.
-	wait(delay(0));
+	co_await delay(0);
 	// A RegisterWorkerRequest can be delivered after its sender dies. Verify this exact WorkerInterface before
 	// making it eligible for recruitment.
 	registrationPing.id = worker.id();
@@ -1316,44 +1323,47 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 	                registrationPing, SERVER_KNOBS->WORKER_FAILURE_TIME, /* sustainedFailureSlope */ 0),
 	            SERVER_KNOBS->WORKER_FAILURE_TIME);
 
-	loop {
-		choose {
-			when(Optional<ErrorOr<LoadedReply>> reply = wait(registrationPingReply)) {
-				if (!reply.present() || !reply.get().present() || reply.get().get().id != registrationPing.id) {
-					TraceEvent("ClusterControllerWorkerRegistrationPingFailed", cluster->id)
-					    .detail("WorkerID", worker.id())
-					    .detail("Address", worker.address())
-					    .detail("TimedOut", !reply.present());
-					removeFailedWorker(worker, cluster);
-					return Void();
-				}
+	while (true) {
+		auto res = co_await race(
+		    registrationPingReply,
+		    IFailureMonitor::failureMonitor().onStateEqual(
+		        worker.storage.getEndpoint(),
+		        FailureStatus(IFailureMonitor::failureMonitor().getState(worker.storage.getEndpoint()).isAvailable())),
+		    failed);
+		if (res.index() == 0) {
+			Optional<ErrorOr<LoadedReply>> reply = std::get<0>(std::move(res));
+			if (!reply.present() || !reply.get().present() || reply.get().get().id != registrationPing.id) {
+				TraceEvent("ClusterControllerWorkerRegistrationPingFailed", cluster->id)
+				    .detail("WorkerID", worker.id())
+				    .detail("Address", worker.address())
+				    .detail("TimedOut", !reply.present());
+				removeFailedWorker(worker, cluster);
+				co_return;
+			}
 
-				auto workerInfo = cluster->id_worker.find(worker.locality.processId());
-				if (workerInfo == cluster->id_worker.end() || workerInfo->second.details.interf.id() != worker.id()) {
-					return Void();
-				}
-				workerInfo->second.verified = true;
-				registrationPingReply = Never();
-				processRegisteredSingletons(cluster,
-				                            worker,
-				                            workerInfo->second.distributorInterf,
-				                            workerInfo->second.ratekeeperInterf,
-				                            workerInfo->second.consistencyScanInterf);
+			auto workerInfo = cluster->id_worker.find(worker.locality.processId());
+			if (workerInfo == cluster->id_worker.end() || workerInfo->second.details.interf.id() != worker.id()) {
+				co_return;
+			}
+			workerInfo->second.verified = true;
+			registrationPingReply = Never();
+			processRegisteredSingletons(cluster,
+			                            worker,
+			                            workerInfo->second.distributorInterf,
+			                            workerInfo->second.ratekeeperInterf,
+			                            workerInfo->second.consistencyScanInterf);
+			checkOutstandingRequests(cluster);
+		} else if (res.index() == 1) {
+			if (IFailureMonitor::failureMonitor().getState(worker.storage.getEndpoint()).isAvailable()) {
+				cluster->ac.add(rebootAndCheck(cluster, worker.locality.processId()));
 				checkOutstandingRequests(cluster);
 			}
-			when(wait(IFailureMonitor::failureMonitor().onStateEqual(
-			    worker.storage.getEndpoint(),
-			    FailureStatus(
-			        IFailureMonitor::failureMonitor().getState(worker.storage.getEndpoint()).isAvailable())))) {
-				if (IFailureMonitor::failureMonitor().getState(worker.storage.getEndpoint()).isAvailable()) {
-					cluster->ac.add(rebootAndCheck(cluster, worker.locality.processId()));
-					checkOutstandingRequests(cluster);
-				}
-			}
-			when(wait(failed)) { // remove workers that have failed
-				removeFailedWorker(worker, cluster);
-				return Void();
-			}
+		} else if (res.index() == 2) {
+			// remove workers that have failed
+			removeFailedWorker(worker, cluster);
+			co_return;
+		} else {
+			UNREACHABLE();
 		}
 	}
 }
@@ -3087,18 +3097,17 @@ Future<Void> monitorConsistencyScan(ClusterControllerData* self) {
 	}
 }
 
-ACTOR Future<Void> dbInfoUpdater(ClusterControllerData* self) {
-	state Future<Void> dbInfoChange = self->db.serverInfo->onChange();
-	state Future<Void> updateDBInfo = self->updateDBInfo.onTrigger();
-	loop {
-		choose {
-			when(wait(updateDBInfo)) {
-				wait(delay(SERVER_KNOBS->DBINFO_BATCH_DELAY) || dbInfoChange);
-			}
-			when(wait(dbInfoChange)) {}
+Future<Void> dbInfoUpdater(ClusterControllerData* self) {
+	Future<Void> dbInfoChange = self->db.serverInfo->onChange();
+	Future<Void> updateDBInfo = self->updateDBInfo.onTrigger();
+	UpdateServerDBInfoRequest req;
+	while (true) {
+		auto trigger = co_await race(updateDBInfo, dbInfoChange);
+		if (trigger.index() == 0) {
+			co_await (delay(SERVER_KNOBS->DBINFO_BATCH_DELAY) || dbInfoChange);
 		}
 
-		state UpdateServerDBInfoRequest req;
+		req = UpdateServerDBInfoRequest();
 		if (dbInfoChange.isReady()) {
 			for (auto& it : self->id_worker) {
 				req.broadcastInfo.push_back(it.second.details.interf.updateServerDBInfo.getEndpoint());
@@ -3122,21 +3131,21 @@ ACTOR Future<Void> dbInfoUpdater(ClusterControllerData* self) {
 
 		TraceEvent("DBInfoStartBroadcast", self->id)
 		    .detail("MasterLifetime", self->db.serverInfo->get().masterLifetime.toString());
-		choose {
-			when(std::vector<Endpoint> notUpdated =
-			         wait(broadcastDBInfoRequest(req, SERVER_KNOBS->DBINFO_SEND_AMOUNT, Optional<Endpoint>(), false))) {
-				TraceEvent("DBInfoFinishBroadcast", self->id).detail("NotUpdated", notUpdated.size());
-				if (notUpdated.size()) {
-					self->updateDBInfoEndpoints.insert(notUpdated.begin(), notUpdated.end());
-					self->updateDBInfo.trigger();
-				}
+		auto res =
+		    co_await race(broadcastDBInfoRequest(req, SERVER_KNOBS->DBINFO_SEND_AMOUNT, Optional<Endpoint>(), false),
+		                  dbInfoChange,
+		                  updateDBInfo);
+		if (res.index() == 0) {
+			std::vector<Endpoint> notUpdated = std::get<0>(std::move(res));
+			TraceEvent("DBInfoFinishBroadcast", self->id).detail("NotUpdated", notUpdated.size());
+			if (notUpdated.size()) {
+				self->updateDBInfoEndpoints.insert(notUpdated.begin(), notUpdated.end());
+				self->updateDBInfo.trigger();
 			}
-			when(wait(dbInfoChange)) {}
-			when(wait(updateDBInfo)) {
-				// The current round of broadcast hasn't finished yet. So we need to include all the current broadcast
-				// endpoints in the new round as well.
-				self->updateDBInfoEndpoints.insert(req.broadcastInfo.begin(), req.broadcastInfo.end());
-			}
+		} else if (res.index() == 2) {
+			// The current round of broadcast hasn't finished yet. So we need to include all the current broadcast
+			// endpoints in the new round as well.
+			self->updateDBInfoEndpoints.insert(req.broadcastInfo.begin(), req.broadcastInfo.end());
 		}
 	}
 }
@@ -3317,15 +3326,15 @@ Future<Void> handleGetEncryptionAtRestMode(ClusterControllerData* self, ClusterC
 	}
 }
 
-ACTOR Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
-                                         Future<Void> leaderFail,
-                                         ServerCoordinators coordinators,
-                                         LocalityData locality,
-                                         Reference<AsyncVar<Optional<UID>>> clusterId) {
-	state ClusterControllerData self(interf, locality, coordinators, clusterId);
-	state Future<Void> coordinationPingDelay = delay(SERVER_KNOBS->WORKER_COORDINATION_PING_DELAY);
-	state uint64_t step = 0;
-	state Future<ErrorOr<Void>> error = errorOr(actorCollection(self.addActor.getFuture()));
+Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
+                                   Future<Void> leaderFail,
+                                   ServerCoordinators coordinators,
+                                   LocalityData locality,
+                                   Reference<AsyncVar<Optional<UID>>> clusterId) {
+	ClusterControllerData self(interf, locality, coordinators, clusterId);
+	Future<Void> coordinationPingDelay = delay(SERVER_KNOBS->WORKER_COORDINATION_PING_DELAY);
+	uint64_t step = 0;
+	Future<ErrorOr<Void>> error = errorOr(actorCollection(self.addActor.getFuture()));
 
 	self.addActor.send(clusterWatchDatabase(&self, &self.db, coordinators)); // Start the master database
 	self.addActor.send(self.updateWorkerList.init(self.db.db));
@@ -3370,8 +3379,20 @@ ACTOR Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
 		self.addActor.send(monitorAndRecruitLogRouters(&self));
 	}
 
-	loop choose {
-		when(ErrorOr<Void> err = wait(error)) {
+	while (true) {
+		auto res = co_await race(error,
+		                         interf.clientInterface.openDatabase.getFuture(),
+		                         interf.recruitStorage.getFuture(),
+		                         interf.registerWorker.getFuture(),
+		                         interf.getWorkers.getFuture(),
+		                         interf.clientInterface.getClientWorkers.getFuture(),
+		                         coordinationPingDelay,
+		                         interf.updateWorkerHealth.getFuture(),
+		                         interf.getServerDBInfo.getFuture(),
+		                         leaderFail,
+		                         interf.clientInterface.ping.getFuture());
+		if (res.index() == 0) {
+			ErrorOr<Void> err = std::get<0>(std::move(res));
 			if (err.isError() && err.getError().code() != error_code_restart_cluster_controller) {
 				endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Stop Received Error", false, err.getError());
 			} else {
@@ -3380,23 +3401,22 @@ ACTOR Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
 
 			// We shut down normally even if there was a serious error (so this fdbserver may be re-elected
 			// cluster controller)
-			return Void();
-		}
-		when(OpenDatabaseRequest req = waitNext(interf.clientInterface.openDatabase.getFuture())) {
+			co_return;
+		} else if (res.index() == 1) {
+			OpenDatabaseRequest req = std::get<1>(std::move(res));
 			++self.openDatabaseRequests;
 			self.addActor.send(clusterOpenDatabase(&self.db, req));
-		}
-		when(RecruitStorageRequest req = waitNext(interf.recruitStorage.getFuture())) {
+		} else if (res.index() == 2) {
+			RecruitStorageRequest req = std::get<2>(std::move(res));
 			clusterRecruitStorage(&self, req);
-		}
-		when(RegisterWorkerRequest req = waitNext(interf.registerWorker.getFuture())) {
+		} else if (res.index() == 3) {
+			RegisterWorkerRequest req = std::get<3>(std::move(res));
 			++self.registerWorkerRequests;
 			registerWorker(req, &self);
-		}
-		when(GetWorkersRequest req = waitNext(interf.getWorkers.getFuture())) {
+		} else if (res.index() == 4) {
+			GetWorkersRequest req = std::get<4>(std::move(res));
 			++self.getWorkersRequests;
 			std::vector<WorkerDetails> workers;
-
 			for (auto const& [id, worker] : self.id_worker) {
 				if ((req.flags & GetWorkersRequest::NON_EXCLUDED_PROCESSES_ONLY) &&
 				    self.db.config.isExcludedServer(worker.details.interf.addresses(),
@@ -3411,10 +3431,9 @@ ACTOR Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
 
 				workers.push_back(worker.details);
 			}
-
 			req.reply.send(workers);
-		}
-		when(GetClientWorkersRequest req = waitNext(interf.clientInterface.getClientWorkers.getFuture())) {
+		} else if (res.index() == 5) {
+			GetClientWorkersRequest req = std::get<5>(std::move(res));
 			++self.getClientWorkersRequests;
 			std::vector<ClientWorkerInterface> workers;
 			for (auto& it : self.id_worker) {
@@ -3423,30 +3442,30 @@ ACTOR Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
 				}
 			}
 			req.reply.send(workers);
-		}
-		when(wait(coordinationPingDelay)) {
+		} else if (res.index() == 6) {
 			CoordinationPingMessage message(self.id, step++);
 			for (auto& it : self.id_worker)
 				it.second.details.interf.coordinationPing.send(message);
 			coordinationPingDelay = delay(SERVER_KNOBS->WORKER_COORDINATION_PING_DELAY);
 			TraceEvent("CoordinationPingSent", self.id).detail("TimeStep", message.timeStep);
-		}
-		when(UpdateWorkerHealthRequest req = waitNext(interf.updateWorkerHealth.getFuture())) {
+		} else if (res.index() == 7) {
+			UpdateWorkerHealthRequest req = std::get<7>(std::move(res));
 			if (SERVER_KNOBS->CC_ENABLE_WORKER_HEALTH_MONITOR) {
 				self.updateWorkerHealth(req);
 			}
-		}
-		when(GetServerDBInfoRequest req = waitNext(interf.getServerDBInfo.getFuture())) {
+		} else if (res.index() == 8) {
+			GetServerDBInfoRequest req = std::get<8>(std::move(res));
 			self.addActor.send(clusterGetServerInfo(&self.db, req.knownServerInfoID, req.reply));
-		}
-		when(wait(leaderFail)) {
+		} else if (res.index() == 9) {
 			// We are no longer the leader if this has changed.
 			endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Leader Replaced", true);
 			CODE_PROBE(true, "Leader replaced");
-			return Void();
-		}
-		when(ReplyPromise<Void> ping = waitNext(interf.clientInterface.ping.getFuture())) {
+			co_return;
+		} else if (res.index() == 10) {
+			ReplyPromise<Void> ping = std::get<10>(std::move(res));
 			ping.send(Void());
+		} else {
+			UNREACHABLE();
 		}
 	}
 }
@@ -3461,32 +3480,32 @@ Future<Void> replaceInterface(ClusterControllerFullInterface interf) {
 	}
 }
 
-ACTOR Future<Void> clusterController(ServerCoordinators coordinators,
-                                     Reference<AsyncVar<Optional<ClusterControllerFullInterface>>> currentCC,
-                                     bool hasConnected,
-                                     Reference<AsyncVar<ClusterControllerPriorityInfo>> asyncPriorityInfo,
-                                     LocalityData locality,
-                                     Reference<AsyncVar<Optional<UID>>> clusterId) {
-	loop {
-		state ClusterControllerFullInterface cci;
-		state bool inRole = false;
+Future<Void> clusterController(ServerCoordinators coordinators,
+                               Reference<AsyncVar<Optional<ClusterControllerFullInterface>>> currentCC,
+                               bool hasConnected,
+                               Reference<AsyncVar<ClusterControllerPriorityInfo>> asyncPriorityInfo,
+                               LocalityData locality,
+                               Reference<AsyncVar<Optional<UID>>> clusterId) {
+	ClusterControllerFullInterface cci;
+	Future<Void> leaderFail;
+	Future<Void> shouldReplace;
+	while (true) {
+		cci = ClusterControllerFullInterface();
+		bool inRole = false;
 		cci.initEndpoints();
 		try {
 			// Register as a possible leader; wait to be elected
-			state Future<Void> leaderFail =
-			    tryBecomeLeader(coordinators, cci, currentCC, hasConnected, asyncPriorityInfo);
-			state Future<Void> shouldReplace = replaceInterface(cci);
+			leaderFail = tryBecomeLeader(coordinators, cci, currentCC, hasConnected, asyncPriorityInfo);
+			shouldReplace = replaceInterface(cci);
 
 			while (!currentCC->get().present() || currentCC->get().get() != cci) {
-				choose {
-					when(wait(currentCC->onChange())) {}
-					when(wait(leaderFail)) {
-						ASSERT(false);
-						throw internal_error();
-					}
-					when(wait(shouldReplace)) {
-						break;
-					}
+				auto res = co_await race(currentCC->onChange(), leaderFail, shouldReplace);
+				if (res.index() == 1) {
+					ASSERT(false);
+					throw internal_error();
+				}
+				if (res.index() == 2) {
+					break;
 				}
 			}
 			if (!shouldReplace.isReady()) {
@@ -3495,7 +3514,7 @@ ACTOR Future<Void> clusterController(ServerCoordinators coordinators,
 				startRole(Role::CLUSTER_CONTROLLER, cci.id(), UID());
 				inRole = true;
 
-				wait(clusterControllerCore(cci, leaderFail, coordinators, locality, clusterId));
+				co_await clusterControllerCore(cci, leaderFail, coordinators, locality, clusterId);
 			}
 		} catch (Error& e) {
 			if (inRole)
@@ -3544,18 +3563,18 @@ void addProcessesToSameDC(ClusterControllerData& self, const std::vector<Network
 }
 
 TEST_CASE("/fdbserver/clustercontroller/rejectUnverifiedWorkerRegistration") {
-	state ClusterControllerData data(ClusterControllerFullInterface(),
-	                                 LocalityData(),
-	                                 ServerCoordinators(Reference<IClusterConnectionRecord>(
-	                                     new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
-	                                 makeReference<AsyncVar<Optional<UID>>>());
-	state LocalityData workerLocality;
+	ClusterControllerData data(ClusterControllerFullInterface(),
+	                           LocalityData(),
+	                           ServerCoordinators(Reference<IClusterConnectionRecord>(
+	                               new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
+	                           makeReference<AsyncVar<Optional<UID>>>());
+	LocalityData workerLocality;
 	workerLocality.set(LocalityData::keyProcessId, Standalone<StringRef>(std::string{ "stale-worker" }));
-	state WorkerInterface worker(workerLocality);
+	WorkerInterface worker(workerLocality);
 	worker.initEndpoints();
 	worker.storage.getEndpoint(TaskPriority::Worker);
 
-	state RegisterWorkerRequest request;
+	RegisterWorkerRequest request;
 	request.wi = worker;
 	request.initialClass = ProcessClass(ProcessClass::StorageClass, ProcessClass::CommandLineSource);
 	request.processClass = request.initialClass;
@@ -3563,31 +3582,30 @@ TEST_CASE("/fdbserver/clustercontroller/rejectUnverifiedWorkerRegistration") {
 	request.recoveredDiskFiles = true;
 	registerWorker(request, &data);
 
-	state Optional<Standalone<StringRef>> processId = worker.locality.processId();
+	Optional<Standalone<StringRef>> processId = worker.locality.processId();
 	ASSERT(processId.present());
 	ASSERT(data.id_worker.contains(processId));
 	ASSERT(!data.id_worker[processId].verified);
 	ASSERT(!data.workerAvailable(data.id_worker[processId], false));
 
-	wait(delay(SERVER_KNOBS->WORKER_FAILURE_TIME + 1.0));
+	co_await delay(SERVER_KNOBS->WORKER_FAILURE_TIME + 1.0);
 	ASSERT(!data.id_worker.contains(processId));
-	return Void();
 }
 
 TEST_CASE("/fdbserver/clustercontroller/verifyLiveWorkerRegistration") {
-	state ClusterControllerData data(ClusterControllerFullInterface(),
-	                                 LocalityData(),
-	                                 ServerCoordinators(Reference<IClusterConnectionRecord>(
-	                                     new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
-	                                 makeReference<AsyncVar<Optional<UID>>>());
-	state LocalityData workerLocality;
+	ClusterControllerData data(ClusterControllerFullInterface(),
+	                           LocalityData(),
+	                           ServerCoordinators(Reference<IClusterConnectionRecord>(
+	                               new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
+	                           makeReference<AsyncVar<Optional<UID>>>());
+	LocalityData workerLocality;
 	workerLocality.set(LocalityData::keyProcessId, Standalone<StringRef>(std::string{ "verified-worker" }));
-	state WorkerInterface worker(workerLocality);
+	WorkerInterface worker(workerLocality);
 	worker.initEndpoints();
 	worker.storage.getEndpoint(TaskPriority::Worker);
-	state FutureStream<LoadedPingRequest> pings = worker.debugPing.getFuture();
+	FutureStream<LoadedPingRequest> pings = worker.debugPing.getFuture();
 
-	state RegisterWorkerRequest request;
+	RegisterWorkerRequest request;
 	request.wi = worker;
 	request.initialClass = ProcessClass(ProcessClass::StorageClass, ProcessClass::CommandLineSource);
 	request.processClass = request.initialClass;
@@ -3595,47 +3613,46 @@ TEST_CASE("/fdbserver/clustercontroller/verifyLiveWorkerRegistration") {
 	request.recoveredDiskFiles = true;
 	registerWorker(request, &data);
 
-	state Optional<Standalone<StringRef>> processId = worker.locality.processId();
+	Optional<Standalone<StringRef>> processId = worker.locality.processId();
 	ASSERT(processId.present());
 	ASSERT(data.id_worker.contains(processId));
 	ASSERT(!data.id_worker[processId].verified);
 
-	state LoadedPingRequest ping = waitNext(pings);
+	LoadedPingRequest ping = co_await pings;
 	ASSERT(ping.id == worker.id());
-	state LoadedReply reply;
+	LoadedReply reply;
 	reply.id = ping.id;
 	reply.payload = ""_sr;
 	ping.reply.send(reply);
 
 	// Allow workerAvailabilityWatch to mark this exact interface verified.
-	wait(delay(0.1));
+	co_await delay(0.1);
 	ASSERT(data.id_worker.contains(processId));
 	ASSERT(data.id_worker[processId].details.interf.id() == worker.id());
 	ASSERT(data.id_worker[processId].verified);
 	ASSERT(data.workerAvailable(data.id_worker[processId], false));
-	return Void();
 }
 
 TEST_CASE("/fdbserver/clustercontroller/unverifiedRegistrationCannotPublishSingleton") {
-	state ClusterControllerData data(ClusterControllerFullInterface(),
-	                                 LocalityData(),
-	                                 ServerCoordinators(Reference<IClusterConnectionRecord>(
-	                                     new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
-	                                 makeReference<AsyncVar<Optional<UID>>>());
-	state LocalityData workerLocality;
+	ClusterControllerData data(ClusterControllerFullInterface(),
+	                           LocalityData(),
+	                           ServerCoordinators(Reference<IClusterConnectionRecord>(
+	                               new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
+	                           makeReference<AsyncVar<Optional<UID>>>());
+	LocalityData workerLocality;
 	workerLocality.set(LocalityData::keyProcessId, Standalone<StringRef>(std::string{ "singleton-worker" }));
-	state WorkerInterface worker(workerLocality);
+	WorkerInterface worker(workerLocality);
 	worker.initEndpoints();
 	worker.storage.getEndpoint(TaskPriority::Worker);
-	state FutureStream<LoadedPingRequest> pings = worker.debugPing.getFuture();
-	state LocalityData currentDistributorLocality;
+	FutureStream<LoadedPingRequest> pings = worker.debugPing.getFuture();
+	LocalityData currentDistributorLocality;
 	currentDistributorLocality.set(LocalityData::keyProcessId,
 	                               Standalone<StringRef>(std::string{ "current-singleton" }));
-	state DataDistributorInterface currentDistributor(currentDistributorLocality, UID(1, 1));
-	state DataDistributorInterface distributor(workerLocality, UID(1, 2));
+	DataDistributorInterface currentDistributor(currentDistributorLocality, UID(1, 1));
+	DataDistributorInterface distributor(workerLocality, UID(1, 2));
 	data.db.setDistributor(currentDistributor);
 
-	state RegisterWorkerRequest request;
+	RegisterWorkerRequest request;
 	request.wi = worker;
 	request.initialClass = ProcessClass(ProcessClass::StorageClass, ProcessClass::CommandLineSource);
 	request.processClass = request.initialClass;
@@ -3644,44 +3661,43 @@ TEST_CASE("/fdbserver/clustercontroller/unverifiedRegistrationCannotPublishSingl
 	request.recoveredDiskFiles = true;
 	registerWorker(request, &data);
 
-	state Optional<Standalone<StringRef>> processId = worker.locality.processId();
+	Optional<Standalone<StringRef>> processId = worker.locality.processId();
 	ASSERT(processId.present());
 	ASSERT(data.id_worker.contains(processId));
 	ASSERT(!data.id_worker[processId].verified);
 	ASSERT(data.db.serverInfo->get().distributor.present());
 	ASSERT(data.db.serverInfo->get().distributor.get().id() == currentDistributor.id());
 
-	state LoadedPingRequest ping = waitNext(pings);
+	LoadedPingRequest ping = co_await pings;
 	ASSERT(ping.id == worker.id());
-	state LoadedReply reply;
+	LoadedReply reply;
 	reply.id = ping.id;
 	reply.payload = ""_sr;
 	ping.reply.send(reply);
 
 	// The singleton can be published only after this exact worker interface answers the verification ping.
-	wait(delay(0.1));
+	co_await delay(0.1);
 	ASSERT(data.id_worker.contains(processId));
 	ASSERT(data.id_worker[processId].verified);
 	ASSERT(data.db.serverInfo->get().distributor.present());
 	ASSERT(data.db.serverInfo->get().distributor.get().id() == distributor.id());
-	return Void();
 }
 
 TEST_CASE("/fdbserver/clustercontroller/staleWatcherCannotRemoveReplacement") {
-	state ClusterControllerData data(ClusterControllerFullInterface(),
-	                                 LocalityData(),
-	                                 ServerCoordinators(Reference<IClusterConnectionRecord>(
-	                                     new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
-	                                 makeReference<AsyncVar<Optional<UID>>>());
-	state LocalityData workerLocality;
+	ClusterControllerData data(ClusterControllerFullInterface(),
+	                           LocalityData(),
+	                           ServerCoordinators(Reference<IClusterConnectionRecord>(
+	                               new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
+	                           makeReference<AsyncVar<Optional<UID>>>());
+	LocalityData workerLocality;
 	workerLocality.set(LocalityData::keyProcessId, Standalone<StringRef>(std::string{ "replaced-worker" }));
 
-	state WorkerInterface oldWorker(workerLocality);
+	WorkerInterface oldWorker(workerLocality);
 	oldWorker.initEndpoints();
 	oldWorker.storage.getEndpoint(TaskPriority::Worker);
-	state FutureStream<LoadedPingRequest> oldPings = oldWorker.debugPing.getFuture();
+	FutureStream<LoadedPingRequest> oldPings = oldWorker.debugPing.getFuture();
 
-	state RegisterWorkerRequest oldRequest;
+	RegisterWorkerRequest oldRequest;
 	oldRequest.wi = oldWorker;
 	oldRequest.initialClass = ProcessClass(ProcessClass::StorageClass, ProcessClass::CommandLineSource);
 	oldRequest.processClass = oldRequest.initialClass;
@@ -3689,24 +3705,24 @@ TEST_CASE("/fdbserver/clustercontroller/staleWatcherCannotRemoveReplacement") {
 	oldRequest.recoveredDiskFiles = true;
 	registerWorker(oldRequest, &data);
 
-	state Optional<Standalone<StringRef>> processId = oldWorker.locality.processId();
+	Optional<Standalone<StringRef>> processId = oldWorker.locality.processId();
 	ASSERT(processId.present());
 
 	// Receive but deliberately do not answer the old interface's verification ping.
-	state LoadedPingRequest unansweredOldPing = waitNext(oldPings);
+	LoadedPingRequest unansweredOldPing = co_await oldPings;
 	ASSERT(unansweredOldPing.id == oldWorker.id());
 
 	// Retain the old watcher while preventing normal replacement from cancelling it.
-	state Future<Void> lateOldWatcher = data.id_worker[processId].watcher;
+	Future<Void> lateOldWatcher = data.id_worker[processId].watcher;
 	data.id_worker[processId].watcher = Never();
 
-	state WorkerInterface newWorker(workerLocality);
+	WorkerInterface newWorker(workerLocality);
 	newWorker.initEndpoints();
 	newWorker.storage.getEndpoint(TaskPriority::Worker);
 	ASSERT(newWorker.id() != oldWorker.id());
-	state FutureStream<LoadedPingRequest> newPings = newWorker.debugPing.getFuture();
+	FutureStream<LoadedPingRequest> newPings = newWorker.debugPing.getFuture();
 
-	state RegisterWorkerRequest newRequest;
+	RegisterWorkerRequest newRequest;
 	newRequest.wi = newWorker;
 	newRequest.initialClass = ProcessClass(ProcessClass::StorageClass, ProcessClass::CommandLineSource);
 	newRequest.processClass = newRequest.initialClass;
@@ -3718,49 +3734,48 @@ TEST_CASE("/fdbserver/clustercontroller/staleWatcherCannotRemoveReplacement") {
 	ASSERT(data.id_worker[processId].details.interf.id() == newWorker.id());
 	ASSERT(!data.id_worker[processId].verified);
 
-	state LoadedPingRequest newPing = waitNext(newPings);
+	LoadedPingRequest newPing = co_await newPings;
 	ASSERT(newPing.id == newWorker.id());
-	state LoadedReply newReply;
+	LoadedReply newReply;
 	newReply.id = newPing.id;
 	newReply.payload = ""_sr;
 	newPing.reply.send(newReply);
 
-	wait(delay(0.1));
+	co_await delay(0.1);
 	ASSERT(data.id_worker.contains(processId));
 	ASSERT(data.id_worker[processId].details.interf.id() == newWorker.id());
 	ASSERT(data.id_worker[processId].verified);
 
 	// The old ping timeout runs removeFailedWorker(oldWorker, ...). Its interface-ID guard must
 	// leave the verified replacement untouched.
-	wait(delay(SERVER_KNOBS->WORKER_FAILURE_TIME + 1.0));
+	co_await delay(SERVER_KNOBS->WORKER_FAILURE_TIME + 1.0);
 	ASSERT(lateOldWatcher.isReady());
 	ASSERT(!lateOldWatcher.isError());
 	ASSERT(data.id_worker.contains(processId));
 	ASSERT(data.id_worker[processId].details.interf.id() == newWorker.id());
 	ASSERT(data.id_worker[processId].verified);
-	return Void();
 }
 
 TEST_CASE("/fdbserver/clustercontroller/unverifiedMasterCannotWinSingletonRecruitment") {
-	state ClusterControllerData data(ClusterControllerFullInterface(),
-	                                 LocalityData(),
-	                                 ServerCoordinators(Reference<IClusterConnectionRecord>(
-	                                     new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
-	                                 makeReference<AsyncVar<Optional<UID>>>());
-	state LocalityData masterLocality;
+	ClusterControllerData data(ClusterControllerFullInterface(),
+	                           LocalityData(),
+	                           ServerCoordinators(Reference<IClusterConnectionRecord>(
+	                               new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
+	                           makeReference<AsyncVar<Optional<UID>>>());
+	LocalityData masterLocality;
 	masterLocality.set(LocalityData::keyProcessId, Standalone<StringRef>(std::string{ "unverified-master" }));
-	state WorkerInterface master(masterLocality);
+	WorkerInterface master(masterLocality);
 	master.initEndpoints();
 	master.storage.getEndpoint(TaskPriority::Worker);
 
-	state LocalityData candidateLocality;
+	LocalityData candidateLocality;
 	candidateLocality.set(LocalityData::keyProcessId, Standalone<StringRef>(std::string{ "singleton-candidate" }));
-	state WorkerInterface candidate(candidateLocality);
+	WorkerInterface candidate(candidateLocality);
 	candidate.initEndpoints();
 	candidate.storage.getEndpoint(TaskPriority::Worker);
 
-	state Optional<Standalone<StringRef>> masterProcessId = master.locality.processId();
-	state Optional<Standalone<StringRef>> candidateProcessId = candidate.locality.processId();
+	Optional<Standalone<StringRef>> masterProcessId = master.locality.processId();
+	Optional<Standalone<StringRef>> candidateProcessId = candidate.locality.processId();
 	ASSERT(masterProcessId.present());
 	ASSERT(candidateProcessId.present());
 	data.masterProcessId = masterProcessId;
@@ -3769,7 +3784,7 @@ TEST_CASE("/fdbserver/clustercontroller/unverifiedMasterCannotWinSingletonRecrui
 	data.id_worker[masterProcessId].details =
 	    WorkerDetails(master, ProcessClass(ProcessClass::StorageClass, ProcessClass::CommandLineSource), false, true);
 
-	state WorkerDetails candidateDetails(
+	WorkerDetails candidateDetails(
 	    candidate, ProcessClass(ProcessClass::StorageClass, ProcessClass::CommandLineSource), false, true);
 	ASSERT(!data.id_worker[masterProcessId].verified);
 	ASSERT(!data.onMasterIsBetter(candidateDetails, recruitment::DataDistributor));
@@ -3966,15 +3981,15 @@ TEST_CASE("/fdbserver/clustercontroller/avoidSatelliteTLogRouterColocation") {
 // based on `UpdateWorkerHealth` request correctly.
 TEST_CASE("/fdbserver/clustercontroller/updateWorkerHealth") {
 	// Create a testing ClusterControllerData. Most of the internal states do not matter in this test.
-	state ClusterControllerData data(ClusterControllerFullInterface(),
-	                                 LocalityData(),
-	                                 ServerCoordinators(Reference<IClusterConnectionRecord>(
-	                                     new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
-	                                 makeReference<AsyncVar<Optional<UID>>>());
-	state NetworkAddress workerAddress(IPAddress(0x01010101), 1);
-	state NetworkAddress badPeer1(IPAddress(0x02020202), 1);
-	state NetworkAddress badPeer2(IPAddress(0x03030303), 1);
-	state NetworkAddress badPeer3(IPAddress(0x04040404), 1);
+	ClusterControllerData data(ClusterControllerFullInterface(),
+	                           LocalityData(),
+	                           ServerCoordinators(Reference<IClusterConnectionRecord>(
+	                               new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
+	                           makeReference<AsyncVar<Optional<UID>>>());
+	NetworkAddress workerAddress(IPAddress(0x01010101), 1);
+	NetworkAddress badPeer1(IPAddress(0x02020202), 1);
+	NetworkAddress badPeer2(IPAddress(0x03030303), 1);
+	NetworkAddress badPeer3(IPAddress(0x04040404), 1);
 
 	// Create a `UpdateWorkerHealthRequest` with two bad peers, and they should appear in the
 	// `workerAddress`'s degradedPeers.
@@ -4003,11 +4018,11 @@ TEST_CASE("/fdbserver/clustercontroller/updateWorkerHealth") {
 	// Create a `UpdateWorkerHealthRequest` with two bad peers, one from the previous test and a new one.
 	// The one from the previous test should have lastRefreshTime updated.
 	// The other one from the previous test not included in this test should not be removed.
-	state double previousStartTime;
-	state double previousRefreshTime;
+	double previousStartTime{ 0 };
+	double previousRefreshTime{ 0 };
 	{
 		// Make the time to move so that now() guarantees to return a larger value than before.
-		wait(delay(0.001));
+		co_await delay(0.001);
 		UpdateWorkerHealthRequest req;
 		req.address = workerAddress;
 		req.degradedPeers.push_back(badPeer1);
@@ -4041,7 +4056,7 @@ TEST_CASE("/fdbserver/clustercontroller/updateWorkerHealth") {
 	// Create a `UpdateWorkerHealthRequest` with empty `degradedPeers`, which should not remove the worker
 	// from `workerHealth`.
 	{
-		wait(delay(0.001));
+		co_await delay(0.001);
 		UpdateWorkerHealthRequest req;
 		req.address = workerAddress;
 		data.updateWorkerHealth(req);
@@ -4059,7 +4074,7 @@ TEST_CASE("/fdbserver/clustercontroller/updateWorkerHealth") {
 
 	// Make badPeer1 a recovered peer, and CC should remove it from `workerAddress` bad peers.
 	{
-		wait(delay(0.001));
+		co_await delay(0.001);
 		UpdateWorkerHealthRequest req;
 		req.address = workerAddress;
 		req.recoveredPeers.push_back(badPeer1);
@@ -4068,8 +4083,6 @@ TEST_CASE("/fdbserver/clustercontroller/updateWorkerHealth") {
 		ASSERT(health.degradedPeers.find(badPeer1) == health.degradedPeers.end());
 		ASSERT(health.disconnectedPeers.find(badPeer1) == health.disconnectedPeers.end());
 	}
-
-	return Void();
 }
 
 TEST_CASE("/fdbserver/clustercontroller/updateRecoveredWorkers") {

--- a/fdbserver/clustercontroller/ClusterController.cpp
+++ b/fdbserver/clustercontroller/ClusterController.cpp
@@ -508,8 +508,6 @@ Future<Void> monitorAndRecruitWorkerSet(ClusterControllerData* self,
 				TraceEvent((std::string(workerName) + "ReRecruitmentSuccess").c_str(), self->id)
 				    .detail("RecoveryCount", recoveryCount);
 				recruitment = Never();
-			} else {
-				UNREACHABLE();
 			}
 		} catch (Error& e) {
 			if (strcmp(workerName, "LogRouter") == 0) {
@@ -1362,8 +1360,6 @@ Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 			// remove workers that have failed
 			removeFailedWorker(worker, cluster);
 			co_return;
-		} else {
-			UNREACHABLE();
 		}
 	}
 }
@@ -3502,8 +3498,6 @@ Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
 		// We are no longer the leader if this has changed.
 		endRole(Role::CLUSTER_CONTROLLER, interf.id(), "Leader Replaced", true);
 		CODE_PROBE(true, "Leader replaced");
-	} else {
-		UNREACHABLE();
 	}
 }
 


### PR DESCRIPTION
This PR converts remaining actors in `ClusterController.actor.cpp` to standard coroutines using the actor rewrite tool. `clusterControllerCore` is further refactored to avoid a large `race` inside of an infinite loop.
