### PR TITLE
Exercise stale CDC stream ownership deterministically

### DIFF
--- a/fdbclient/NativeCdc.cpp
+++ b/fdbclient/NativeCdc.cpp
@@ -441,9 +441,7 @@ Future<bool> removeNativeCdcStream(Database cx, Key name, CDCStreamId streamId, 
 			const Key nameKey = cdcStreamNameKeyFor(name);
 			Optional<Value> currentId = co_await tr.get(nameKey);
 			if (!nativeCdcNameMatchesStream(currentId, streamId)) {
-				CODE_PROBE(currentId.present(),
-				           "Native CDC preserves a replacement stream during removal retry",
-				           probe::decoration::rare);
+				CODE_PROBE(currentId.present(), "Native CDC preserves a replacement stream during removal retry");
 				if (currentId.present()) {
 					TraceEvent("NativeCdcRemovalPreservesReplacement")
 					    .detail("RemovedStreamId", streamId)
@@ -454,7 +452,7 @@ Future<bool> removeNativeCdcStream(Database cx, Key name, CDCStreamId streamId, 
 
 			Optional<UID> assignedProxy = co_await getNativeCdcProxyAssignment(&tr, streamId);
 			if (!assignedProxy.present() || assignedProxy.get() != proxyId) {
-				CODE_PROBE(true, "Native CDC rejects removal through a stale owner", probe::decoration::rare);
+				CODE_PROBE(true, "Native CDC rejects removal through a stale owner");
 				throw wrong_shard_server();
 			}
 

--- a/fdbserver/cdcproxy/CDCProxy.cpp
+++ b/fdbserver/cdcproxy/CDCProxy.cpp
@@ -458,7 +458,7 @@ Future<CDCStreamReadState> readCDCStreamState(Database cx,
 
 			RangeResult assignedProxies = co_await assignedProxiesFuture;
 			if (assignedProxies.size() != 1 || decodeCDCProxyKey(assignedProxies[0].key).second != expectedProxyId) {
-				CODE_PROBE(true, "CDC proxy rejects request for stream owned elsewhere", probe::decoration::rare);
+				CODE_PROBE(true, "CDC proxy rejects request for stream owned elsewhere");
 				throw wrong_shard_server();
 			}
 

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -631,7 +631,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 				continue;
 			}
 			if (!retainedPublishedOwner) {
-				co_await timeoutError(waitForAssignedProxy(cx, streamId, wrongOwner.get().id()), operationTimeout);
+				co_await timeoutError(waitForAssignedProxy(cx, streamId), operationTimeout);
 				continue;
 			}
 			if (!rejectedWrongOwner(acknowledgement)) {

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -506,6 +506,8 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		const Key key = "native-cdc-e2e/stale-ownership/value"_sr;
 		const Value value = "replacement-survives-stale-removal"_sr;
 		const double deadline = now() + operationTimeout;
+		CDCStreamId expectedStreamId =
+		    co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout);
 
 		const auto rejectedWrongOwner = [](ErrorOr<Void> const& result) {
 			ASSERT(!result.present());
@@ -520,8 +522,10 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 
 		while (true) {
 			ASSERT_LT(now(), deadline);
-			const CDCStreamId streamId =
-			    co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout);
+			Reference<NativeCdcConsumer> existing =
+			    co_await timeoutError(createNativeCdcConsumer(cx, name), operationTimeout);
+			ASSERT_EQ(existing->position().streamId, expectedStreamId);
+			const CDCStreamId streamId = expectedStreamId;
 			CDCProxyInterface owner = co_await timeoutError(waitForAssignedProxy(cx, streamId), operationTimeout);
 			Optional<CDCProxyInterface> wrongOwner;
 			for (const auto& proxy : cx->clientInfo->get().cdcProxies) {
@@ -538,27 +542,29 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 			const ErrorOr<Void> acknowledgement =
 			    co_await timeoutError(wrongOwner.get().ack.tryGetReply(CDCAckRequest(streamId, 0)), operationTimeout);
 			if (!rejectedWrongOwner(acknowledgement)) {
-				ASSERT_EQ(co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout),
-				          streamId);
+				existing = co_await timeoutError(createNativeCdcConsumer(cx, name), operationTimeout);
+				ASSERT_EQ(existing->position().streamId, expectedStreamId);
 				continue;
 			}
 			const ErrorOr<Void> removal = co_await timeoutError(
 			    wrongOwner.get().removeStream.tryGetReply(CDCRemoveStreamRequest(name, streamId)), operationTimeout);
 			if (!rejectedWrongOwner(removal)) {
-				ASSERT_EQ(co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout),
-				          streamId);
+				existing = co_await timeoutError(createNativeCdcConsumer(cx, name), operationTimeout);
+				ASSERT_EQ(existing->position().streamId, expectedStreamId);
 				continue;
 			}
-			ASSERT_EQ(co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout), streamId);
+			existing = co_await timeoutError(createNativeCdcConsumer(cx, name), operationTimeout);
+			ASSERT_EQ(existing->position().streamId, expectedStreamId);
 
 			co_await timeoutError(removeNativeCdcStreamClient(cx, name), operationTimeout);
 			const CDCStreamId replacementId =
 			    co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout);
 			ASSERT_NE(replacementId, streamId);
+			expectedStreamId = replacementId;
 			const ErrorOr<Void> staleRemoval = co_await timeoutError(
 			    owner.removeStream.tryGetReply(CDCRemoveStreamRequest(name, streamId)), operationTimeout);
-			ASSERT_EQ(co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout),
-			          replacementId);
+			existing = co_await timeoutError(createNativeCdcConsumer(cx, name), operationTimeout);
+			ASSERT_EQ(existing->position().streamId, expectedStreamId);
 			if (!staleRemoval.present()) {
 				const int errorCode = staleRemoval.getError().code();
 				ASSERT(errorCode == error_code_request_maybe_delivered || errorCode == error_code_connection_failed ||

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -463,6 +463,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 	}
 
 	Future<Void> validateProxyReplacement(Database cx) {
+		co_await validateStaleStreamOwnership(cx);
 		const Key name = "native-cdc-e2e/proxy-replacement"_sr;
 		const KeyRange keys(
 		    KeyRangeRef("native-cdc-e2e/proxy-replacement/"_sr, "native-cdc-e2e/proxy-replacement0"_sr));
@@ -496,6 +497,83 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		const Version committed = co_await writeValue(cx, key, value);
 		co_await consumeThroughValue(consumer, committed, key, value);
 		co_await timeoutError(removeNativeCdcStreamClient(cx, name), operationTimeout);
+	}
+
+	// Stale proxy ownership and old stream IDs must not modify a live replacement stream.
+	Future<Void> validateStaleStreamOwnership(Database cx) {
+		const Key name = "native-cdc-e2e/stale-ownership"_sr;
+		const KeyRange keys(KeyRangeRef("native-cdc-e2e/stale-ownership/"_sr, "native-cdc-e2e/stale-ownership0"_sr));
+		const Key key = "native-cdc-e2e/stale-ownership/value"_sr;
+		const Value value = "replacement-survives-stale-removal"_sr;
+		const double deadline = now() + operationTimeout;
+
+		const auto rejectedWrongOwner = [](ErrorOr<Void> const& result) {
+			ASSERT(!result.present());
+			const int errorCode = result.getError().code();
+			if (errorCode == error_code_wrong_shard_server) {
+				return true;
+			}
+			ASSERT(errorCode == error_code_request_maybe_delivered || errorCode == error_code_connection_failed ||
+			       errorCode == error_code_broken_promise);
+			return false;
+		};
+
+		while (true) {
+			ASSERT_LT(now(), deadline);
+			const CDCStreamId streamId =
+			    co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout);
+			CDCProxyInterface owner = co_await timeoutError(waitForAssignedProxy(cx, streamId), operationTimeout);
+			Optional<CDCProxyInterface> wrongOwner;
+			for (const auto& proxy : cx->clientInfo->get().cdcProxies) {
+				if (proxy.id() != owner.id()) {
+					wrongOwner = proxy;
+					break;
+				}
+			}
+			if (!wrongOwner.present()) {
+				co_await delay(0.01);
+				continue;
+			}
+
+			const ErrorOr<Void> acknowledgement =
+			    co_await timeoutError(wrongOwner.get().ack.tryGetReply(CDCAckRequest(streamId, 0)), operationTimeout);
+			if (!rejectedWrongOwner(acknowledgement)) {
+				ASSERT_EQ(co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout),
+				          streamId);
+				continue;
+			}
+			const ErrorOr<Void> removal = co_await timeoutError(
+			    wrongOwner.get().removeStream.tryGetReply(CDCRemoveStreamRequest(name, streamId)), operationTimeout);
+			if (!rejectedWrongOwner(removal)) {
+				ASSERT_EQ(co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout),
+				          streamId);
+				continue;
+			}
+			ASSERT_EQ(co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout), streamId);
+
+			co_await timeoutError(removeNativeCdcStreamClient(cx, name), operationTimeout);
+			const CDCStreamId replacementId =
+			    co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout);
+			ASSERT_NE(replacementId, streamId);
+			const ErrorOr<Void> staleRemoval = co_await timeoutError(
+			    owner.removeStream.tryGetReply(CDCRemoveStreamRequest(name, streamId)), operationTimeout);
+			ASSERT_EQ(co_await timeoutError(registerNativeCdcStreamClient(cx, name, keys), operationTimeout),
+			          replacementId);
+			if (!staleRemoval.present()) {
+				const int errorCode = staleRemoval.getError().code();
+				ASSERT(errorCode == error_code_request_maybe_delivered || errorCode == error_code_connection_failed ||
+				       errorCode == error_code_broken_promise);
+				continue;
+			}
+
+			Reference<NativeCdcConsumer> consumer =
+			    co_await timeoutError(createNativeCdcConsumer(cx, name), operationTimeout);
+			ASSERT_EQ(consumer->position().streamId, replacementId);
+			const Version committed = co_await writeValue(cx, key, value);
+			co_await consumeThroughValue(consumer, committed, key, value);
+			co_await timeoutError(removeNativeCdcStreamClient(cx, name), operationTimeout);
+			co_return;
+		}
 	}
 
 	Future<Void> consumeMemoryMarker(Reference<NativeCdcConsumer> consumer,

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -499,6 +499,44 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		co_await timeoutError(removeNativeCdcStreamClient(cx, name), operationTimeout);
 	}
 
