### PR TITLE
Retry transient errors when reading consistency-check server tags

### DIFF
--- a/fdbserver/consistencyscan/ConsistencyScan.cpp
+++ b/fdbserver/consistencyscan/ConsistencyScan.cpp
@@ -1746,10 +1746,20 @@ Future<Void> checkDataConsistency(Database cx,
 		std::vector<UID> sourceStorageServers;
 		std::vector<UID> destStorageServers;
 		Transaction tr(cx);
-		tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 		int bytesReadInRange = 0;
 
-		RangeResult UIDtoTagMap = co_await tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY);
+		RangeResult UIDtoTagMap;
+		while (true) {
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+			Error err;
+			try {
+				UIDtoTagMap = co_await tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY);
+				break;
+			} catch (Error& e) {
+				err = e;
+			}
+			co_await tr.onError(err);
+		}
 		ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
 		decodeKeyServersValue(UIDtoTagMap, keyLocations[shard].value, sourceStorageServers, destStorageServers, false);
 


### PR DESCRIPTION
## Summary

- Retry transient transaction errors while reading the server-tag map for consistency-check shards.
- Reapply `LOCK_AWARE` after transaction resets and complete shard validation instead of treating a retryable error as a consistency failure.

## Validation

- Built and ran `fdbserver_consistencyscanlinktest` with Clang.
- Reproduced the failing `tests/fast/FuzzApiCorrectnessClean.toml` simulation with fault injection enabled.
- Replayed the identical failing configuration and seed with the fix: all consistency checks completed successfully.
