### PR TITLE
documentation: update downloads links with foundationdb-7.3.77

### DIFF
--- a/documentation/sphinx/source/downloads.rst
+++ b/documentation/sphinx/source/downloads.rst
@@ -10,27 +10,27 @@ FoundationDB is available for download on the following platforms and the latest
 macOS
 -----
 
-The macOS installation package is supported on macOS 10.7+. It includes the client and (optionally) the server.
+The macOS installation package is supported on macOS 13+. It includes the client and (optionally) the server.
 
-* `FoundationDB-7.3.63_x86_64.pkg <https://github.com/apple/foundationdb/releases/download/7.3.63/FoundationDB-7.3.63_x86_64.pkg>`_
-* `FoundationDB-7.3.63_arm64.pkg <https://github.com/apple/foundationdb/releases/download/7.3.63/FoundationDB-7.3.63_arm64.pkg>`_
+* `FoundationDB-7.3.69_x86_64.pkg <https://github.com/apple/foundationdb/releases/download/7.3.69/FoundationDB-7.3.69_x86_64.pkg>`_
+* `FoundationDB-7.3.69_arm64.pkg <https://github.com/apple/foundationdb/releases/download/7.3.69/FoundationDB-7.3.69_arm64.pkg>`_
 
 Ubuntu
 ------
 
-The Ubuntu packages are supported on 64-bit Ubuntu 12.04+, but beware of the Linux kernel bug in Ubuntu 12.x.
+The Ubuntu packages are supported on 64-bit Ubuntu 18.04+.
 
-* `foundationdb-clients_7.3.63-1_amd64.deb <https://github.com/apple/foundationdb/releases/download/7.3.63/foundationdb-clients_7.3.63-1_amd64.deb>`_
-* `foundationdb-server_7.3.63-1_amd64.deb <https://github.com/apple/foundationdb/releases/download/7.3.63/foundationdb-server_7.3.63-1_amd64.deb>`_ (depends on the clients package)
+* `foundationdb-clients_7.3.77-1_amd64.deb <https://github.com/apple/foundationdb/releases/download/7.3.77/foundationdb-clients_7.3.77-1_amd64.deb>`_
+* `foundationdb-server_7.3.77-1_amd64.deb <https://github.com/apple/foundationdb/releases/download/7.3.77/foundationdb-server_7.3.77-1_amd64.deb>`_ (depends on the clients package)
 
 
 RHEL/CentOS 7
 ---------------
 
-The RHEL/CentOS EL7 packages are supported on 64-bit RHEL/CentOS 7.x.
+The RHEL/CentOS EL7 packages are supported on 64-bit RHEL/CentOS/Rockylinux 7+.
 
-* `foundationdb-clients-7.3.63-1.el7.x86_64.rpm <https://github.com/apple/foundationdb/releases/download/7.3.63/foundationdb-clients-7.3.63-1.el7.x86_64.rpm>`_
-* `foundationdb-server-7.3.63-1.el7.x86_64.rpm <https://github.com/apple/foundationdb/releases/download/7.3.63/foundationdb-server-7.3.63-1.el7.x86_64.rpm>`_ (depends on the clients package)
+* `foundationdb-clients-7.3.77-1.el7.x86_64.rpm <https://github.com/apple/foundationdb/releases/download/7.3.77/foundationdb-clients-7.3.77-1.el7.x86_64.rpm>`_
+* `foundationdb-server-7.3.77-1.el7.x86_64.rpm <https://github.com/apple/foundationdb/releases/download/7.3.77/foundationdb-server-7.3.77-1.el7.x86_64.rpm>`_ (depends on the clients package)
 
 Windows
 -------
@@ -58,12 +58,12 @@ Ruby 2.0.0+
 
 Ruby Gem is available on `rubygems.org <https://rubygems.org/gems/fdb>`_
 
-Java 8+
--------
+Java 11+
+--------
 
 Java jars are available from `Maven Central <https://search.maven.org/artifact/org.foundationdb/fdb-java>`_
 
-Go 1.11+
+Go 1.22+
 --------
 
 The FoundationDB Go package is available on `GitHub <https://github.com/apple/foundationdb/tree/master/bindings/go>`_

--- a/documentation/sphinx/source/release-notes/release-notes-720.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-720.rst
@@ -1,5 +1,3 @@
-.. _release-notes:
-
 #############
 Release Notes
 #############

--- a/documentation/sphinx/source/release-notes/release-notes-740.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-740.rst
@@ -1,3 +1,5 @@
+.. _release-notes:
+
 #############
 Release Notes
 #############


### PR DESCRIPTION
also update supported OS version guidance

(will validate by building docs locally and testing the links)

After this, I can backport all docs-site updates to release-7.4 branch for inclusion in the next 7.4.x release.

We could consider updating these version numbers just _before_ building the release, to match the impending release, but we do not mark a release stable right away - that comes some weeks later.