+	Future<Void> setUnpublishedStreamOwner(Database cx,
+	                                       Key name,
+	                                       CDCStreamId streamId,
+	                                       UID expectedOwner,
+	                                       UID newOwner) {
+		Transaction tr(cx);
+		while (true) {
+			Error err;
+			try {
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+
+				Optional<Value> currentId = co_await tr.get(cdcStreamNameKeyFor(name));
+				ASSERT(currentId.present());
+				ASSERT_EQ(decodeCDCStreamNameValue(currentId.get()), streamId);
+
+				const KeyRange assignmentRange = cdcProxyRangeFor(streamId);
+				RangeResult assignments = co_await tr.getRange(assignmentRange, 2);
+				ASSERT_EQ(assignments.size(), 1);
+				const auto [assignedStreamId, assignedOwner] = decodeCDCProxyKey(assignments[0].key);
+				ASSERT_EQ(assignedStreamId, streamId);
+				if (assignedOwner == newOwner) {
+					co_return;
+				}
+				ASSERT_EQ(assignedOwner, expectedOwner);
+
+				tr.clear(assignmentRange);
+				tr.set(cdcProxyKeyFor(streamId, newOwner), Value());
+				co_await tr.commit();
+				co_return;
+			} catch (Error& e) {
+				err = e;
+			}
+			co_await tr.onError(err);
+		}
+	}
+
 	// Stale proxy ownership and old stream IDs must not modify a live replacement stream.
 	Future<Void> validateStaleStreamOwnership(Database cx) {
 		const Key name = "native-cdc-e2e/stale-ownership"_sr;
@@ -539,8 +577,43 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 				continue;
 			}
 
