### PR TITLE
Extract mapped-range key codec into MappedKeyPlan

### DIFF
--- a/fdbserver/storageserver/MappedKeyPlan.cpp
+++ b/fdbserver/storageserver/MappedKeyPlan.cpp
@@ -1,0 +1,156 @@
+/*
+ * MappedKeyPlan.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MappedKeyPlan.h"
+
+#include <exception>
+#include <string>
+
+#include "flow/Trace.h"
+
+namespace {
+
+const Tuple& unpackKeyTuple(Optional<Tuple>& keyTuple, const KeyValueRef& keyValue) {
+	if (!keyTuple.present()) {
+		try {
+			keyTuple = Tuple::unpack(keyValue.key);
+		} catch (Error& e) {
+			TraceEvent("KeyNotTuple").error(e).detail("Key", keyValue.key.printable());
+			throw key_not_tuple();
+		}
+	}
+	return keyTuple.get();
+}
+
+const Tuple& unpackValueTuple(Optional<Tuple>& valueTuple, const KeyValueRef& keyValue) {
+	if (!valueTuple.present()) {
+		try {
+			valueTuple = Tuple::unpack(keyValue.value);
+		} catch (Error& e) {
+			TraceEvent("ValueNotTuple").error(e).detail("Value", keyValue.value.printable());
+			throw value_not_tuple();
+		}
+	}
+	return valueTuple.get();
+}
+
+bool unescapeLiterals(std::string& value, const std::string& before, const std::string& after) {
+	bool escaped = false;
+	size_t position = 0;
+	while (true) {
+		size_t found = value.find(before, position);
+		if (found == std::string::npos) {
+			break;
+		}
+		value.replace(found, before.length(), after);
+		position = found + after.length();
+		escaped = true;
+	}
+	return escaped;
+}
+
+bool singleKeyOrValue(const std::string& value, size_t size) {
+	return size > 5 && value[0] == '{' && (value[1] == 'K' || value[1] == 'V') && value[2] == '[' &&
+	       value[size - 2] == ']' && value[size - 1] == '}';
+}
+
+} // namespace
+
+MappedKeyPlan::MappedKeyPlan(StringRef mapper) {
+	try {
+		mappedKeyFormatTuple = Tuple::unpack(mapper);
+	} catch (Error& e) {
+		TraceEvent("MapperNotTuple").error(e).detail("Mapper", mapper);
+		throw mapper_not_tuple();
+	}
+
+	mappedKeyElements.reserve(mappedKeyFormatTuple.size());
+
+	for (size_t i = 0; i < mappedKeyFormatTuple.size(); i++) {
+		Tuple::ElementType type = mappedKeyFormatTuple.getType(i);
+		if (type == Tuple::BYTES || type == Tuple::UTF8) {
+			std::string value = mappedKeyFormatTuple.getString(i).toString();
+			auto size = value.size();
+			bool escaped = unescapeLiterals(value, "{{", "{");
+			escaped = unescapeLiterals(value, "}}", "}") || escaped;
+			if (escaped) {
+				mappedKeyElements.emplace_back(Tuple::makeTuple(value));
+			} else if (singleKeyOrValue(value, size)) {
+				mappedKeyElements.emplace_back(Tuple());
+			} else if (value == "{...}") {
+				if (i != mappedKeyFormatTuple.size() - 1) {
+					throw mapper_bad_range_decriptor();
+				}
+				mappedKeyElements.emplace_back(Optional<Tuple>());
+				rangeQuery = true;
+			} else {
+				Tuple element;
+				element.appendRaw(mappedKeyFormatTuple.subTupleRawString(i));
+				mappedKeyElements.emplace_back(element);
+			}
+		} else {
+			Tuple element;
+			element.appendRaw(mappedKeyFormatTuple.subTupleRawString(i));
+			mappedKeyElements.emplace_back(element);
+		}
+	}
+}
+
+Key MappedKeyPlan::constructMappedKey(const KeyValueRef& keyValue) const {
+	Optional<Tuple> keyTuple;
+	Optional<Tuple> valueTuple;
+	Tuple mappedKeyTuple;
+
+	mappedKeyTuple.reserve(mappedKeyElements.size());
+
+	for (size_t i = 0; i < mappedKeyElements.size(); i++) {
+		if (!mappedKeyElements[i].present()) {
+			continue;
+		}
+		if (mappedKeyElements[i].get().size()) {
+			mappedKeyTuple.append(mappedKeyElements[i].get());
+		} else {
+			std::string value = mappedKeyFormatTuple.getString(i).toString();
+			auto size = value.size();
+			int index;
+			try {
+				index = std::stoi(value.substr(3, size - 5));
+			} catch (std::exception& e) {
+				throw mapper_bad_index();
+			}
+
+			const Tuple* referenceTuple;
+			if (value[1] == 'K') {
+				referenceTuple = &unpackKeyTuple(keyTuple, keyValue);
+			} else if (value[1] == 'V') {
+				referenceTuple = &unpackValueTuple(valueTuple, keyValue);
+			} else {
+				ASSERT(false);
+				throw internal_error();
+			}
+			if (index < 0 || index >= referenceTuple->size()) {
+				throw mapper_bad_index();
+			}
+			mappedKeyTuple.appendRaw(referenceTuple->subTupleRawString(index));
+		}
+	}
+
+	return mappedKeyTuple.pack();
+}

--- a/fdbserver/storageserver/MappedKeyPlan.h
+++ b/fdbserver/storageserver/MappedKeyPlan.h
@@ -1,0 +1,43 @@
+/*
+ * MappedKeyPlan.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBSERVER_STORAGESERVER_MAPPEDKEYPLAN_H
+#define FDBSERVER_STORAGESERVER_MAPPEDKEYPLAN_H
+#pragma once
+
+#include <vector>
+
+#include "fdbclient/FDBTypes.h"
+#include "fdbclient/Tuple.h"
+
+class MappedKeyPlan {
+public:
+	explicit MappedKeyPlan(StringRef mapper);
+
+	Key constructMappedKey(const KeyValueRef& keyValue) const;
+	bool isRangeQuery() const { return rangeQuery; }
+
+private:
+	Tuple mappedKeyFormatTuple;
+	std::vector<Optional<Tuple>> mappedKeyElements;
+	bool rangeQuery = false;
+};
+
+#endif

--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -51,6 +51,7 @@
 #include "fdbserver/core/MoveKeys.h"
 #include "fdbserver/core/MutationTracking.h"
 #include "fdbserver/core/OTELSpanContextMessage.h"
+#include "MappedKeyPlan.h"
 #include "ReadLatencySamples.h"
 #include "fdbserver/core/RecoveryState.h"
 #include "fdbserver/core/RocksDBCheckpointUtils.h"
@@ -3621,140 +3622,6 @@ Future<GetRangeReqAndResultRef> quickGetKeyValues(StorageServer* data,
 	}
 }
 
-void unpackKeyTuple(Tuple** referenceTuple, Optional<Tuple>& keyTuple, KeyValueRef* keyValue) {
-	if (!keyTuple.present()) {
-		// May throw exception if the key is not parsable as a tuple.
-		try {
-			keyTuple = Tuple::unpack(keyValue->key);
-		} catch (Error& e) {
-			TraceEvent("KeyNotTuple").error(e).detail("Key", keyValue->key.printable());
-			throw key_not_tuple();
-		}
-	}
-	*referenceTuple = &keyTuple.get();
-}
-
-void unpackValueTuple(Tuple** referenceTuple, Optional<Tuple>& valueTuple, KeyValueRef* keyValue) {
-	if (!valueTuple.present()) {
-		// May throw exception if the value is not parsable as a tuple.
-		try {
-			valueTuple = Tuple::unpack(keyValue->value);
-		} catch (Error& e) {
-			TraceEvent("ValueNotTuple").error(e).detail("Value", keyValue->value.printable());
-			throw value_not_tuple();
-		}
-	}
-	*referenceTuple = &valueTuple.get();
-}
-
-bool unescapeLiterals(std::string& s, std::string before, std::string after) {
-	bool escaped = false;
-	size_t p = 0;
-	while (true) {
-		size_t found = s.find(before, p);
-		if (found == std::string::npos) {
-			break;
-		}
-		s.replace(found, before.length(), after);
-		p = found + after.length();
-		escaped = true;
-	}
-	return escaped;
-}
-
-bool singleKeyOrValue(const std::string& s, size_t sz) {
-	// format would be {K[??]} or {V[??]}
-	return sz > 5 && s[0] == '{' && (s[1] == 'K' || s[1] == 'V') && s[2] == '[' && s[sz - 2] == ']' && s[sz - 1] == '}';
-}
-
-bool rangeQuery(const std::string& s) {
-	return s == "{...}";
-}
-
-// create a vector of Optional<Tuple>
-// in case of a singleKeyOrValue, insert an empty Tuple to vector as placeholder
-// in case of a rangeQuery, insert Optional.empty as placeholder
-// in other cases, insert the correct Tuple to be used.
-void preprocessMappedKey(Tuple& mappedKeyFormatTuple, std::vector<Optional<Tuple>>& vt, bool& isRangeQuery) {
-	vt.reserve(mappedKeyFormatTuple.size());
-
-	for (int i = 0; i < mappedKeyFormatTuple.size(); i++) {
-		Tuple::ElementType type = mappedKeyFormatTuple.getType(i);
-		if (type == Tuple::BYTES || type == Tuple::UTF8) {
-			std::string s = mappedKeyFormatTuple.getString(i).toString();
-			auto sz = s.size();
-			bool escaped = unescapeLiterals(s, "{{", "{");
-			escaped = unescapeLiterals(s, "}}", "}") || escaped;
-			if (escaped) {
-				vt.emplace_back(Tuple::makeTuple(s));
-			} else if (singleKeyOrValue(s, sz)) {
-				// when it is SingleKeyOrValue, insert an empty Tuple to vector as placeholder
-				vt.emplace_back(Tuple());
-			} else if (rangeQuery(s)) {
-				if (i != mappedKeyFormatTuple.size() - 1) {
-					// It must be the last element of the mapper tuple
-					throw mapper_bad_range_decriptor();
-				}
-				// when it is rangeQuery, insert Optional.empty as placeholder
-				vt.emplace_back(Optional<Tuple>());
-				isRangeQuery = true;
-			} else {
-				Tuple t;
-				t.appendRaw(mappedKeyFormatTuple.subTupleRawString(i));
-				vt.emplace_back(t);
-			}
-		} else {
-			Tuple t;
-			t.appendRaw(mappedKeyFormatTuple.subTupleRawString(i));
-			vt.emplace_back(t);
-		}
-	}
-}
-
-Key constructMappedKey(KeyValueRef* keyValue, std::vector<Optional<Tuple>>& vec, Tuple& mappedKeyFormatTuple) {
-	// Lazily parse key and/or value to tuple because they may not need to be a tuple if not used.
-	Optional<Tuple> keyTuple;
-	Optional<Tuple> valueTuple;
-	Tuple mappedKeyTuple;
-
-	mappedKeyTuple.reserve(vec.size());
-
-	for (int i = 0; i < vec.size(); i++) {
-		if (!vec[i].present()) {
-			// rangeQuery
-			continue;
-		}
-		if (vec[i].get().size()) {
-			mappedKeyTuple.append(vec[i].get());
-		} else {
-			// singleKeyOrValue is true
-			std::string s = mappedKeyFormatTuple.getString(i).toString();
-			auto sz = s.size();
-			int idx;
-			Tuple* referenceTuple;
-			try {
-				idx = std::stoi(s.substr(3, sz - 5));
-			} catch (std::exception& e) {
-				throw mapper_bad_index();
-			}
-			if (s[1] == 'K') {
-				unpackKeyTuple(&referenceTuple, keyTuple, keyValue);
-			} else if (s[1] == 'V') {
-				unpackValueTuple(&referenceTuple, valueTuple, keyValue);
-			} else {
-				ASSERT(false);
-				throw internal_error();
-			}
-			if (idx < 0 || idx >= referenceTuple->size()) {
-				throw mapper_bad_index();
-			}
-			mappedKeyTuple.appendRaw(referenceTuple->subTupleRawString(idx));
-		}
-	}
-
-	return mappedKeyTuple.pack();
-}
-
 struct AuditGetShardInfoRes {
 	Version readAtVersion;
 	UID serverId;
@@ -5407,55 +5274,42 @@ TEST_CASE("/fdbserver/storageserver/constructMappedKey") {
 	{
 		Tuple mappedKeyFormatTuple =
 		    Tuple::makeTuple("normal"_sr, "{{escaped}}"_sr, "{K[2]}"_sr, "{V[0]}"_sr, "{...}"_sr);
-
-		std::vector<Optional<Tuple>> vt;
-		bool isRangeQuery = false;
-		preprocessMappedKey(mappedKeyFormatTuple, vt, isRangeQuery);
-
-		Key mappedKey = constructMappedKey(&kvr, vt, mappedKeyFormatTuple);
+		MappedKeyPlan mappedKeyPlan(mappedKeyFormatTuple.pack());
+		Key mappedKey = mappedKeyPlan.constructMappedKey(kvr);
 
 		Key expectedMappedKey =
 		    Tuple::makeTuple("normal"_sr, "{escaped}"_sr, "key-2"_sr, "value-0"_sr).getDataAsStandalone();
 		//		std::cout << printable(mappedKey) << " == " << printable(expectedMappedKey) << std::endl;
 		ASSERT(mappedKey.compare(expectedMappedKey) == 0);
-		ASSERT(isRangeQuery == true);
+		ASSERT(mappedKeyPlan.isRangeQuery() == true);
 	}
 
 	{
 		Tuple mappedKeyFormatTuple = Tuple::makeTuple("{{{{}}"_sr, "}}"_sr);
-
-		std::vector<Optional<Tuple>> vt;
-		bool isRangeQuery = false;
-		preprocessMappedKey(mappedKeyFormatTuple, vt, isRangeQuery);
-		Key mappedKey = constructMappedKey(&kvr, vt, mappedKeyFormatTuple);
+		MappedKeyPlan mappedKeyPlan(mappedKeyFormatTuple.pack());
+		Key mappedKey = mappedKeyPlan.constructMappedKey(kvr);
 
 		Key expectedMappedKey = Tuple::makeTuple("{{}"_sr, "}"_sr).getDataAsStandalone();
 		//		std::cout << printable(mappedKey) << " == " << printable(expectedMappedKey) << std::endl;
 		ASSERT(mappedKey.compare(expectedMappedKey) == 0);
-		ASSERT(isRangeQuery == false);
+		ASSERT(mappedKeyPlan.isRangeQuery() == false);
 	}
 	{
 		Tuple mappedKeyFormatTuple = Tuple::makeTuple("{{{{}}"_sr, "}}"_sr);
-
-		std::vector<Optional<Tuple>> vt;
-		bool isRangeQuery = false;
-		preprocessMappedKey(mappedKeyFormatTuple, vt, isRangeQuery);
-		Key mappedKey = constructMappedKey(&kvr, vt, mappedKeyFormatTuple);
+		MappedKeyPlan mappedKeyPlan(mappedKeyFormatTuple.pack());
+		Key mappedKey = mappedKeyPlan.constructMappedKey(kvr);
 
 		Key expectedMappedKey = Tuple::makeTuple("{{}"_sr, "}"_sr).getDataAsStandalone();
 		//		std::cout << printable(mappedKey) << " == " << printable(expectedMappedKey) << std::endl;
 		ASSERT(mappedKey.compare(expectedMappedKey) == 0);
-		ASSERT(isRangeQuery == false);
+		ASSERT(mappedKeyPlan.isRangeQuery() == false);
 	}
 	{
 		Tuple mappedKeyFormatTuple = Tuple::makeTuple("{K[100]}"_sr);
 		bool throwException = false;
 		try {
-			std::vector<Optional<Tuple>> vt;
-			bool isRangeQuery = false;
-			preprocessMappedKey(mappedKeyFormatTuple, vt, isRangeQuery);
-
-			Key mappedKey = constructMappedKey(&kvr, vt, mappedKeyFormatTuple);
+			MappedKeyPlan mappedKeyPlan(mappedKeyFormatTuple.pack());
+			Key mappedKey = mappedKeyPlan.constructMappedKey(kvr);
 		} catch (Error& e) {
 			ASSERT(e.code() == error_code_mapper_bad_index);
 			throwException = true;
@@ -5466,11 +5320,8 @@ TEST_CASE("/fdbserver/storageserver/constructMappedKey") {
 		Tuple mappedKeyFormatTuple = Tuple::makeTuple("{...}"_sr, "last-element"_sr);
 		bool throwException2 = false;
 		try {
-			std::vector<Optional<Tuple>> vt;
-			bool isRangeQuery = false;
-			preprocessMappedKey(mappedKeyFormatTuple, vt, isRangeQuery);
-
-			Key mappedKey = constructMappedKey(&kvr, vt, mappedKeyFormatTuple);
+			MappedKeyPlan mappedKeyPlan(mappedKeyFormatTuple.pack());
+			Key mappedKey = mappedKeyPlan.constructMappedKey(kvr);
 		} catch (Error& e) {
 			ASSERT(e.code() == error_code_mapper_bad_range_decriptor);
 			throwException2 = true;
@@ -5481,16 +5332,27 @@ TEST_CASE("/fdbserver/storageserver/constructMappedKey") {
 		Tuple mappedKeyFormatTuple = Tuple::makeTuple("{K[not-a-number]}"_sr);
 		bool throwException3 = false;
 		try {
-			std::vector<Optional<Tuple>> vt;
-			bool isRangeQuery = false;
-			preprocessMappedKey(mappedKeyFormatTuple, vt, isRangeQuery);
-
-			Key mappedKey = constructMappedKey(&kvr, vt, mappedKeyFormatTuple);
+			MappedKeyPlan mappedKeyPlan(mappedKeyFormatTuple.pack());
+			Key mappedKey = mappedKeyPlan.constructMappedKey(kvr);
 		} catch (Error& e) {
 			ASSERT(e.code() == error_code_mapper_bad_index);
 			throwException3 = true;
 		}
 		ASSERT(throwException3);
+	}
+	{
+		KeyValueRef invalidKeyAndValue("\xff"_sr, "\xff"_sr);
+		MappedKeyPlan literalPlan(Tuple::makeTuple("literal"_sr).pack());
+		ASSERT(literalPlan.constructMappedKey(invalidKeyAndValue) ==
+		       Tuple::makeTuple("literal"_sr).getDataAsStandalone());
+
+		KeyValueRef invalidValue(key, "\xff"_sr);
+		MappedKeyPlan keyPlan(Tuple::makeTuple("{K[1]}"_sr).pack());
+		ASSERT(keyPlan.constructMappedKey(invalidValue) == Tuple::makeTuple("key-1"_sr).getDataAsStandalone());
+
+		KeyValueRef invalidKey("\xff"_sr, value);
+		MappedKeyPlan valuePlan(Tuple::makeTuple("{V[1]}"_sr).pack());
+		ASSERT(valuePlan.constructMappedKey(invalidKey) == Tuple::makeTuple("value-1"_sr).getDataAsStandalone());
 	}
 	return Void();
 }
@@ -5546,17 +5408,7 @@ Future<GetMappedKeyValuesReply> mapKeyValues(StorageServer* data,
 	if (pOriginalReq->options.present() && pOriginalReq->options.get().debugID.present())
 		g_traceBatch.addEvent(
 		    "TransactionDebug", pOriginalReq->options.get().debugID.get().first(), "storageserver.mapKeyValues.Start");
-	Tuple mappedKeyFormatTuple;
-
-	try {
-		mappedKeyFormatTuple = Tuple::unpack(mapper);
-	} catch (Error& e) {
-		TraceEvent("MapperNotTuple").error(e).detail("Mapper", mapper);
-		throw mapper_not_tuple();
-	}
-	std::vector<Optional<Tuple>> vt;
-	bool isRangeQuery = false;
-	preprocessMappedKey(mappedKeyFormatTuple, vt, isRangeQuery);
+	MappedKeyPlan mappedKeyPlan(mapper);
 
 	int sz = input.data.size();
 	const int k = std::min(sz, SERVER_KNOBS->MAX_PARALLEL_QUICK_GET_VALUE);
@@ -5577,15 +5429,15 @@ Future<GetMappedKeyValuesReply> mapKeyValues(StorageServer* data,
 			// Clear key value to the default.
 			kvm->key = ""_sr;
 			kvm->value = ""_sr;
-			Key mappedKey = constructMappedKey(it, vt, mappedKeyFormatTuple);
+			Key mappedKey = mappedKeyPlan.constructMappedKey(*it);
 			// Make sure the mappedKey is always available, so that it's good even we want to get key asynchronously.
 			result.arena.dependsOn(mappedKey.arena());
 
 			// std::cout << "key:" << printable(kvm->key) << ", value:" << printable(kvm->value)
 			//          << ", mappedKey:" << printable(mappedKey) << std::endl;
 
-			subqueries.push_back(
-			    mapSubquery(data, input.version, pOriginalReq, &result.arena, isRangeQuery, it, kvm, mappedKey));
+			subqueries.push_back(mapSubquery(
+			    data, input.version, pOriginalReq, &result.arena, mappedKeyPlan.isRangeQuery(), it, kvm, mappedKey));
 		}
 		co_await waitForAll(subqueries);
 		if (pOriginalReq->options.present() && pOriginalReq->options.get().debugID.present()) {


### PR DESCRIPTION
## Summary

- Extract mapped-range mapper parsing and key construction into a private `MappedKeyPlan` within the storage-server component.
- Preserve escaped literals, key/value tuple substitutions, range markers, error handling, and mapped-key ownership.
- Extend mapped-key coverage to verify that key and value tuples are decoded only when the mapper references them.

This helps to reduce the size of the large `storageserver.cpp` file.

## Validation

- `fdbserver_storageserver_test`
- `fdbserver_storageserver_test -f /fdbserver/storageserver/constructMappedKey`
