### PR TITLE
Exercise stale CDC stream initialization deterministically

### DIFF
--- a/fdbclient/NativeCdc.cpp
+++ b/fdbclient/NativeCdc.cpp
@@ -795,7 +795,7 @@ Future<CDCConsumeReply> NativeCdcConsumer::consumeImpl(Reference<NativeCdcConsum
 
 Future<CDCConsumeReply> NativeCdcConsumer::consume() {
 	if (operationOutstanding) {
-		CODE_PROBE(true, "Native CDC consumer rejects overlapping operations", probe::decoration::rare);
+		CODE_PROBE(true, "Native CDC consumer rejects overlapping operations");
 		return Future<CDCConsumeReply>(client_invalid_operation());
 	}
 	operationOutstanding = true;
@@ -842,7 +842,7 @@ Future<Void> NativeCdcConsumer::acknowledgeImpl(Reference<NativeCdcConsumer> sel
 
 Future<Void> NativeCdcConsumer::acknowledge() {
 	if (operationOutstanding) {
-		CODE_PROBE(true, "Native CDC consumer rejects overlapping operations", probe::decoration::rare);
+		CODE_PROBE(true, "Native CDC consumer rejects overlapping operations");
 		return Future<Void>(client_invalid_operation());
 	}
 	operationOutstanding = true;

--- a/fdbserver/cdcproxy/CDCProxy.cpp
+++ b/fdbserver/cdcproxy/CDCProxy.cpp
@@ -286,6 +286,16 @@ bool isCurrentStreamInitialization(std::unordered_map<CDCStreamId, Reference<CDC
 	return stream->active && current != streams.end() && current->second.getPtr() == stream.getPtr();
 }
 
+bool isCurrentTagOwner(std::unordered_map<CDCStreamId, Reference<CDCBufferedStream>> const& streams,
+                       Tag const& tag,
+                       CDCStreamId streamId) {
+	const auto stream = streams.find(streamId);
+	return stream != streams.end() && stream->second->active &&
+	       std::any_of(stream->second->tagIntervals.begin(),
+	                   stream->second->tagIntervals.end(),
+	                   [&tag](CDCTagInterval const& interval) { return interval.tag == tag; });
+}
+
 // New TLogs retain every recovered tag until it is popped past the recovery boundary. An unshared retired tag has no
 // active consumer to advance it, so stopping at its pre-recovery removal version can keep the old generation forever.
 Version retiredTagPopTarget(Version retiredVersion, Optional<Version> safePopVersion, Optional<Version> recoveryEnd) {
@@ -1707,6 +1717,11 @@ Future<Void> CDCProxy::serveBufferStatusForTestingRequests(FutureStream<GetCDCPr
 			}
 			co_await race(popPauseChangedForTesting.onTrigger(), pendingInitialization->changed.onTrigger());
 		}
+		for (const auto& [tag, bufferedTag] : tags) {
+			for (const CDCStreamId streamId : bufferedTag->streamIds) {
+				ASSERT(isCurrentTagOwner(streams, tag, streamId));
+			}
+		}
 		CDCProxyBufferStatus status;
 		status.bufferedBytes = bufferedBytes;
 		status.activePermits = bufferLock.activePermits();
@@ -2003,16 +2018,29 @@ TEST_CASE("/NativeCDC/StreamInitializationLifecycle") {
 	std::unordered_map<CDCStreamId, Reference<CDCBufferedStream>> streams;
 	auto stream = makeReference<CDCBufferedStream>(1);
 	auto replacement = makeReference<CDCBufferedStream>(1);
+	const Tag assignedTag(tagLocalityCDC, 1);
+	const Tag anotherTag(tagLocalityCDC, 2);
 
 	ASSERT(!isCurrentStreamInitialization(streams, stream));
+	ASSERT(!isCurrentTagOwner(streams, assignedTag, stream->streamId));
 	streams.emplace(stream->streamId, stream);
 	ASSERT(isCurrentStreamInitialization(streams, stream));
+	ASSERT(!isCurrentTagOwner(streams, assignedTag, stream->streamId));
+	stream->tagIntervals.emplace_back(assignedTag, 100, 200);
+	ASSERT(isCurrentTagOwner(streams, assignedTag, stream->streamId));
+	ASSERT(!isCurrentTagOwner(streams, anotherTag, stream->streamId));
 	stream->active = false;
 	ASSERT(!isCurrentStreamInitialization(streams, stream));
+	ASSERT(!isCurrentTagOwner(streams, assignedTag, stream->streamId));
 	stream->active = true;
 	streams.at(stream->streamId) = replacement;
 	ASSERT(!isCurrentStreamInitialization(streams, stream));
 	ASSERT(isCurrentStreamInitialization(streams, replacement));
+	ASSERT(!isCurrentTagOwner(streams, assignedTag, stream->streamId));
+	replacement->tagIntervals.emplace_back(assignedTag, 200, 300);
+	ASSERT(isCurrentTagOwner(streams, assignedTag, replacement->streamId));
+	streams.erase(replacement->streamId);
+	ASSERT(!isCurrentTagOwner(streams, assignedTag, replacement->streamId));
 	return Void();
 }
 

--- a/fdbserver/cdcproxy/CDCProxy.cpp
+++ b/fdbserver/cdcproxy/CDCProxy.cpp
@@ -317,6 +317,8 @@ class CDCProxy {
 	bool popsPausedAfterSnapshotForTesting = false;
 	int64_t popSnapshotsPausedForTesting = 0;
 	AsyncTrigger popPauseChangedForTesting;
+	std::unordered_set<CDCStreamId> pausedStreamInitializationsForTesting;
+	AsyncTrigger streamInitializationPauseChangedForTesting;
 	bool logSystemInitialized = false;
 	bool lastLogSystemHasTLogs = false;
 	uint64_t lastLogSystemRecoveryCount = 0;
@@ -1149,6 +1151,17 @@ Future<Void> CDCProxy::bufferTag(Reference<CDCBufferedTag> tag) {
 Future<Void> CDCProxy::initializeStream(Reference<CDCBufferedStream> stream) {
 	try {
 		const CDCStreamReadState metadata = co_await readCDCStreamState(cx, stream->streamId, id, true);
+		if (popsPausedForTesting) {
+			pausedStreamInitializationsForTesting.insert(stream->streamId);
+			ScopeExit releaseInitializationPause([this, stream]() {
+				pausedStreamInitializationsForTesting.erase(stream->streamId);
+				streamInitializationPauseChangedForTesting.trigger();
+			});
+			streamInitializationPauseChangedForTesting.trigger();
+			while (popsPausedForTesting) {
+				co_await popPauseChangedForTesting.onTrigger();
+			}
+		}
 		if (!isCurrentStreamInitialization(streams, stream)) {
 			CODE_PROBE(true, "CDC proxy discards stale stream initialization");
 			co_return;
@@ -1684,6 +1697,22 @@ Future<Void> CDCProxy::serveBufferStatusForTestingRequests(FutureStream<GetCDCPr
 		if (!g_network->isSimulated()) {
 			request.reply.sendError(client_invalid_operation());
 			continue;
+		}
+		while (popsPausedForTesting) {
+			Reference<CDCBufferedStream> pendingInitialization;
+			for (const auto& [streamId, stream] : streams) {
+				if (stream->active && !stream->initialized &&
+				    !pausedStreamInitializationsForTesting.contains(streamId)) {
+					pendingInitialization = stream;
+					break;
+				}
+			}
+			if (!pendingInitialization) {
+				break;
+			}
+			co_await race(streamInitializationPauseChangedForTesting.onTrigger(),
+			              popPauseChangedForTesting.onTrigger(),
+			              pendingInitialization->changed.onTrigger());
 		}
 		CDCProxyBufferStatus status;
 		status.bufferedBytes = bufferedBytes;

--- a/fdbserver/cdcproxy/CDCProxy.cpp
+++ b/fdbserver/cdcproxy/CDCProxy.cpp
@@ -77,6 +77,7 @@ struct CDCBufferedStream : ReferenceCounted<CDCBufferedStream> {
 	Optional<KeyRange> keys;
 	bool active = true;
 	bool initialized = false;
+	bool initializationPausedForTesting = false;
 	bool tooOld = false;
 	bool bufferLimitExceeded = false;
 	Version minVersion = invalidVersion;
@@ -317,8 +318,6 @@ class CDCProxy {
 	bool popsPausedAfterSnapshotForTesting = false;
 	int64_t popSnapshotsPausedForTesting = 0;
 	AsyncTrigger popPauseChangedForTesting;
-	std::unordered_set<CDCStreamId> pausedStreamInitializationsForTesting;
-	AsyncTrigger streamInitializationPauseChangedForTesting;
 	bool logSystemInitialized = false;
 	bool lastLogSystemHasTLogs = false;
 	uint64_t lastLogSystemRecoveryCount = 0;
@@ -1152,15 +1151,12 @@ Future<Void> CDCProxy::initializeStream(Reference<CDCBufferedStream> stream) {
 	try {
 		const CDCStreamReadState metadata = co_await readCDCStreamState(cx, stream->streamId, id, true);
 		if (popsPausedForTesting) {
-			pausedStreamInitializationsForTesting.insert(stream->streamId);
-			ScopeExit releaseInitializationPause([this, stream]() {
-				pausedStreamInitializationsForTesting.erase(stream->streamId);
-				streamInitializationPauseChangedForTesting.trigger();
-			});
-			streamInitializationPauseChangedForTesting.trigger();
+			stream->initializationPausedForTesting = true;
+			stream->changed.trigger();
 			while (popsPausedForTesting) {
 				co_await popPauseChangedForTesting.onTrigger();
 			}
+			stream->initializationPausedForTesting = false;
 		}
 		if (!isCurrentStreamInitialization(streams, stream)) {
 			CODE_PROBE(true, "CDC proxy discards stale stream initialization");
@@ -1701,8 +1697,7 @@ Future<Void> CDCProxy::serveBufferStatusForTestingRequests(FutureStream<GetCDCPr
 		while (popsPausedForTesting) {
 			Reference<CDCBufferedStream> pendingInitialization;
 			for (const auto& [streamId, stream] : streams) {
-				if (stream->active && !stream->initialized &&
-				    !pausedStreamInitializationsForTesting.contains(streamId)) {
+				if (stream->active && !stream->initialized && !stream->initializationPausedForTesting) {
 					pendingInitialization = stream;
 					break;
 				}
@@ -1710,9 +1705,7 @@ Future<Void> CDCProxy::serveBufferStatusForTestingRequests(FutureStream<GetCDCPr
 			if (!pendingInitialization) {
 				break;
 			}
-			co_await race(streamInitializationPauseChangedForTesting.onTrigger(),
-			              popPauseChangedForTesting.onTrigger(),
-			              pendingInitialization->changed.onTrigger());
+			co_await race(popPauseChangedForTesting.onTrigger(), pendingInitialization->changed.onTrigger());
 		}
 		CDCProxyBufferStatus status;
 		status.bufferedBytes = bufferedBytes;

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -468,41 +468,65 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		const KeyRange keys(
 		    KeyRangeRef("native-cdc-e2e/stale-initialization/"_sr, "native-cdc-e2e/stale-initialization0"_sr));
 		const double deadline = now() + operationTimeout;
+		bool recovering = false;
+		bool streamRegistered = false;
 
 		while (true) {
-			co_await timeoutError(setAllProxyPopsPaused(cx, true), operationTimeout);
-			const CDCStreamId streamId =
-			    co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout);
-			CDCProxyInterface proxy = co_await timeoutError(waitForAssignedProxy(cx, streamId), operationTimeout);
-			const CDCCursor cursor(streamId, invalidVersion);
-			Future<ErrorOr<CDCConsumeReply>> pendingConsume = proxy.consume.tryGetReply(CDCConsumeRequest(cursor));
-			while (true) {
-				const CDCProxyBufferStatus status = co_await getProxyStatus(proxy);
-				ASSERT(status.popsPaused);
-				if (pendingConsume.isReady()) {
-					const ErrorOr<CDCConsumeReply> result = co_await pendingConsume;
-					ASSERT(!result.present());
-					ASSERT_EQ(result.getError().code(), error_code_wrong_shard_server);
-					pendingConsume = proxy.consume.tryGetReply(CDCConsumeRequest(cursor));
-				} else if (status.activeConsumeRequests > 0) {
-					break;
-				}
-				ASSERT_LT(now(), deadline);
-				co_await delay(0.01);
-			}
-
-			co_await timeoutError(removeNativeCdcStreamClient(cx, name), operationTimeout);
-			const ErrorOr<CDCConsumeReply> result = co_await timeoutError(pendingConsume, operationTimeout);
-			ASSERT(!result.present());
-			const int errorCode = result.getError().code();
-			if (errorCode == error_code_wrong_shard_server) {
-				co_await timeoutError(setAllProxyPopsPaused(cx, false), operationTimeout);
-				co_return;
-			}
-			ASSERT(errorCode == error_code_request_maybe_delivered || errorCode == error_code_connection_failed ||
-			       errorCode == error_code_broken_promise);
-			co_await timeoutError(setAllProxyPopsPaused(cx, false), operationTimeout);
 			ASSERT_LT(now(), deadline);
+			try {
+				if (recovering) {
+					co_await timeoutError(setAllProxyPopsPaused(cx, false), operationTimeout);
+					if (streamRegistered) {
+						co_await timeoutError(removeNativeCdcStreamClient(cx, name), operationTimeout);
+						streamRegistered = false;
+					}
+					recovering = false;
+				}
+
+				co_await timeoutError(setAllProxyPopsPaused(cx, true), operationTimeout);
+				streamRegistered = true;
+				const CDCStreamId streamId =
+				    co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout);
+				CDCProxyInterface proxy = co_await timeoutError(waitForAssignedProxy(cx, streamId), operationTimeout);
+				const CDCCursor cursor(streamId, invalidVersion);
+				Future<ErrorOr<CDCConsumeReply>> pendingConsume = proxy.consume.tryGetReply(CDCConsumeRequest(cursor));
+				while (true) {
+					const CDCProxyBufferStatus status = co_await getPublishedProxyStatus(cx, proxy);
+					if (!status.popsPaused) {
+						throw wrong_shard_server();
+					}
+					if (pendingConsume.isReady()) {
+						const ErrorOr<CDCConsumeReply> result = co_await pendingConsume;
+						ASSERT(!result.present());
+						if (result.getError().code() != error_code_wrong_shard_server) {
+							throw result.getError();
+						}
+						pendingConsume = proxy.consume.tryGetReply(CDCConsumeRequest(cursor));
+					} else if (status.activeConsumeRequests > 0) {
+						break;
+					}
+					ASSERT_LT(now(), deadline);
+					co_await delay(0.01);
+				}
+
+				co_await timeoutError(removeNativeCdcStreamClient(cx, name), operationTimeout);
+				streamRegistered = false;
+				const ErrorOr<CDCConsumeReply> result = co_await timeoutError(pendingConsume, operationTimeout);
+				ASSERT(!result.present());
+				if (result.getError().code() != error_code_wrong_shard_server) {
+					throw result.getError();
+				}
+				co_await timeoutError(setAllProxyPopsPaused(cx, false), operationTimeout);
+				co_await getPublishedProxyStatus(cx, proxy);
+				co_return;
+			} catch (Error& e) {
+				if (e.code() != error_code_wrong_shard_server && e.code() != error_code_broken_promise &&
+				    e.code() != error_code_connection_failed && e.code() != error_code_request_maybe_delivered) {
+					throw;
+				}
+				recovering = true;
+			}
+			co_await delay(0);
 		}
 	}
 
@@ -572,6 +596,23 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 	Future<CDCProxyBufferStatus> getProxyStatus(CDCProxyInterface proxy) {
 		co_return co_await timeoutError(proxy.getBufferStatusForTesting.getReply(GetCDCProxyBufferStatusRequest()),
 		                                operationTimeout);
+	}
+
+	Future<CDCProxyBufferStatus> getPublishedProxyStatus(Database cx, CDCProxyInterface proxy) {
+		Future<Void> changed = cx->clientInfo->onChange();
+		const auto& proxies = cx->clientInfo->get().cdcProxies;
+		if (std::find(proxies.begin(), proxies.end(), proxy) == proxies.end()) {
+			throw wrong_shard_server();
+		}
+		auto result = co_await race(getProxyStatus(proxy), changed);
+		if (result.index() != 0) {
+			throw wrong_shard_server();
+		}
+		const auto& currentProxies = cx->clientInfo->get().cdcProxies;
+		if (std::find(currentProxies.begin(), currentProxies.end(), proxy) == currentProxies.end()) {
+			throw wrong_shard_server();
+		}
+		co_return std::get<0>(result);
 	}
 
 	Future<std::pair<CDCProxyInterface, CDCProxyBufferStatus>> getAssignedProxyStatus(Database cx,

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -604,15 +604,18 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		if (std::find(proxies.begin(), proxies.end(), proxy) == proxies.end()) {
 			throw wrong_shard_server();
 		}
-		auto result = co_await race(getProxyStatus(proxy), changed);
-		if (result.index() != 0) {
-			throw wrong_shard_server();
+		Future<CDCProxyBufferStatus> status = getProxyStatus(proxy);
+		while (true) {
+			auto result = co_await race(status, changed);
+			changed = cx->clientInfo->onChange();
+			const auto& currentProxies = cx->clientInfo->get().cdcProxies;
+			if (std::find(currentProxies.begin(), currentProxies.end(), proxy) == currentProxies.end()) {
+				throw wrong_shard_server();
+			}
+			if (result.index() == 0) {
+				co_return std::get<0>(result);
+			}
 		}
-		const auto& currentProxies = cx->clientInfo->get().cdcProxies;
-		if (std::find(currentProxies.begin(), currentProxies.end(), proxy) == currentProxies.end()) {
-			throw wrong_shard_server();
-		}
-		co_return std::get<0>(result);
 	}
 
 	Future<std::pair<CDCProxyInterface, CDCProxyBufferStatus>> getAssignedProxyStatus(Database cx,

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -462,6 +462,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		}
 	}
 
+	// Remove a stream after its metadata read to verify that its paused initializer cannot revive removed state.
 	Future<Void> validateStaleStreamInitialization(Database cx) {
 		const Key name = "native-cdc-e2e/stale-initialization"_sr;
 		const KeyRange keys(

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -462,6 +462,40 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		}
 	}
 
+	Future<Void> validateStaleStreamInitialization(Database cx) {
+		const Key name = "native-cdc-e2e/stale-initialization"_sr;
+		const KeyRange keys(
+		    KeyRangeRef("native-cdc-e2e/stale-initialization/"_sr, "native-cdc-e2e/stale-initialization0"_sr));
+
+		co_await timeoutError(setAllProxyPopsPaused(cx, true), operationTimeout);
+		const CDCStreamId streamId =
+		    co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout);
+		CDCProxyInterface proxy = co_await timeoutError(waitForAssignedProxy(cx, streamId), operationTimeout);
+		const CDCCursor cursor(streamId, invalidVersion);
+		Future<ErrorOr<CDCConsumeReply>> pendingConsume = proxy.consume.tryGetReply(CDCConsumeRequest(cursor));
+		const double deadline = now() + operationTimeout;
+		while (true) {
+			const CDCProxyBufferStatus status = co_await getProxyStatus(proxy);
+			ASSERT(status.popsPaused);
+			if (pendingConsume.isReady()) {
+				const ErrorOr<CDCConsumeReply> result = co_await pendingConsume;
+				ASSERT(!result.present());
+				ASSERT_EQ(result.getError().code(), error_code_wrong_shard_server);
+				pendingConsume = proxy.consume.tryGetReply(CDCConsumeRequest(cursor));
+			} else if (status.activeConsumeRequests > 0) {
+				break;
+			}
+			ASSERT_LT(now(), deadline);
+			co_await delay(0.01);
+		}
+
+		co_await timeoutError(removeNativeCdcStreamClient(cx, name), operationTimeout);
+		const ErrorOr<CDCConsumeReply> result = co_await timeoutError(pendingConsume, operationTimeout);
+		ASSERT(!result.present());
+		ASSERT_EQ(result.getError().code(), error_code_wrong_shard_server);
+		co_await timeoutError(setAllProxyPopsPaused(cx, false), operationTimeout);
+	}
+
 	Future<Void> validateProxyReplacement(Database cx) {
 		const Key name = "native-cdc-e2e/proxy-replacement"_sr;
 		const KeyRange keys(
@@ -1342,6 +1376,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		co_await validateClearClipping(cx);
 		co_await validateAssignmentPublication(cx);
 		if (testProxyReplacement) {
+			co_await validateStaleStreamInitialization(cx);
 			co_await validateProxyReplacement(cx);
 		}
 		if (testMemoryBound) {

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -467,34 +467,43 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		const Key name = "native-cdc-e2e/stale-initialization"_sr;
 		const KeyRange keys(
 		    KeyRangeRef("native-cdc-e2e/stale-initialization/"_sr, "native-cdc-e2e/stale-initialization0"_sr));
-
-		co_await timeoutError(setAllProxyPopsPaused(cx, true), operationTimeout);
-		const CDCStreamId streamId =
-		    co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout);
-		CDCProxyInterface proxy = co_await timeoutError(waitForAssignedProxy(cx, streamId), operationTimeout);
-		const CDCCursor cursor(streamId, invalidVersion);
-		Future<ErrorOr<CDCConsumeReply>> pendingConsume = proxy.consume.tryGetReply(CDCConsumeRequest(cursor));
 		const double deadline = now() + operationTimeout;
-		while (true) {
-			const CDCProxyBufferStatus status = co_await getProxyStatus(proxy);
-			ASSERT(status.popsPaused);
-			if (pendingConsume.isReady()) {
-				const ErrorOr<CDCConsumeReply> result = co_await pendingConsume;
-				ASSERT(!result.present());
-				ASSERT_EQ(result.getError().code(), error_code_wrong_shard_server);
-				pendingConsume = proxy.consume.tryGetReply(CDCConsumeRequest(cursor));
-			} else if (status.activeConsumeRequests > 0) {
-				break;
-			}
-			ASSERT_LT(now(), deadline);
-			co_await delay(0.01);
-		}
 
-		co_await timeoutError(removeNativeCdcStreamClient(cx, name), operationTimeout);
-		const ErrorOr<CDCConsumeReply> result = co_await timeoutError(pendingConsume, operationTimeout);
-		ASSERT(!result.present());
-		ASSERT_EQ(result.getError().code(), error_code_wrong_shard_server);
-		co_await timeoutError(setAllProxyPopsPaused(cx, false), operationTimeout);
+		while (true) {
+			co_await timeoutError(setAllProxyPopsPaused(cx, true), operationTimeout);
+			const CDCStreamId streamId =
+			    co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout);
+			CDCProxyInterface proxy = co_await timeoutError(waitForAssignedProxy(cx, streamId), operationTimeout);
+			const CDCCursor cursor(streamId, invalidVersion);
+			Future<ErrorOr<CDCConsumeReply>> pendingConsume = proxy.consume.tryGetReply(CDCConsumeRequest(cursor));
+			while (true) {
+				const CDCProxyBufferStatus status = co_await getProxyStatus(proxy);
+				ASSERT(status.popsPaused);
+				if (pendingConsume.isReady()) {
+					const ErrorOr<CDCConsumeReply> result = co_await pendingConsume;
+					ASSERT(!result.present());
+					ASSERT_EQ(result.getError().code(), error_code_wrong_shard_server);
+					pendingConsume = proxy.consume.tryGetReply(CDCConsumeRequest(cursor));
+				} else if (status.activeConsumeRequests > 0) {
+					break;
+				}
+				ASSERT_LT(now(), deadline);
+				co_await delay(0.01);
+			}
+
+			co_await timeoutError(removeNativeCdcStreamClient(cx, name), operationTimeout);
+			const ErrorOr<CDCConsumeReply> result = co_await timeoutError(pendingConsume, operationTimeout);
+			ASSERT(!result.present());
+			const int errorCode = result.getError().code();
+			if (errorCode == error_code_wrong_shard_server) {
+				co_await timeoutError(setAllProxyPopsPaused(cx, false), operationTimeout);
+				co_return;
+			}
+			ASSERT(errorCode == error_code_request_maybe_delivered || errorCode == error_code_connection_failed ||
+			       errorCode == error_code_broken_promise);
+			co_await timeoutError(setAllProxyPopsPaused(cx, false), operationTimeout);
+			ASSERT_LT(now(), deadline);
+		}
 	}
 
 	Future<Void> validateProxyReplacement(Database cx) {
@@ -680,6 +689,12 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		const Version idleStartVersion = idleConsumer->position().lastConsumedVersion;
 		Future<CDCConsumeReply> idleConsume;
 		co_await startBlockedConsume(cx, streamId, idleConsumer, *proxy, &idleConsume);
+		Future<CDCConsumeReply> overlappingConsume = idleConsumer->consume();
+		ASSERT(overlappingConsume.isReady() && overlappingConsume.isError());
+		ASSERT_EQ(overlappingConsume.getError().code(), error_code_client_invalid_operation);
+		Future<Void> overlappingAcknowledgement = idleConsumer->acknowledge();
+		ASSERT(overlappingAcknowledgement.isReady() && overlappingAcknowledgement.isError());
+		ASSERT_EQ(overlappingAcknowledgement.getError().code(), error_code_client_invalid_operation);
 
 		// Assignment publications for unrelated streams used to abandon the client reply without canceling the
 		// corresponding server actor. The active request and read demand must remain bounded at one.


### PR DESCRIPTION
## Summary

- Pause CDC stream initialization after its durable metadata read using existing simulation-only pop controls.
- Synchronize the existing test-only status endpoint with pending stream initialization without changing CDC interfaces or serialized state.
- Remove a paused stream in the assignment-publication workload, verify the outstanding consume fails with `wrong_shard_server`, and deterministically exercise stale-initialization cleanup.

## Validation

- `clang-format --dry-run --Werror fdbserver/cdcproxy/CDCProxy.cpp fdbserver/workloads/NativeCdcEndToEnd.cpp`
- `fdbserver_cdcproxy_test -f /NativeCDC/StreamInitializationLifecycle` (1 test passed)
- `fdbserver_cdcproxy_test` (11 tests passed)
- `fdbserver -r simulation -f tests/fast/NativeCdcAssignmentPublication.toml --seed {1,2,3,4,5} --buggify off` (5 runs passed; stale-initialization probe covered in every run)
- `fdbserver -r simulation -f tests/fast/NativeCdcDurableAckScan.toml --seed 11 --buggify off`
- `fdbserver -r simulation -f tests/fast/NativeCdcRetiredRecovery.toml --seed 12 --buggify off`
- `fdbserver -r simulation -f tests/fast/NativeCdcRetiredSharedTagSnapshot.toml --seed 13 --buggify off`
- `fdbserver -r simulation -f tests/fast/NativeCdcMemoryBound.toml --seed 14 --buggify off`