-			const ErrorOr<Void> acknowledgement =
-			    co_await timeoutError(wrongOwner.get().ack.tryGetReply(CDCAckRequest(streamId, 0)), operationTimeout);
+			const ErrorOr<Void> initialized =
+			    co_await timeoutError(owner.ack.tryGetReply(CDCAckRequest(streamId, 0)), operationTimeout);
+			if (!initialized.present()) {
+				const int errorCode = initialized.getError().code();
+				ASSERT(errorCode == error_code_wrong_shard_server || errorCode == error_code_request_maybe_delivered ||
+				       errorCode == error_code_connection_failed || errorCode == error_code_broken_promise);
+				existing = co_await timeoutError(createNativeCdcConsumer(cx, name), operationTimeout);
+				ASSERT_EQ(existing->position().streamId, expectedStreamId);
+				co_await delay(0.01);
+				continue;
+			}
+
+			// Keep published ownership and initialized local state unchanged while durable ownership differs.
+			co_await timeoutError(setUnpublishedStreamOwner(cx, name, streamId, owner.id(), wrongOwner.get().id()),
+			                      operationTimeout);
+			ErrorOr<Void> acknowledgement = request_maybe_delivered();
+			Optional<Error> acknowledgementError;
+			bool retainedPublishedOwner = false;
+			try {
+				acknowledgement =
+				    co_await timeoutError(owner.ack.tryGetReply(CDCAckRequest(streamId, 0)), operationTimeout);
+				const auto& publishedOwners = cx->clientInfo->get().streamToCDCProxyId;
+				const auto publishedOwner = publishedOwners.find(streamId);
+				retainedPublishedOwner =
+				    publishedOwner != publishedOwners.end() && publishedOwner->second == owner.id();
+			} catch (Error& e) {
+				if (e.code() == error_code_actor_cancelled) {
+					throw;
+				}
+				acknowledgementError = e;
+			}
+			co_await timeoutError(setUnpublishedStreamOwner(cx, name, streamId, wrongOwner.get().id(), owner.id()),
+			                      operationTimeout);
+			if (acknowledgementError.present()) {
+				throw acknowledgementError.get();
+			}
+			ASSERT(retainedPublishedOwner);
 			if (!rejectedWrongOwner(acknowledgement)) {
 				existing = co_await timeoutError(createNativeCdcConsumer(cx, name), operationTimeout);
 				ASSERT_EQ(existing->position().streamId, expectedStreamId);

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -499,7 +499,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		co_await timeoutError(removeNativeCdcStreamClient(cx, name), operationTimeout);
 	}
 
