### PR TITLE
Extract shared client option validation

### DIFF
--- a/fdbclient/ClientOptionValidation.cpp
+++ b/fdbclient/ClientOptionValidation.cpp
@@ -30,7 +30,7 @@ void validateOptionValuePresent(Optional<StringRef> value) {
 }
 
 void validateOptionValueNotPresent(Optional<StringRef> value) {
-	if (value.present() && value.get().size() > 0) {
+	if (value.present() && !value.get().empty()) {
 		throw invalid_option_value();
 	}
 }

--- a/fdbclient/ClientOptionValidation.cpp
+++ b/fdbclient/ClientOptionValidation.cpp
@@ -20,6 +20,8 @@
 
 #include "fdbclient/ClientOptionValidation.h"
 
+#include <cstring>
+
 #include "flow/Error.h"
 #include "flow/UnitTest.h"
 
@@ -55,10 +57,11 @@ template <class Validate>
 void expectInvalidOptionValue(Validate&& validate) {
 	try {
 		validate();
-		ASSERT(false);
 	} catch (Error& error) {
 		ASSERT_EQ(error.code(), error_code_invalid_option_value);
+		return;
 	}
+	ASSERT(false);
 }
 
 } // namespace
@@ -80,8 +83,13 @@ TEST_CASE("/fdbclient/ClientOptionValidation/Presence") {
 }
 
 TEST_CASE("/fdbclient/ClientOptionValidation/Integer") {
-	int64_t encodedValue = -123;
-	const Optional<StringRef> value = StringRef(reinterpret_cast<const uint8_t*>(&encodedValue), sizeof(encodedValue));
+	const auto encode = [](int64_t value) {
+		Standalone<StringRef> encoded = makeAlignedString(alignof(int64_t), sizeof(value));
+		std::memcpy(mutateString(encoded), &value, sizeof(value));
+		return encoded;
+	};
+	const int64_t encodedValue = -123;
+	const Standalone<StringRef> value = encode(encodedValue);
 	const Optional<StringRef> missing;
 	const Optional<StringRef> empty = StringRef();
 	const uint8_t oversized[sizeof(encodedValue) + 1] = {};
@@ -90,17 +98,13 @@ TEST_CASE("/fdbclient/ClientOptionValidation/Integer") {
 	ASSERT_EQ(extractIntOption(value, encodedValue, encodedValue), encodedValue);
 	expectInvalidOptionValue([&] { extractIntOption(missing); });
 	expectInvalidOptionValue([&] { extractIntOption(empty); });
-	expectInvalidOptionValue([&] {
-		extractIntOption(StringRef(reinterpret_cast<const uint8_t*>(&encodedValue), sizeof(encodedValue) - 1));
-	});
+	expectInvalidOptionValue([&] { extractIntOption(StringRef(value.begin(), value.size() - 1)); });
 	expectInvalidOptionValue([&] { extractIntOption(StringRef(oversized, sizeof(oversized))); });
 	expectInvalidOptionValue([&] { extractIntOption(value, encodedValue + 1); });
 	expectInvalidOptionValue([&] { extractIntOption(value, std::numeric_limits<int64_t>::min(), encodedValue - 1); });
 
-	encodedValue = std::numeric_limits<int64_t>::min();
-	ASSERT_EQ(extractIntOption(value), encodedValue);
-	encodedValue = std::numeric_limits<int64_t>::max();
-	ASSERT_EQ(extractIntOption(value), encodedValue);
+	ASSERT_EQ(extractIntOption(encode(std::numeric_limits<int64_t>::min())), std::numeric_limits<int64_t>::min());
+	ASSERT_EQ(extractIntOption(encode(std::numeric_limits<int64_t>::max())), std::numeric_limits<int64_t>::max());
 
 	return Void();
 }

--- a/fdbclient/ClientOptionValidation.cpp
+++ b/fdbclient/ClientOptionValidation.cpp
@@ -1,0 +1,106 @@
+/*
+ * ClientOptionValidation.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbclient/ClientOptionValidation.h"
+
+#include "flow/Error.h"
+#include "flow/UnitTest.h"
+
+void validateOptionValuePresent(Optional<StringRef> value) {
+	if (!value.present()) {
+		throw invalid_option_value();
+	}
+}
+
+void validateOptionValueNotPresent(Optional<StringRef> value) {
+	if (value.present() && value.get().size() > 0) {
+		throw invalid_option_value();
+	}
+}
+
+int64_t extractIntOption(Optional<StringRef> value, int64_t minValue, int64_t maxValue) {
+	validateOptionValuePresent(value);
+	if (value.get().size() != 8) {
+		throw invalid_option_value();
+	}
+
+	int64_t passed = *((int64_t*)(value.get().begin()));
+	if (passed > maxValue || passed < minValue) {
+		throw invalid_option_value();
+	}
+
+	return passed;
+}
+
+namespace {
+
+template <class Validate>
+void expectInvalidOptionValue(Validate&& validate) {
+	try {
+		validate();
+		ASSERT(false);
+	} catch (Error& error) {
+		ASSERT_EQ(error.code(), error_code_invalid_option_value);
+	}
+}
+
+} // namespace
+
+TEST_CASE("/fdbclient/ClientOptionValidation/Presence") {
+	const Optional<StringRef> missing;
+	const Optional<StringRef> empty = StringRef();
+	const Optional<StringRef> nonEmpty = "value"_sr;
+
+	expectInvalidOptionValue([&] { validateOptionValuePresent(missing); });
+	validateOptionValuePresent(empty);
+	validateOptionValuePresent(nonEmpty);
+
+	validateOptionValueNotPresent(missing);
+	validateOptionValueNotPresent(empty);
+	expectInvalidOptionValue([&] { validateOptionValueNotPresent(nonEmpty); });
+
+	return Void();
+}
+
+TEST_CASE("/fdbclient/ClientOptionValidation/Integer") {
+	int64_t encodedValue = -123;
+	const Optional<StringRef> value = StringRef(reinterpret_cast<const uint8_t*>(&encodedValue), sizeof(encodedValue));
+	const Optional<StringRef> missing;
+	const Optional<StringRef> empty = StringRef();
+	const uint8_t oversized[sizeof(encodedValue) + 1] = {};
+
+	ASSERT_EQ(extractIntOption(value), encodedValue);
+	ASSERT_EQ(extractIntOption(value, encodedValue, encodedValue), encodedValue);
+	expectInvalidOptionValue([&] { extractIntOption(missing); });
+	expectInvalidOptionValue([&] { extractIntOption(empty); });
+	expectInvalidOptionValue([&] {
+		extractIntOption(StringRef(reinterpret_cast<const uint8_t*>(&encodedValue), sizeof(encodedValue) - 1));
+	});
+	expectInvalidOptionValue([&] { extractIntOption(StringRef(oversized, sizeof(oversized))); });
+	expectInvalidOptionValue([&] { extractIntOption(value, encodedValue + 1); });
+	expectInvalidOptionValue([&] { extractIntOption(value, std::numeric_limits<int64_t>::min(), encodedValue - 1); });
+
+	encodedValue = std::numeric_limits<int64_t>::min();
+	ASSERT_EQ(extractIntOption(value), encodedValue);
+	encodedValue = std::numeric_limits<int64_t>::max();
+	ASSERT_EQ(extractIntOption(value), encodedValue);
+
+	return Void();
+}

--- a/fdbclient/MultiVersionTransaction.cpp
+++ b/fdbclient/MultiVersionTransaction.cpp
@@ -28,6 +28,7 @@
 #include <sanitizer/lsan_interface.h>
 #endif
 
+#include "fdbclient/ClientOptionValidation.h"
 #include "fdbclient/FDBOptions.g.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/GenericManagementAPI.h"
@@ -1411,30 +1412,6 @@ Future<Void> timeoutImpl(Reference<ThreadSingleAssignmentVar<Void>> tsav, double
 
 	tsav->trySendError(transaction_timed_out());
 }
-
-namespace {
-
-void validateOptionValuePresent(Optional<StringRef> value) {
-	if (!value.present()) {
-		throw invalid_option_value();
-	}
-}
-
-int64_t extractIntOption(Optional<StringRef> value, int64_t minValue, int64_t maxValue) {
-	validateOptionValuePresent(value);
-	if (value.get().size() != 8) {
-		throw invalid_option_value();
-	}
-
-	int64_t passed = *((int64_t*)(value.get().begin()));
-	if (passed > maxValue || passed < minValue) {
-		throw invalid_option_value();
-	}
-
-	return passed;
-}
-
-} // namespace
 
 // Configure a timeout based on the options set for this transaction. This timeout only applies
 // if we don't have an underlying database object to connect with.

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -48,6 +48,7 @@
 #include "fdbclient/ActorLineageProfiler.h"
 #include "fdbclient/AnnotateActor.h"
 #include "fdbclient/Atomic.h"
+#include "fdbclient/ClientOptionValidation.h"
 #include "fdbclient/ClusterInterface.h"
 #include "fdbclient/ClusterConnectionFile.h"
 #include "fdbclient/ClusterConnectionMemoryRecord.h"

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -275,32 +275,6 @@ bool DatabaseContext::sampleOnCost(uint64_t cost) const {
 	return deterministicRandom()->random01() <= (double)cost / sampleCost;
 }
 
-void validateOptionValuePresent(Optional<StringRef> value) {
-	if (!value.present()) {
-		throw invalid_option_value();
-	}
-}
-
-void validateOptionValueNotPresent(Optional<StringRef> value) {
-	if (value.present() && value.get().size() > 0) {
-		throw invalid_option_value();
-	}
-}
-
-int64_t extractIntOption(Optional<StringRef> value, int64_t minValue, int64_t maxValue) {
-	validateOptionValuePresent(value);
-	if (value.get().size() != 8) {
-		throw invalid_option_value();
-	}
-
-	int64_t passed = *((int64_t*)(value.get().begin()));
-	if (passed > maxValue || passed < minValue) {
-		throw invalid_option_value();
-	}
-
-	return passed;
-}
-
 void DatabaseContext::setOption(FDBDatabaseOptions::Option option, Optional<StringRef> value) {
 	int defaultFor = FDBDatabaseOptions::optionInfo.getMustExist(option).defaultFor;
 	if (defaultFor >= 0) {

--- a/fdbclient/ReadYourWrites.cpp
+++ b/fdbclient/ReadYourWrites.cpp
@@ -20,6 +20,7 @@
 
 #include "fdbclient/ReadYourWrites.h"
 #include "RYWIterator.h"
+#include "fdbclient/ClientOptionValidation.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/Atomic.h"
 #include "fdbclient/DatabaseContext.h"

--- a/fdbclient/include/fdbclient/ClientOptionValidation.h
+++ b/fdbclient/include/fdbclient/ClientOptionValidation.h
@@ -1,0 +1,33 @@
+/*
+ * ClientOptionValidation.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "flow/Arena.h"
+
+#include <cstdint>
+#include <limits>
+
+void validateOptionValuePresent(Optional<StringRef> value);
+void validateOptionValueNotPresent(Optional<StringRef> value);
+
+int64_t extractIntOption(Optional<StringRef> value,
+                         int64_t minValue = std::numeric_limits<int64_t>::min(),
+                         int64_t maxValue = std::numeric_limits<int64_t>::max());

--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -30,7 +30,6 @@
 #include "flow/WipedString.h"
 #include "flow/TDMetric.h"
 #include "flow/IRandom.h"
-#include "fdbclient/ClientOptionValidation.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/ProcessClass.h"
 #include "fdbclient/CommitProxyInterface.h"

--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -30,6 +30,7 @@
 #include "flow/WipedString.h"
 #include "flow/TDMetric.h"
 #include "flow/IRandom.h"
+#include "fdbclient/ClientOptionValidation.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/ProcessClass.h"
 #include "fdbclient/CommitProxyInterface.h"
@@ -59,9 +60,6 @@ template <>
 void addref(DatabaseContext* ptr);
 template <>
 void delref(DatabaseContext* ptr);
-
-void validateOptionValuePresent(Optional<StringRef> value);
-void validateOptionValueNotPresent(Optional<StringRef> value);
 
 void enableClientInfoLogging();
 
@@ -545,10 +543,6 @@ Future<Void> Database::run(Fun fun) {
 
 ACTOR Future<Version> waitForCommittedVersion(Database cx, Version version, SpanContext spanContext);
 Future<Standalone<VectorRef<DDMetricsRef>>> waitDataDistributionMetricsList(Database cx, KeyRange keys, int shardLimit);
-
-int64_t extractIntOption(Optional<StringRef> value,
-                         int64_t minValue = std::numeric_limits<int64_t>::min(),
-                         int64_t maxValue = std::numeric_limits<int64_t>::max());
 
 // Takes a snapshot of the cluster, specifically the following persistent
 // states: coordinator, TLog and storage state


### PR DESCRIPTION
## Summary

- Extract actor-independent client option presence and integer validation into a shared client component.
- Reuse the same helpers in the native, read-your-writes, and multiversion clients without introducing a Native API dependency in the multiversion client.
- Cover absent and empty values, integer encoding sizes, signed bounds, and default integer limits with focused unit tests.

## Validation

- `fdbclient_test -f /fdbclient/ClientOptionValidation/` (2 tests passed)
- `fdbclient_test` (92 tests passed)