-	Future<Void> setUnpublishedStreamOwner(Database cx,
+	Future<bool> setUnpublishedStreamOwner(Database cx,
 	                                       Key name,
 	                                       CDCStreamId streamId,
 	                                       UID expectedOwner,
@@ -523,11 +523,13 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 				const auto [assignedStreamId, assignedOwner] = decodeCDCProxyKey(assignments[0].key);
 				ASSERT_EQ(assignedStreamId, streamId);
 				if (assignedOwner == newOwner && !publishAssignment) {
-					co_return;
+					co_return true;
 				}
-				if (assignedOwner != newOwner) {
-					ASSERT_EQ(assignedOwner, expectedOwner);
-
+				const bool unexpectedOwner = assignedOwner != newOwner && assignedOwner != expectedOwner;
+				if (unexpectedOwner && !publishAssignment) {
+					co_return false;
+				}
+				if (!unexpectedOwner && assignedOwner != newOwner) {
 					tr.clear(assignmentRange);
 					tr.set(cdcProxyKeyFor(streamId, newOwner), Value());
 				}
@@ -537,7 +539,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 					                             IncludeVersion(ProtocolVersion::withNativeCdc())));
 				}
 				co_await tr.commit();
-				co_return;
+				co_return !unexpectedOwner;
 			} catch (Error& e) {
 				err = e;
 			}
@@ -598,8 +600,11 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 			}
 
 			// Keep published ownership and initialized local state unchanged while durable ownership differs.
-			co_await timeoutError(setUnpublishedStreamOwner(cx, name, streamId, owner.id(), wrongOwner.get().id()),
-			                      operationTimeout);
+			const bool swappedOwner = co_await timeoutError(
+			    setUnpublishedStreamOwner(cx, name, streamId, owner.id(), wrongOwner.get().id()), operationTimeout);
+			if (!swappedOwner) {
+				continue;
+			}
 			ErrorOr<Void> acknowledgement = request_maybe_delivered();
 			Optional<Error> acknowledgementError;
 			bool retainedPublishedOwner = false;
@@ -616,11 +621,14 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 				}
 				acknowledgementError = e;
 			}
-			co_await timeoutError(
+			const bool restoredOwner = co_await timeoutError(
 			    setUnpublishedStreamOwner(cx, name, streamId, wrongOwner.get().id(), owner.id(), true),
 			    operationTimeout);
 			if (acknowledgementError.present()) {
 				throw acknowledgementError.get();
+			}
+			if (!restoredOwner) {
+				continue;
 			}
 			if (!retainedPublishedOwner) {
 				co_await timeoutError(waitForAssignedProxy(cx, streamId, wrongOwner.get().id()), operationTimeout);

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -503,7 +503,8 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 	                                       Key name,
 	                                       CDCStreamId streamId,
 	                                       UID expectedOwner,
-	                                       UID newOwner) {
+	                                       UID newOwner,
+	                                       bool publishAssignment = false) {
 		Transaction tr(cx);
 		while (true) {
 			Error err;
@@ -521,13 +522,20 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 				ASSERT_EQ(assignments.size(), 1);
 				const auto [assignedStreamId, assignedOwner] = decodeCDCProxyKey(assignments[0].key);
 				ASSERT_EQ(assignedStreamId, streamId);
-				if (assignedOwner == newOwner) {
+				if (assignedOwner == newOwner && !publishAssignment) {
 					co_return;
 				}
-				ASSERT_EQ(assignedOwner, expectedOwner);
+				if (assignedOwner != newOwner) {
+					ASSERT_EQ(assignedOwner, expectedOwner);
 
-				tr.clear(assignmentRange);
-				tr.set(cdcProxyKeyFor(streamId, newOwner), Value());
+					tr.clear(assignmentRange);
+					tr.set(cdcProxyKeyFor(streamId, newOwner), Value());
+				}
+				if (publishAssignment) {
+					tr.set(cdcProxyAssignmentChangeKey,
+					       BinaryWriter::toValue(deterministicRandom()->randomUniqueID(),
+					                             IncludeVersion(ProtocolVersion::withNativeCdc())));
+				}
 				co_await tr.commit();
 				co_return;
 			} catch (Error& e) {
@@ -608,12 +616,16 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 				}
 				acknowledgementError = e;
 			}
-			co_await timeoutError(setUnpublishedStreamOwner(cx, name, streamId, wrongOwner.get().id(), owner.id()),
-			                      operationTimeout);
+			co_await timeoutError(
+			    setUnpublishedStreamOwner(cx, name, streamId, wrongOwner.get().id(), owner.id(), true),
+			    operationTimeout);
 			if (acknowledgementError.present()) {
 				throw acknowledgementError.get();
 			}
-			ASSERT(retainedPublishedOwner);
+			if (!retainedPublishedOwner) {
+				co_await timeoutError(waitForAssignedProxy(cx, streamId, wrongOwner.get().id()), operationTimeout);
+				continue;
+			}
 			if (!rejectedWrongOwner(acknowledgement)) {
 				existing = co_await timeoutError(createNativeCdcConsumer(cx, name), operationTimeout);
 				ASSERT_EQ(existing->position().streamId, expectedStreamId);


### PR DESCRIPTION
## Summary

- Reject acknowledgements and removals sent to a non-owning CDC proxy.
- Ensure removal retried with an obsolete stream ID cannot delete its same-name replacement.
- Promote all three deterministically covered ownership probes from rare to required coverage.

## Testing

- `fdbclient_test`: 90/90 passed.
- `fdbserver_cdcproxy_test`: 11/11 passed.
- Six focused `NativeCdcAssignmentPublication.toml` simulation seeds and eight adjacent Native CDC smoke tests passed.
- 10,000 filtered Native CDC simulations passed with zero failures.
- Each of the three ownership probes was hit 1,355 times.
