### PR TITLE
Preserve DD maintenance start versions across transaction retries

### DIFF
--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -52,9 +52,16 @@ class MaintenanceStartVersionState {
 public:
 	enum class Action { Preserve, Record, Clear };
 
-	explicit MaintenanceStartVersionState(Optional<Key> observedZone) : observedZone_(std::move(observedZone)) {}
+	explicit MaintenanceStartVersionState(Optional<Key> observedZone, bool primary = true)
+	  : primary_(primary), observedZone_(std::move(observedZone)) {}
 
 	Action reconcile(const Optional<Key>& zone, const Optional<Version>& durableStart, Version readVersion) {
+		if (!primary_) {
+			observedZone_ = zone;
+			startVersion_ = zone.present() && durableStart.present() ? durableStart.get() : invalidVersion;
+			return Action::Preserve;
+		}
+
 		if (zone != observedZone_) {
 			observedZone_ = zone;
 			startVersion_ = invalidVersion;
@@ -103,6 +110,7 @@ public:
 	Version startVersion() const { return startVersion_; }
 
 private:
+	const bool primary_;
 	Optional<Key> observedZone_;
 	Optional<Version> originalDurableStart_;
 	Version startVersion_ = invalidVersion;
@@ -2729,7 +2737,7 @@ public:
 	static Future<Void> waitHealthyZoneChange(DDTeamCollection* self) {
 		auto* counters = waitHealthyZoneChangeCounters();
 		ReadYourWritesTransaction tr(self->dbContext());
-		MaintenanceStartVersionState maintenanceStart(self->healthyZone.get());
+		MaintenanceStartVersionState maintenanceStart(self->healthyZone.get(), self->primary);
 		while (true) {
 			counters->started->increment(1);
 			Error err;
@@ -2802,6 +2810,9 @@ public:
 				}
 
 				Future<Void> watchFuture = tr.watch(healthyZoneKey);
+				if (!self->primary) {
+					watchFuture = watchFuture || tr.watch(healthyZoneStartVersionKey);
+				}
 				co_await tr.commit();
 				maintenanceStart.committed();
 				counters->committed->increment(1);
@@ -7669,6 +7680,64 @@ TEST_CASE("/DataDistribution/Maintenance/ConcurrentWriterPreservesCommittedStart
 	ASSERT_EQ(maintenanceState.startVersion(), 100);
 	ASSERT(maintenanceState.reconcile(newZone, Optional<Version>(125), 300) == State::Action::Preserve);
 	ASSERT_EQ(maintenanceState.startVersion(), 125);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionAdoptsCommittedStart") {
+	using State = MaintenanceStartVersionState;
+	const Optional<Key> zone(Key("zone-a"_sr));
+	State primaryState(Optional<Key>{}, true);
+	State remoteState(Optional<Key>{}, false);
+
+	ASSERT(primaryState.reconcile(zone, Optional<Version>{}, 100) == State::Action::Record);
+	primaryState.committed();
+	ASSERT(remoteState.reconcile(zone, Optional<Version>(100), 200) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 100);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionWaitsForPrimaryStart") {
+	using State = MaintenanceStartVersionState;
+	const Optional<Key> zone(Key("zone-a"_sr));
+	State primaryState(Optional<Key>{}, true);
+	State remoteState(Optional<Key>{}, false);
+
+	ASSERT(remoteState.reconcile(zone, Optional<Version>{}, 100) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT(primaryState.reconcile(zone, Optional<Version>{}, 200) == State::Action::Record);
+	primaryState.committed();
+	ASSERT(remoteState.reconcile(zone, Optional<Version>(200), 300) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 200);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionAdoptsReplacedStart") {
+	using State = MaintenanceStartVersionState;
+	const Optional<Key> oldZone(Key("zone-a"_sr));
+	const Optional<Key> newZone(Key("zone-b"_sr));
+	State primaryState(oldZone, true);
+	State remoteState(oldZone, false);
+
+	ASSERT(remoteState.reconcile(oldZone, Optional<Version>(100), 200) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 100);
+	ASSERT(remoteState.reconcile(newZone, Optional<Version>(100), 250) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 100);
+	ASSERT(primaryState.reconcile(newZone, Optional<Version>(100), 300) == State::Action::Record);
+	primaryState.committed();
+	ASSERT(remoteState.reconcile(newZone, Optional<Version>(300), 400) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 300);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionNeverClearsDurableStart") {
+	using State = MaintenanceStartVersionState;
+	const Optional<Key> zone(Key("zone-a"_sr));
+	State remoteState(zone, false);
+
+	ASSERT(remoteState.reconcile(zone, Optional<Version>(100), 200) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 100);
+	ASSERT(remoteState.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
 	return Void();
 }
 

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -2650,25 +2650,71 @@ public:
 		}
 	}
 
-	// Persists the version at which the current maintenance mode was started, so that a DD
-	// recruited mid-maintenance (see getOrRecordMaintenanceStart) can recover the true start.
-	static Version recordNewMaintenanceStart(ReadYourWritesTransaction* tr) {
-		Version version = tr->getReadVersion().get();
+	class MaintenanceStartVersionState {
+	public:
+		enum class Action { Preserve, Record, Clear };
+
+		explicit MaintenanceStartVersionState(Optional<Key> observedZone) : observedZone_(std::move(observedZone)) {}
+
+		Action reconcile(const Optional<Key>& zone, const Optional<Version>& durableStart, Version readVersion) {
+			if (zone != observedZone_) {
+				observedZone_ = zone;
+				startVersion_ = invalidVersion;
+				pendingRecord_ = false;
+				if (zone.present()) {
+					startVersion_ = readVersion;
+					originalDurableStart_ = durableStart;
+					pendingRecord_ = true;
+					return Action::Record;
+				}
+			}
+
+			if (!zone.present()) {
+				startVersion_ = invalidVersion;
+				pendingRecord_ = false;
+				return durableStart.present() ? Action::Clear : Action::Preserve;
+			}
+
+			if (pendingRecord_) {
+				if (durableStart.present() && durableStart.get() == startVersion_) {
+					pendingRecord_ = false;
+					return Action::Preserve;
+				}
+
+				// A different newly durable value belongs to the DD collection that won the transaction conflict.
+				if (durableStart.present() && durableStart != originalDurableStart_) {
+					startVersion_ = durableStart.get();
+					pendingRecord_ = false;
+					return Action::Preserve;
+				}
+				return Action::Record;
+			}
+
+			if (durableStart.present()) {
+				startVersion_ = durableStart.get();
+				return Action::Preserve;
+			}
+
+			startVersion_ = readVersion;
+			originalDurableStart_ = durableStart;
+			pendingRecord_ = true;
+			return Action::Record;
+		}
+
+		void committed() { pendingRecord_ = false; }
+		Version startVersion() const { return startVersion_; }
+
+	private:
+		Optional<Key> observedZone_;
+		Optional<Version> originalDurableStart_;
+		Version startVersion_ = invalidVersion;
+		bool pendingRecord_ = false;
+	};
+
+	static void recordMaintenanceStart(ReadYourWritesTransaction* tr, Version version) {
 		BinaryWriter bw(Unversioned());
 		bw << version;
 		tr->set(healthyZoneStartVersionKey, bw.toValue());
-		return version;
-	}
-
-	// Adopts the start version persisted by whichever DD instance first observed the current
-	// maintenance mode, for the case where this DD was (re)recruited while the maintenance was active.
-	// Falls back to recording a fresh start now if the key was never written.
-	static Future<Version> getOrRecordMaintenanceStart(ReadYourWritesTransaction* tr) {
-		Optional<Value> startVal = co_await tr->get(healthyZoneStartVersionKey);
-		if (startVal.present()) {
-			co_return BinaryReader::fromStringRef<Version>(startVal.get(), Unversioned());
-		}
-		co_return recordNewMaintenanceStart(tr);
 	}
 
 	// -1.0 if the start version was never established (should only happen if this DD instance
@@ -2683,11 +2729,7 @@ public:
 	static Future<Void> waitHealthyZoneChange(DDTeamCollection* self) {
 		auto* counters = waitHealthyZoneChangeCounters();
 		ReadYourWritesTransaction tr(self->dbContext());
-		// maintenanceStartVersion tracks the version at which the current maintenance/disable-DD
-		// window began, durably persisted via healthyZoneStartVersionKey, so that
-		// MaintenanceZoneEnd*/DataDistributionDisabledForStorageServerFailuresEnd can report an
-		// accurate Duration even if this DD instance was recruited mid-window.
-		Version maintenanceStartVersion = invalidVersion;
+		MaintenanceStartVersionState maintenanceStart(self->healthyZone.get());
 		while (true) {
 			counters->started->increment(1);
 			Error err;
@@ -2696,6 +2738,29 @@ public:
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 				Optional<Value> val = co_await tr.get(healthyZoneKey);
+				Optional<Value> startVal = co_await tr.get(healthyZoneStartVersionKey);
+				Optional<Version> durableStart;
+				if (startVal.present()) {
+					durableStart = BinaryReader::fromStringRef<Version>(startVal.get(), Unversioned());
+				}
+
+				Optional<Key> activeZone;
+				if (val.present()) {
+					auto configuredZone = decodeHealthyZoneValue(val.get());
+					if (configuredZone.first == ignoreSSFailuresZoneString ||
+					    configuredZone.second > tr.getReadVersion().get()) {
+						activeZone = configuredZone.first;
+					}
+				}
+
+				Version previousStartVersion = maintenanceStart.startVersion();
+				auto action = maintenanceStart.reconcile(activeZone, durableStart, tr.getReadVersion().get());
+				if (action == MaintenanceStartVersionState::Action::Record) {
+					recordMaintenanceStart(&tr, maintenanceStart.startVersion());
+				} else if (action == MaintenanceStartVersionState::Action::Clear) {
+					tr.clear(healthyZoneStartVersionKey);
+				}
+
 				Future<Void> healthyZoneTimeout = Never();
 				if (val.present()) {
 					auto p = decodeHealthyZoneValue(val.get());
@@ -2704,9 +2769,6 @@ public:
 						if (self->healthyZone.get() != p.first) {
 							TraceEvent("DataDistributionDisabledForStorageServerFailuresStart", self->distributorId)
 							    .log();
-							maintenanceStartVersion = recordNewMaintenanceStart(&tr);
-						} else if (maintenanceStartVersion == invalidVersion) {
-							maintenanceStartVersion = co_await getOrRecordMaintenanceStart(&tr);
 						}
 						healthyZoneTimeout = Never();
 						self->healthyZone.set(p.first);
@@ -2720,21 +2782,16 @@ public:
 							    .detail("EndVersion", p.second)
 							    .detail("Duration", timeoutSeconds);
 							self->healthyZone.set(p.first);
-							maintenanceStartVersion = recordNewMaintenanceStart(&tr);
-						} else if (maintenanceStartVersion == invalidVersion) {
-							maintenanceStartVersion = co_await getOrRecordMaintenanceStart(&tr);
 						}
 					} else if (self->healthyZone.get().present()) {
 						// maintenance hits timeout
 						TraceEvent("MaintenanceZoneEndTimeout", self->distributorId)
-						    .detail("Duration", maintenanceDurationSeconds(&tr, maintenanceStartVersion));
+						    .detail("Duration", maintenanceDurationSeconds(&tr, previousStartVersion));
 						self->healthyZone.set(Optional<Key>());
-						tr.clear(healthyZoneStartVersionKey);
-						maintenanceStartVersion = invalidVersion;
 					}
 				} else if (self->healthyZone.get().present()) {
 					// `healthyZone` has been cleared
-					double duration = maintenanceDurationSeconds(&tr, maintenanceStartVersion);
+					double duration = maintenanceDurationSeconds(&tr, previousStartVersion);
 					if (self->healthyZone.get().get() == ignoreSSFailuresZoneString) {
 						TraceEvent("DataDistributionDisabledForStorageServerFailuresEnd", self->distributorId)
 						    .detail("Duration", duration);
@@ -2742,12 +2799,11 @@ public:
 						TraceEvent("MaintenanceZoneEndManualClear", self->distributorId).detail("Duration", duration);
 					}
 					self->healthyZone.set(Optional<Key>());
-					tr.clear(healthyZoneStartVersionKey);
-					maintenanceStartVersion = invalidVersion;
 				}
 
 				Future<Void> watchFuture = tr.watch(healthyZoneKey);
 				co_await tr.commit();
+				maintenanceStart.committed();
 				counters->committed->increment(1);
 				co_await (watchFuture || healthyZoneTimeout);
 				tr.reset();
@@ -7573,5 +7629,118 @@ TEST_CASE("/DataDistribution/TeamTracker/RetriesMergedShardForUndesiredServer") 
 
 TEST_CASE("/DataDistribution/TeamTracker/RechecksHealthyZone") {
 	wait(DDTeamCollectionUnitTest::TeamTracker_RechecksHealthyZone());
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/FailedStartRetriesOriginalVersion") {
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	const Optional<Key> zone(Key("zone-a"_sr));
+	State maintenanceState(Optional<Key>{});
+
+	ASSERT(maintenanceState.reconcile(zone, Optional<Version>{}, 100) == State::Action::Record);
+	ASSERT_EQ(maintenanceState.startVersion(), 100);
+	ASSERT(maintenanceState.reconcile(zone, Optional<Version>{}, 200) == State::Action::Record);
+	ASSERT_EQ(maintenanceState.startVersion(), 100);
+	maintenanceState.committed();
+	ASSERT(maintenanceState.reconcile(zone, Optional<Version>(100), 300) == State::Action::Preserve);
+	ASSERT_EQ(maintenanceState.startVersion(), 100);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/AmbiguousCommitPreservesDurableStart") {
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	const Optional<Key> zone(Key("zone-a"_sr));
+	State maintenanceState(Optional<Key>{});
+
+	ASSERT(maintenanceState.reconcile(zone, Optional<Version>{}, 100) == State::Action::Record);
+	ASSERT(maintenanceState.reconcile(zone, Optional<Version>(100), 200) == State::Action::Preserve);
+	ASSERT_EQ(maintenanceState.startVersion(), 100);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/ConcurrentWriterPreservesCommittedStart") {
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	const Optional<Key> oldZone(Key("zone-a"_sr));
+	const Optional<Key> newZone(Key("zone-b"_sr));
+	State maintenanceState(oldZone);
+
+	ASSERT(maintenanceState.reconcile(newZone, Optional<Version>(50), 100) == State::Action::Record);
+	ASSERT(maintenanceState.reconcile(newZone, Optional<Version>(50), 200) == State::Action::Record);
+	ASSERT_EQ(maintenanceState.startVersion(), 100);
+	ASSERT(maintenanceState.reconcile(newZone, Optional<Version>(125), 300) == State::Action::Preserve);
+	ASSERT_EQ(maintenanceState.startVersion(), 125);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/FailedClearRetriesWithoutLocalZone") {
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	const Optional<Key> zone(Key("zone-a"_sr));
+	State maintenanceState(zone);
+
+	ASSERT(maintenanceState.reconcile(zone, Optional<Version>(100), 200) == State::Action::Preserve);
+	ASSERT(maintenanceState.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Clear);
+	ASSERT_EQ(maintenanceState.startVersion(), invalidVersion);
+	ASSERT(maintenanceState.reconcile(Optional<Key>{}, Optional<Version>(100), 400) == State::Action::Clear);
+	ASSERT(maintenanceState.reconcile(Optional<Key>{}, Optional<Version>{}, 500) == State::Action::Preserve);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/ExternallyClearedZoneRemovesStaleStart") {
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	State maintenanceState(Optional<Key>{});
+
+	ASSERT(maintenanceState.reconcile(Optional<Key>{}, Optional<Version>(100), 200) == State::Action::Clear);
+	ASSERT(maintenanceState.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Clear);
+	ASSERT(maintenanceState.reconcile(Optional<Key>{}, Optional<Version>{}, 400) == State::Action::Preserve);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/ZoneChangeReplacesStaleStart") {
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	const Optional<Key> oldZone(Key("zone-a"_sr));
+	const Optional<Key> newZone(Key("zone-b"_sr));
+	State maintenanceState(oldZone);
+
+	ASSERT(maintenanceState.reconcile(oldZone, Optional<Version>(100), 200) == State::Action::Preserve);
+	maintenanceState.committed();
+	ASSERT(maintenanceState.reconcile(newZone, Optional<Version>(100), 300) == State::Action::Record);
+	ASSERT_EQ(maintenanceState.startVersion(), 300);
+	ASSERT(maintenanceState.reconcile(newZone, Optional<Version>(100), 400) == State::Action::Record);
+	ASSERT_EQ(maintenanceState.startVersion(), 300);
+	ASSERT(maintenanceState.reconcile(newZone, Optional<Version>(300), 500) == State::Action::Preserve);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/SameZoneRestartAfterFailedClear") {
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	const Optional<Key> zone(Key("zone-a"_sr));
+	State maintenanceState(zone);
+
+	ASSERT(maintenanceState.reconcile(zone, Optional<Version>(100), 200) == State::Action::Preserve);
+	ASSERT(maintenanceState.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Clear);
+	ASSERT(maintenanceState.reconcile(zone, Optional<Version>(100), 400) == State::Action::Record);
+	ASSERT_EQ(maintenanceState.startVersion(), 400);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/RecruitmentAdoptsDurableStart") {
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	const Optional<Key> zone(Key("zone-a"_sr));
+	State maintenanceState(zone);
+
+	ASSERT(maintenanceState.reconcile(zone, Optional<Version>(100), 500) == State::Action::Preserve);
+	ASSERT_EQ(maintenanceState.startVersion(), 100);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/RecruitmentRepairsMissingStart") {
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	const Optional<Key> zone(Key("zone-a"_sr));
+	State maintenanceState(zone);
+
+	ASSERT(maintenanceState.reconcile(zone, Optional<Version>{}, 500) == State::Action::Record);
+	ASSERT_EQ(maintenanceState.startVersion(), 500);
+	ASSERT(maintenanceState.reconcile(zone, Optional<Version>{}, 600) == State::Action::Record);
+	ASSERT_EQ(maintenanceState.startVersion(), 500);
 	return Void();
 }

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <climits>
+#include <cstdlib>
 #include <unordered_set>
 
 #include "fdbclient/SystemData.h"
@@ -31,6 +32,8 @@
 #include "TCInfo.h"
 #include "ExclusionTracker.h"
 #include "flow/IRandom.h"
+#include "flow/ProcessEvents.h"
+#include "flow/ScopeExit.h"
 #include "flow/Trace.h"
 #include "flow/network.h"
 #include "flow/TxnCounters.h"
@@ -66,8 +69,37 @@ public:
 
 	Action reconcile(const Optional<Key>& zone, const Optional<Version>& durableStart, Version readVersion) {
 		if (!primary_) {
+			bool replacedZone = zone.present() && observedZone_.present() && zone != observedZone_;
+			bool changedStart = zone.present() && observedZone_.present() && zone == observedZone_ &&
+			                    startVersion_ != invalidVersion && durableStart.present() &&
+			                    durableStart.get() != startVersion_;
+			if (replacedZone || changedStart) {
+				Version replacementFloor = std::max(minimumReplacementStart_.orDefault(invalidVersion), startVersion_);
+				if (durableStart.present()) {
+					replacementFloor = std::max(replacementFloor, durableStart.get());
+				}
+				if (replacementFloor != invalidVersion) {
+					minimumReplacementStart_ = replacementFloor;
+				}
+			}
+
 			observedZone_ = zone;
-			startVersion_ = zone.present() && durableStart.present() ? durableStart.get() : invalidVersion;
+			if (!zone.present()) {
+				if (durableStart.present()) {
+					minimumReplacementStart_ =
+					    std::max(std::max(minimumReplacementStart_.orDefault(invalidVersion), startVersion_),
+					             durableStart.get());
+				} else {
+					minimumReplacementStart_ = Optional<Version>{};
+				}
+				startVersion_ = invalidVersion;
+			} else if (durableStart.present() &&
+			           (!minimumReplacementStart_.present() || durableStart.get() > minimumReplacementStart_.get())) {
+				startVersion_ = durableStart.get();
+				minimumReplacementStart_ = Optional<Version>{};
+			} else {
+				startVersion_ = invalidVersion;
+			}
 			return Action::Preserve;
 		}
 
@@ -121,6 +153,9 @@ public:
 		if (startVersion_ != invalidVersion || !localZone.present() || !durableStart.present()) {
 			return startVersion_;
 		}
+		if (minimumReplacementStart_.present()) {
+			return invalidVersion;
+		}
 		return durableStart.get();
 	}
 
@@ -128,6 +163,7 @@ private:
 	const bool primary_;
 	Optional<Key> observedZone_;
 	Optional<Version> originalDurableStart_;
+	Optional<Version> minimumReplacementStart_;
 	Version startVersion_ = invalidVersion;
 	bool pendingRecord_ = false;
 };
@@ -2739,13 +2775,28 @@ public:
 		tr->set(healthyZoneStartVersionKey, bw.toValue());
 	}
 
-	// -1.0 if the start version was never established (should only happen if this DD instance
-	// raced a commit failure with a window's start/end); otherwise the elapsed window duration.
+	// -1.0 if a committed start cannot be attributed to this window after a failed commit or
+	// coalesced window transition; otherwise the elapsed window duration.
 	static double maintenanceDurationSeconds(ReadYourWritesTransaction* tr, Version startVersion) {
 		if (startVersion == invalidVersion) {
 			return -1.0;
 		}
 		return (tr->getReadVersion().get() - startVersion) / (double)SERVER_KNOBS->VERSIONS_PER_SECOND;
+	}
+
+	static void traceMaintenanceEnd(DDTeamCollection* self,
+	                                ReadYourWritesTransaction* tr,
+	                                Version startVersion,
+	                                bool timedOut) {
+		double duration = maintenanceDurationSeconds(tr, startVersion);
+		if (timedOut) {
+			TraceEvent("MaintenanceZoneEndTimeout", self->distributorId).detail("Duration", duration);
+		} else if (self->healthyZone.get().get() == ignoreSSFailuresZoneString) {
+			TraceEvent("DataDistributionDisabledForStorageServerFailuresEnd", self->distributorId)
+			    .detail("Duration", duration);
+		} else {
+			TraceEvent("MaintenanceZoneEndManualClear", self->distributorId).detail("Duration", duration);
+		}
 	}
 
 	static Future<Void> waitHealthyZoneChange(DDTeamCollection* self) {
@@ -2781,6 +2832,10 @@ public:
 				if (action != MaintenanceStartVersionState::Action::Preserve) {
 					Optional<Value> durableOwner = co_await tr.get(moveKeysLockOwnerKey);
 					if (!ownsMaintenanceLock(self->lock, durableOwner)) {
+						if (action == MaintenanceStartVersionState::Action::Clear &&
+						    self->healthyZone.get().present()) {
+							traceMaintenanceEnd(self, &tr, previousStartVersion, val.present());
+						}
 						throw movekeys_conflict();
 					}
 					if (action == MaintenanceStartVersionState::Action::Record) {
@@ -2815,19 +2870,12 @@ public:
 						}
 					} else if (self->healthyZone.get().present()) {
 						// maintenance hits timeout
-						TraceEvent("MaintenanceZoneEndTimeout", self->distributorId)
-						    .detail("Duration", maintenanceDurationSeconds(&tr, previousStartVersion));
+						traceMaintenanceEnd(self, &tr, previousStartVersion, true);
 						self->healthyZone.set(Optional<Key>());
 					}
 				} else if (self->healthyZone.get().present()) {
 					// `healthyZone` has been cleared
-					double duration = maintenanceDurationSeconds(&tr, previousStartVersion);
-					if (self->healthyZone.get().get() == ignoreSSFailuresZoneString) {
-						TraceEvent("DataDistributionDisabledForStorageServerFailuresEnd", self->distributorId)
-						    .detail("Duration", duration);
-					} else {
-						TraceEvent("MaintenanceZoneEndManualClear", self->distributorId).detail("Duration", duration);
-					}
+					traceMaintenanceEnd(self, &tr, previousStartVersion, false);
 					self->healthyZone.set(Optional<Key>());
 				}
 
@@ -6436,6 +6484,10 @@ Future<Void> DDTeamCollection::printSnapshotTeamsInfo(Reference<DDTeamCollection
 
 class DDTeamCollectionUnitTest {
 public:
+	static void setHealthyZoneForTest(DDTeamCollection* collection, Optional<Key> zone) {
+		collection->healthyZone.set(std::move(zone));
+	}
+
 	static void setTestEndpoint(StorageServerInterface& interface, int id) {
 		// These unit tests do not run storage server actors, but team tracking still logs each
 		// interface's address. Give every fixture interface a synthetic, unregistered endpoint.
@@ -7725,6 +7777,68 @@ TEST_CASE("/DataDistribution/Maintenance/SupersededPrimaryCannotMutateMaintenanc
 	ASSERT(!ownsMaintenanceLock(currentLock, Optional<Value>{}));
 	ASSERT(previousPrimary.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Clear);
 	ASSERT(!ownsMaintenanceLock(previousLock, durableOwner));
+
+	const Optional<Key> disabledZone{ Key(ignoreSSFailuresZoneString) };
+	State supersededDisabledPrimary(disabledZone, true);
+	ASSERT(supersededDisabledPrimary.reconcile(disabledZone, Optional<Version>(100), 150) == State::Action::Preserve);
+	ASSERT_EQ(supersededDisabledPrimary.endingStartVersion(disabledZone, Optional<Version>(100)), 100);
+	ASSERT(supersededDisabledPrimary.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Clear);
+	ASSERT(!ownsMaintenanceLock(previousLock, durableOwner));
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/WindowEndEventsPreserveDuration") {
+	auto collection = DDTeamCollectionUnitTest::testTeamCollection(1, makeReference<PolicyOne>(), 0);
+	ReadYourWritesTransaction tr(collection->dbContext());
+	tr.setVersion(SERVER_KNOBS->VERSIONS_PER_SECOND + 100);
+
+	int observedEvents[3] = {};
+	double observedDurations[3] = {};
+	bool malformedEvent = false;
+	ProcessEvents::Event capture({ "TraceEvent::DataDistributionDisabledForStorageServerFailuresEnd"_sr,
+	                               "TraceEvent::MaintenanceZoneEndManualClear"_sr,
+	                               "TraceEvent::MaintenanceZoneEndTimeout"_sr },
+	                             [&](StringRef name, std::any const& data, Error const&) noexcept {
+		                             auto* trace = std::any_cast<BaseTraceEvent*>(&data);
+		                             if (trace == nullptr || *trace == nullptr) {
+			                             malformedEvent = true;
+			                             return;
+		                             }
+
+		                             int index =
+		                                 name == "TraceEvent::DataDistributionDisabledForStorageServerFailuresEnd"_sr
+		                                     ? 0
+		                                 : name == "TraceEvent::MaintenanceZoneEndManualClear"_sr ? 1
+		                                                                                          : 2;
+		                             ++observedEvents[index];
+		                             bool foundDuration = false;
+		                             for (const auto& field : (*trace)->getFields()) {
+			                             if (field.first == "Duration") {
+				                             char* end = nullptr;
+				                             observedDurations[index] = std::strtod(field.second.c_str(), &end);
+				                             foundDuration = end != field.second.c_str() && *end == '\0';
+				                             break;
+			                             }
+		                             }
+		                             malformedEvent = malformedEvent || !foundDuration;
+	                             });
+
+	const bool previouslyTracingEvents = g_traceProcessEvents;
+	g_traceProcessEvents = true;
+	ScopeExit restoreTraceProcessEvents(
+	    [previouslyTracingEvents]() { g_traceProcessEvents = previouslyTracingEvents; });
+
+	DDTeamCollectionUnitTest::setHealthyZoneForTest(collection.get(), Key(ignoreSSFailuresZoneString));
+	DDTeamCollectionImpl::traceMaintenanceEnd(collection.get(), &tr, 100, false);
+	DDTeamCollectionUnitTest::setHealthyZoneForTest(collection.get(), Key("zone-a"_sr));
+	DDTeamCollectionImpl::traceMaintenanceEnd(collection.get(), &tr, 100, false);
+	DDTeamCollectionImpl::traceMaintenanceEnd(collection.get(), &tr, 100, true);
+
+	ASSERT(!malformedEvent);
+	for (int i = 0; i < 3; ++i) {
+		ASSERT_EQ(observedEvents[i], 1);
+		ASSERT_EQ(observedDurations[i], 1.0);
+	}
 	return Void();
 }
 
@@ -7766,11 +7880,153 @@ TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionAdoptsReplacedStart") {
 	ASSERT(remoteState.reconcile(oldZone, Optional<Version>(100), 200) == State::Action::Preserve);
 	ASSERT_EQ(remoteState.startVersion(), 100);
 	ASSERT(remoteState.reconcile(newZone, Optional<Version>(100), 250) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 100);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
 	ASSERT(primaryState.reconcile(newZone, Optional<Version>(100), 300) == State::Action::Record);
 	primaryState.committed();
 	ASSERT(remoteState.reconcile(newZone, Optional<Version>(300), 400) == State::Action::Preserve);
 	ASSERT_EQ(remoteState.startVersion(), 300);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionRejectsPreviousWindowStartOnReplacement") {
+	using State = MaintenanceStartVersionState;
+	const Optional<Key> oldZone(Key("zone-a"_sr));
+	const Optional<Key> newZone(Key("zone-b"_sr));
+	const Optional<Key> thirdZone(Key("zone-c"_sr));
+	State remoteState(oldZone, false);
+
+	ASSERT(remoteState.reconcile(oldZone, Optional<Version>(100), 200) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 100);
+	ASSERT_EQ(remoteState.endingStartVersion(oldZone, Optional<Version>(300)), 100);
+	ASSERT(remoteState.reconcile(newZone, Optional<Version>(100), 250) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>(100)), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>{}), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(Optional<Key>{}, Optional<Version>(300)), invalidVersion);
+	ASSERT(remoteState.reconcile(newZone, Optional<Version>(100), 260) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT(remoteState.reconcile(newZone, Optional<Version>{}, 270) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT(remoteState.reconcile(newZone, Optional<Version>(100), 280) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>(300)), invalidVersion);
+	ASSERT(remoteState.reconcile(thirdZone, Optional<Version>(300), 350) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(thirdZone, Optional<Version>(300)), invalidVersion);
+	ASSERT(remoteState.reconcile(thirdZone, Optional<Version>(300), 360) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(thirdZone, Optional<Version>(400)), invalidVersion);
+	ASSERT(remoteState.reconcile(Optional<Key>{}, Optional<Version>(300), 450) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+
+	ASSERT(remoteState.reconcile(oldZone, Optional<Version>(500), 600) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 500);
+	ASSERT(remoteState.reconcile(newZone, Optional<Version>(700), 800) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>(700)), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>{}), invalidVersion);
+	ASSERT(remoteState.reconcile(newZone, Optional<Version>(700), 900) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT(remoteState.reconcile(newZone, Optional<Version>(750), 950) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 750);
+	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>(650)), 750);
+	ASSERT(remoteState.reconcile(oldZone, Optional<Version>(650), 1000) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(oldZone, Optional<Version>(650)), invalidVersion);
+	ASSERT(remoteState.reconcile(Optional<Key>{}, Optional<Version>(650), 1100) == State::Action::Preserve);
+	ASSERT(remoteState.reconcile(thirdZone, Optional<Version>(650), 1200) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(thirdZone, Optional<Version>(650)), invalidVersion);
+	ASSERT(remoteState.reconcile(thirdZone, Optional<Version>(900), 1250) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 900);
+
+	State unknownStart(oldZone, false);
+	ASSERT(unknownStart.reconcile(oldZone, Optional<Version>{}, 1300) == State::Action::Preserve);
+	ASSERT(unknownStart.reconcile(newZone, Optional<Version>(1400), 1500) == State::Action::Preserve);
+	ASSERT_EQ(unknownStart.startVersion(), invalidVersion);
+	ASSERT(unknownStart.reconcile(newZone, Optional<Version>(1400), 1600) == State::Action::Preserve);
+	ASSERT_EQ(unknownStart.startVersion(), invalidVersion);
+	ASSERT(unknownStart.reconcile(newZone, Optional<Version>(1700), 1800) == State::Action::Preserve);
+	ASSERT_EQ(unknownStart.startVersion(), 1700);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionRejectsStaleStartAfterWindowClears") {
+	using State = MaintenanceStartVersionState;
+	const Optional<Key> oldZone(Key("zone-a"_sr));
+	const Optional<Key> newZone(Key("zone-b"_sr));
+	const Optional<Key> thirdZone(Key("zone-c"_sr));
+	State restartedWindow(oldZone, false);
+
+	ASSERT(restartedWindow.reconcile(oldZone, Optional<Version>(100), 200) == State::Action::Preserve);
+	ASSERT_EQ(restartedWindow.endingStartVersion(oldZone, Optional<Version>(100)), 100);
+	ASSERT(restartedWindow.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Preserve);
+	ASSERT(restartedWindow.reconcile(Optional<Key>{}, Optional<Version>(100), 400) == State::Action::Preserve);
+	ASSERT(restartedWindow.reconcile(newZone, Optional<Version>(100), 500) == State::Action::Preserve);
+	ASSERT_EQ(restartedWindow.startVersion(), invalidVersion);
+	ASSERT_EQ(restartedWindow.endingStartVersion(newZone, Optional<Version>(100)), invalidVersion);
+	ASSERT_EQ(restartedWindow.endingStartVersion(newZone, Optional<Version>(600)), invalidVersion);
+	ASSERT(restartedWindow.reconcile(newZone, Optional<Version>(600), 700) == State::Action::Preserve);
+	ASSERT_EQ(restartedWindow.startVersion(), 600);
+
+	ASSERT_EQ(restartedWindow.endingStartVersion(newZone, Optional<Version>(800)), 600);
+	ASSERT(restartedWindow.reconcile(Optional<Key>{}, Optional<Version>(800), 900) == State::Action::Preserve);
+	ASSERT(restartedWindow.reconcile(thirdZone, Optional<Version>(800), 1000) == State::Action::Preserve);
+	ASSERT_EQ(restartedWindow.startVersion(), invalidVersion);
+	ASSERT_EQ(restartedWindow.endingStartVersion(thirdZone, Optional<Version>(800)), invalidVersion);
+	ASSERT(restartedWindow.reconcile(Optional<Key>{}, Optional<Version>{}, 1100) == State::Action::Preserve);
+	ASSERT(restartedWindow.reconcile(oldZone, Optional<Version>(800), 1200) == State::Action::Preserve);
+	ASSERT_EQ(restartedWindow.startVersion(), 800);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionRejectsSkippedIntermediateWindowStart") {
+	using State = MaintenanceStartVersionState;
+	const Optional<Key> oldZone(Key("zone-a"_sr));
+	const Optional<Key> latestZone(Key("zone-c"_sr));
+	State remoteState(oldZone, false);
+
+	ASSERT(remoteState.reconcile(oldZone, Optional<Version>(100), 200) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 100);
+	ASSERT(remoteState.reconcile(latestZone, Optional<Version>(300), 400) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(latestZone, Optional<Version>(300)), invalidVersion);
+	ASSERT(remoteState.reconcile(latestZone, Optional<Version>(300), 450) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(latestZone, Optional<Version>(500)), invalidVersion);
+	ASSERT(remoteState.reconcile(latestZone, Optional<Version>(500), 600) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 500);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionRejectsUnattributedEndAfterReplacement") {
+	using State = MaintenanceStartVersionState;
+	const Optional<Key> oldZone(Key("zone-a"_sr));
+	const Optional<Key> newZone(Key("zone-b"_sr));
+	State remoteState(oldZone, false);
+
+	ASSERT(remoteState.reconcile(oldZone, Optional<Version>(100), 200) == State::Action::Preserve);
+	ASSERT(remoteState.reconcile(newZone, Optional<Version>(100), 250) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>(300)), invalidVersion);
+	ASSERT(remoteState.reconcile(newZone, Optional<Version>(300), 350) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>(300)), 300);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionRejectsChangedStartForSameZone") {
+	using State = MaintenanceStartVersionState;
+	const Optional<Key> zone(Key("zone-a"_sr));
+	State remoteState(zone, false);
+
+	ASSERT(remoteState.reconcile(zone, Optional<Version>(100), 200) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 100);
+	ASSERT(remoteState.reconcile(zone, Optional<Version>(300), 400) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(zone, Optional<Version>(300)), invalidVersion);
+	ASSERT(remoteState.reconcile(zone, Optional<Version>(300), 450) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT(remoteState.reconcile(zone, Optional<Version>(500), 600) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), 500);
 	return Void();
 }
 

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -2650,6 +2650,8 @@ public:
 		}
 	}
 
+	// Preserves a maintenance window's original start version across transaction retries.
+	// A competing durable start version takes precedence over an uncommitted local version.
 	class MaintenanceStartVersionState {
 	public:
 		enum class Action { Preserve, Record, Clear };

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -19,7 +19,6 @@
  */
 
 #include <climits>
-#include <cstdlib>
 #include <unordered_set>
 
 #include "fdbclient/SystemData.h"
@@ -32,8 +31,6 @@
 #include "TCInfo.h"
 #include "ExclusionTracker.h"
 #include "flow/IRandom.h"
-#include "flow/ProcessEvents.h"
-#include "flow/ScopeExit.h"
 #include "flow/Trace.h"
 #include "flow/network.h"
 #include "flow/TxnCounters.h"
@@ -51,123 +48,9 @@ auto get(MapContainer& m, K const& k) -> decltype(m.at(k)) {
 	return it->second;
 }
 
-bool ownsMaintenanceLock(const MoveKeysLock& lock, const Optional<Value>& durableOwner) {
-	return durableOwner.present() &&
-	       BinaryReader::fromStringRef<UID>(durableOwner.get(), Unversioned()) == lock.myOwner;
-}
-
 } // namespace
 
 namespace data_distribution {
-
-class MaintenanceStartVersionState {
-public:
-	enum class Action { Preserve, Record, Clear };
-
-	explicit MaintenanceStartVersionState(Optional<Key> observedZone, bool primary = true)
-	  : primary_(primary), observedZone_(std::move(observedZone)) {}
-
-	Action reconcile(const Optional<Key>& zone, const Optional<Version>& durableStart, Version readVersion) {
-		if (!primary_) {
-			bool replacedZone = zone.present() && observedZone_.present() && zone != observedZone_;
-			bool changedStart = zone.present() && observedZone_.present() && zone == observedZone_ &&
-			                    startVersion_ != invalidVersion && durableStart.present() &&
-			                    durableStart.get() != startVersion_;
-			if (replacedZone || changedStart) {
-				Version replacementFloor = std::max(minimumReplacementStart_.orDefault(invalidVersion), startVersion_);
-				if (durableStart.present()) {
-					replacementFloor = std::max(replacementFloor, durableStart.get());
-				}
-				if (replacementFloor != invalidVersion) {
-					minimumReplacementStart_ = replacementFloor;
-				}
-			}
-
-			observedZone_ = zone;
-			if (!zone.present()) {
-				if (durableStart.present()) {
-					minimumReplacementStart_ =
-					    std::max(std::max(minimumReplacementStart_.orDefault(invalidVersion), startVersion_),
-					             durableStart.get());
-				} else {
-					minimumReplacementStart_ = Optional<Version>{};
-				}
-				startVersion_ = invalidVersion;
-			} else if (durableStart.present() &&
-			           (!minimumReplacementStart_.present() || durableStart.get() > minimumReplacementStart_.get())) {
-				startVersion_ = durableStart.get();
-				minimumReplacementStart_ = Optional<Version>{};
-			} else {
-				startVersion_ = invalidVersion;
-			}
-			return Action::Preserve;
-		}
-
-		if (zone != observedZone_) {
-			observedZone_ = zone;
-			startVersion_ = invalidVersion;
-			pendingRecord_ = false;
-			if (zone.present()) {
-				startVersion_ = readVersion;
-				originalDurableStart_ = durableStart;
-				pendingRecord_ = true;
-				return Action::Record;
-			}
-		}
-
-		if (!zone.present()) {
-			startVersion_ = invalidVersion;
-			pendingRecord_ = false;
-			return durableStart.present() ? Action::Clear : Action::Preserve;
-		}
-
-		if (pendingRecord_) {
-			if (durableStart.present() && durableStart.get() == startVersion_) {
-				pendingRecord_ = false;
-				return Action::Preserve;
-			}
-
-			// A different newly durable value belongs to the DD collection that won the transaction conflict.
-			if (durableStart.present() && durableStart != originalDurableStart_) {
-				startVersion_ = durableStart.get();
-				pendingRecord_ = false;
-				return Action::Preserve;
-			}
-			return Action::Record;
-		}
-
-		if (durableStart.present()) {
-			startVersion_ = durableStart.get();
-			return Action::Preserve;
-		}
-
-		startVersion_ = readVersion;
-		originalDurableStart_ = durableStart;
-		pendingRecord_ = true;
-		return Action::Record;
-	}
-
-	void committed() { pendingRecord_ = false; }
-	Version startVersion() const { return startVersion_; }
-	Version endingStartVersion(const Optional<Key>& localZone, const Optional<Version>& durableStart) const {
-		if (startVersion_ != invalidVersion || !localZone.present() || !durableStart.present()) {
-			return startVersion_;
-		}
-		if (minimumReplacementStart_.present()) {
-			return invalidVersion;
-		}
-		return durableStart.get();
-	}
-
-private:
-	const bool primary_;
-	Optional<Key> observedZone_;
-	Optional<Version> originalDurableStart_;
-	Optional<Version> minimumReplacementStart_;
-	Version startVersion_ = invalidVersion;
-	bool pendingRecord_ = false;
-};
-
 int EligibilityCounter::fromGetTeamRequest(GetTeamRequest const& req) {
 	// equivalent to bit set operation
 	return req.preferLowerDiskUtil * EligibilityCounter::LOW_DISK_UTIL +
@@ -195,8 +78,6 @@ int EligibilityCounter::getCount(int combinedType) const {
 }
 
 } // namespace data_distribution
-
-using data_distribution::MaintenanceStartVersionState;
 
 static TxnCounters* updateNextWigglingStorageIDCounters() {
 	static auto* c = makeCounters("/dd/updateNextWigglingStorageID");
@@ -2769,14 +2650,75 @@ public:
 		}
 	}
 
+	class MaintenanceStartVersionState {
+	public:
+		enum class Action { Preserve, Record, Clear };
+
+		explicit MaintenanceStartVersionState(Optional<Key> observedZone) : observedZone_(std::move(observedZone)) {}
+
+		Action reconcile(const Optional<Key>& zone, const Optional<Version>& durableStart, Version readVersion) {
+			if (zone != observedZone_) {
+				observedZone_ = zone;
+				startVersion_ = invalidVersion;
+				pendingRecord_ = false;
+				if (zone.present()) {
+					startVersion_ = readVersion;
+					originalDurableStart_ = durableStart;
+					pendingRecord_ = true;
+					return Action::Record;
+				}
+			}
+
+			if (!zone.present()) {
+				startVersion_ = invalidVersion;
+				pendingRecord_ = false;
+				return durableStart.present() ? Action::Clear : Action::Preserve;
+			}
+
+			if (pendingRecord_) {
+				if (durableStart.present() && durableStart.get() == startVersion_) {
+					pendingRecord_ = false;
+					return Action::Preserve;
+				}
+
+				// A different newly durable value belongs to the DD collection that won the transaction conflict.
+				if (durableStart.present() && durableStart != originalDurableStart_) {
+					startVersion_ = durableStart.get();
+					pendingRecord_ = false;
+					return Action::Preserve;
+				}
+				return Action::Record;
+			}
+
+			if (durableStart.present()) {
+				startVersion_ = durableStart.get();
+				return Action::Preserve;
+			}
+
+			startVersion_ = readVersion;
+			originalDurableStart_ = durableStart;
+			pendingRecord_ = true;
+			return Action::Record;
+		}
+
+		void committed() { pendingRecord_ = false; }
+		Version startVersion() const { return startVersion_; }
+
+	private:
+		Optional<Key> observedZone_;
+		Optional<Version> originalDurableStart_;
+		Version startVersion_ = invalidVersion;
+		bool pendingRecord_ = false;
+	};
+
 	static void recordMaintenanceStart(ReadYourWritesTransaction* tr, Version version) {
 		BinaryWriter bw(Unversioned());
 		bw << version;
 		tr->set(healthyZoneStartVersionKey, bw.toValue());
 	}
 
-	// -1.0 if a committed start cannot be attributed to this window after a failed commit or
-	// coalesced window transition; otherwise the elapsed window duration.
+	// -1.0 if the start version was never established (should only happen if this DD instance
+	// raced a commit failure with a window's start/end); otherwise the elapsed window duration.
 	static double maintenanceDurationSeconds(ReadYourWritesTransaction* tr, Version startVersion) {
 		if (startVersion == invalidVersion) {
 			return -1.0;
@@ -2784,25 +2726,10 @@ public:
 		return (tr->getReadVersion().get() - startVersion) / (double)SERVER_KNOBS->VERSIONS_PER_SECOND;
 	}
 
-	static void traceMaintenanceEnd(DDTeamCollection* self,
-	                                ReadYourWritesTransaction* tr,
-	                                Version startVersion,
-	                                bool timedOut) {
-		double duration = maintenanceDurationSeconds(tr, startVersion);
-		if (timedOut) {
-			TraceEvent("MaintenanceZoneEndTimeout", self->distributorId).detail("Duration", duration);
-		} else if (self->healthyZone.get().get() == ignoreSSFailuresZoneString) {
-			TraceEvent("DataDistributionDisabledForStorageServerFailuresEnd", self->distributorId)
-			    .detail("Duration", duration);
-		} else {
-			TraceEvent("MaintenanceZoneEndManualClear", self->distributorId).detail("Duration", duration);
-		}
-	}
-
 	static Future<Void> waitHealthyZoneChange(DDTeamCollection* self) {
 		auto* counters = waitHealthyZoneChangeCounters();
 		ReadYourWritesTransaction tr(self->dbContext());
-		MaintenanceStartVersionState maintenanceStart(self->healthyZone.get(), self->primary);
+		MaintenanceStartVersionState maintenanceStart(self->healthyZone.get());
 		while (true) {
 			counters->started->increment(1);
 			Error err;
@@ -2826,24 +2753,12 @@ public:
 					}
 				}
 
-				Version previousStartVersion =
-				    maintenanceStart.endingStartVersion(self->healthyZone.get(), durableStart);
+				Version previousStartVersion = maintenanceStart.startVersion();
 				auto action = maintenanceStart.reconcile(activeZone, durableStart, tr.getReadVersion().get());
-				if (action != MaintenanceStartVersionState::Action::Preserve) {
-					Optional<Value> durableOwner = co_await tr.get(moveKeysLockOwnerKey);
-					if (!ownsMaintenanceLock(self->lock, durableOwner)) {
-						if (action == MaintenanceStartVersionState::Action::Clear &&
-						    self->healthyZone.get().present()) {
-							traceMaintenanceEnd(self, &tr, previousStartVersion, val.present());
-						}
-						throw movekeys_conflict();
-					}
-					if (action == MaintenanceStartVersionState::Action::Record) {
-						recordMaintenanceStart(&tr, maintenanceStart.startVersion());
-					} else {
-						ASSERT(action == MaintenanceStartVersionState::Action::Clear);
-						tr.clear(healthyZoneStartVersionKey);
-					}
+				if (action == MaintenanceStartVersionState::Action::Record) {
+					recordMaintenanceStart(&tr, maintenanceStart.startVersion());
+				} else if (action == MaintenanceStartVersionState::Action::Clear) {
+					tr.clear(healthyZoneStartVersionKey);
 				}
 
 				Future<Void> healthyZoneTimeout = Never();
@@ -2870,19 +2785,23 @@ public:
 						}
 					} else if (self->healthyZone.get().present()) {
 						// maintenance hits timeout
-						traceMaintenanceEnd(self, &tr, previousStartVersion, true);
+						TraceEvent("MaintenanceZoneEndTimeout", self->distributorId)
+						    .detail("Duration", maintenanceDurationSeconds(&tr, previousStartVersion));
 						self->healthyZone.set(Optional<Key>());
 					}
 				} else if (self->healthyZone.get().present()) {
 					// `healthyZone` has been cleared
-					traceMaintenanceEnd(self, &tr, previousStartVersion, false);
+					double duration = maintenanceDurationSeconds(&tr, previousStartVersion);
+					if (self->healthyZone.get().get() == ignoreSSFailuresZoneString) {
+						TraceEvent("DataDistributionDisabledForStorageServerFailuresEnd", self->distributorId)
+						    .detail("Duration", duration);
+					} else {
+						TraceEvent("MaintenanceZoneEndManualClear", self->distributorId).detail("Duration", duration);
+					}
 					self->healthyZone.set(Optional<Key>());
 				}
 
 				Future<Void> watchFuture = tr.watch(healthyZoneKey);
-				if (!self->primary) {
-					watchFuture = watchFuture || tr.watch(healthyZoneStartVersionKey);
-				}
 				co_await tr.commit();
 				maintenanceStart.committed();
 				counters->committed->increment(1);
@@ -6484,10 +6403,6 @@ Future<Void> DDTeamCollection::printSnapshotTeamsInfo(Reference<DDTeamCollection
 
 class DDTeamCollectionUnitTest {
 public:
-	static void setHealthyZoneForTest(DDTeamCollection* collection, Optional<Key> zone) {
-		collection->healthyZone.set(std::move(zone));
-	}
-
 	static void setTestEndpoint(StorageServerInterface& interface, int id) {
 		// These unit tests do not run storage server actors, but team tracking still logs each
 		// interface's address. Give every fixture interface a synthetic, unregistered endpoint.
@@ -7718,7 +7633,7 @@ TEST_CASE("/DataDistribution/TeamTracker/RechecksHealthyZone") {
 }
 
 TEST_CASE("/DataDistribution/Maintenance/FailedStartRetriesOriginalVersion") {
-	using State = MaintenanceStartVersionState;
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
 	const Optional<Key> zone(Key("zone-a"_sr));
 	State maintenanceState(Optional<Key>{});
 
@@ -7733,7 +7648,7 @@ TEST_CASE("/DataDistribution/Maintenance/FailedStartRetriesOriginalVersion") {
 }
 
 TEST_CASE("/DataDistribution/Maintenance/AmbiguousCommitPreservesDurableStart") {
-	using State = MaintenanceStartVersionState;
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
 	const Optional<Key> zone(Key("zone-a"_sr));
 	State maintenanceState(Optional<Key>{});
 
@@ -7744,7 +7659,7 @@ TEST_CASE("/DataDistribution/Maintenance/AmbiguousCommitPreservesDurableStart") 
 }
 
 TEST_CASE("/DataDistribution/Maintenance/ConcurrentWriterPreservesCommittedStart") {
-	using State = MaintenanceStartVersionState;
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
 	const Optional<Key> oldZone(Key("zone-a"_sr));
 	const Optional<Key> newZone(Key("zone-b"_sr));
 	State maintenanceState(oldZone);
@@ -7757,324 +7672,8 @@ TEST_CASE("/DataDistribution/Maintenance/ConcurrentWriterPreservesCommittedStart
 	return Void();
 }
 
-TEST_CASE("/DataDistribution/Maintenance/SupersededPrimaryCannotMutateMaintenanceStart") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> zone(Key("zone-a"_sr));
-	MoveKeysLock previousLock;
-	MoveKeysLock currentLock;
-	previousLock.myOwner = UID(1, 1);
-	currentLock.myOwner = UID(2, 2);
-	const Optional<Value> durableOwner(BinaryWriter::toValue(currentLock.myOwner, Unversioned()));
-	State currentPrimary(zone, true);
-	State previousPrimary(Optional<Key>{}, true);
-
-	ASSERT(currentPrimary.reconcile(zone, Optional<Version>(100), 150) == State::Action::Preserve);
-	ASSERT_EQ(currentPrimary.startVersion(), 100);
-	ASSERT(previousPrimary.reconcile(zone, Optional<Version>(100), 200) == State::Action::Record);
-	ASSERT_EQ(previousPrimary.startVersion(), 200);
-	ASSERT(ownsMaintenanceLock(currentLock, durableOwner));
-	ASSERT(!ownsMaintenanceLock(previousLock, durableOwner));
-	ASSERT(!ownsMaintenanceLock(currentLock, Optional<Value>{}));
-	ASSERT(previousPrimary.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Clear);
-	ASSERT(!ownsMaintenanceLock(previousLock, durableOwner));
-
-	const Optional<Key> disabledZone{ Key(ignoreSSFailuresZoneString) };
-	State supersededDisabledPrimary(disabledZone, true);
-	ASSERT(supersededDisabledPrimary.reconcile(disabledZone, Optional<Version>(100), 150) == State::Action::Preserve);
-	ASSERT_EQ(supersededDisabledPrimary.endingStartVersion(disabledZone, Optional<Version>(100)), 100);
-	ASSERT(supersededDisabledPrimary.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Clear);
-	ASSERT(!ownsMaintenanceLock(previousLock, durableOwner));
-	return Void();
-}
-
-TEST_CASE("/DataDistribution/Maintenance/WindowEndEventsPreserveDuration") {
-	auto collection = DDTeamCollectionUnitTest::testTeamCollection(1, makeReference<PolicyOne>(), 0);
-	ReadYourWritesTransaction tr(collection->dbContext());
-	tr.setVersion(SERVER_KNOBS->VERSIONS_PER_SECOND + 100);
-
-	int observedEvents[3] = {};
-	double observedDurations[3] = {};
-	bool malformedEvent = false;
-	ProcessEvents::Event capture({ "TraceEvent::DataDistributionDisabledForStorageServerFailuresEnd"_sr,
-	                               "TraceEvent::MaintenanceZoneEndManualClear"_sr,
-	                               "TraceEvent::MaintenanceZoneEndTimeout"_sr },
-	                             [&](StringRef name, std::any const& data, Error const&) noexcept {
-		                             auto* trace = std::any_cast<BaseTraceEvent*>(&data);
-		                             if (trace == nullptr || *trace == nullptr) {
-			                             malformedEvent = true;
-			                             return;
-		                             }
-
-		                             int index =
-		                                 name == "TraceEvent::DataDistributionDisabledForStorageServerFailuresEnd"_sr
-		                                     ? 0
-		                                 : name == "TraceEvent::MaintenanceZoneEndManualClear"_sr ? 1
-		                                                                                          : 2;
-		                             ++observedEvents[index];
-		                             bool foundDuration = false;
-		                             for (const auto& field : (*trace)->getFields()) {
-			                             if (field.first == "Duration") {
-				                             char* end = nullptr;
-				                             observedDurations[index] = std::strtod(field.second.c_str(), &end);
-				                             foundDuration = end != field.second.c_str() && *end == '\0';
-				                             break;
-			                             }
-		                             }
-		                             malformedEvent = malformedEvent || !foundDuration;
-	                             });
-
-	const bool previouslyTracingEvents = g_traceProcessEvents;
-	g_traceProcessEvents = true;
-	ScopeExit restoreTraceProcessEvents(
-	    [previouslyTracingEvents]() { g_traceProcessEvents = previouslyTracingEvents; });
-
-	DDTeamCollectionUnitTest::setHealthyZoneForTest(collection.get(), Key(ignoreSSFailuresZoneString));
-	DDTeamCollectionImpl::traceMaintenanceEnd(collection.get(), &tr, 100, false);
-	DDTeamCollectionUnitTest::setHealthyZoneForTest(collection.get(), Key("zone-a"_sr));
-	DDTeamCollectionImpl::traceMaintenanceEnd(collection.get(), &tr, 100, false);
-	DDTeamCollectionImpl::traceMaintenanceEnd(collection.get(), &tr, 100, true);
-
-	ASSERT(!malformedEvent);
-	for (int i = 0; i < 3; ++i) {
-		ASSERT_EQ(observedEvents[i], 1);
-		ASSERT_EQ(observedDurations[i], 1.0);
-	}
-	return Void();
-}
-
-TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionAdoptsCommittedStart") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> zone(Key("zone-a"_sr));
-	State primaryState(Optional<Key>{}, true);
-	State remoteState(Optional<Key>{}, false);
-
-	ASSERT(primaryState.reconcile(zone, Optional<Version>{}, 100) == State::Action::Record);
-	primaryState.committed();
-	ASSERT(remoteState.reconcile(zone, Optional<Version>(100), 200) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 100);
-	return Void();
-}
-
-TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionWaitsForPrimaryStart") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> zone(Key("zone-a"_sr));
-	State primaryState(Optional<Key>{}, true);
-	State remoteState(Optional<Key>{}, false);
-
-	ASSERT(remoteState.reconcile(zone, Optional<Version>{}, 100) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT(primaryState.reconcile(zone, Optional<Version>{}, 200) == State::Action::Record);
-	primaryState.committed();
-	ASSERT(remoteState.reconcile(zone, Optional<Version>(200), 300) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 200);
-	return Void();
-}
-
-TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionAdoptsReplacedStart") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> oldZone(Key("zone-a"_sr));
-	const Optional<Key> newZone(Key("zone-b"_sr));
-	State primaryState(oldZone, true);
-	State remoteState(oldZone, false);
-
-	ASSERT(remoteState.reconcile(oldZone, Optional<Version>(100), 200) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 100);
-	ASSERT(remoteState.reconcile(newZone, Optional<Version>(100), 250) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT(primaryState.reconcile(newZone, Optional<Version>(100), 300) == State::Action::Record);
-	primaryState.committed();
-	ASSERT(remoteState.reconcile(newZone, Optional<Version>(300), 400) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 300);
-	return Void();
-}
-
-TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionRejectsPreviousWindowStartOnReplacement") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> oldZone(Key("zone-a"_sr));
-	const Optional<Key> newZone(Key("zone-b"_sr));
-	const Optional<Key> thirdZone(Key("zone-c"_sr));
-	State remoteState(oldZone, false);
-
-	ASSERT(remoteState.reconcile(oldZone, Optional<Version>(100), 200) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 100);
-	ASSERT_EQ(remoteState.endingStartVersion(oldZone, Optional<Version>(300)), 100);
-	ASSERT(remoteState.reconcile(newZone, Optional<Version>(100), 250) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>(100)), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>{}), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(Optional<Key>{}, Optional<Version>(300)), invalidVersion);
-	ASSERT(remoteState.reconcile(newZone, Optional<Version>(100), 260) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT(remoteState.reconcile(newZone, Optional<Version>{}, 270) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT(remoteState.reconcile(newZone, Optional<Version>(100), 280) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>(300)), invalidVersion);
-	ASSERT(remoteState.reconcile(thirdZone, Optional<Version>(300), 350) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(thirdZone, Optional<Version>(300)), invalidVersion);
-	ASSERT(remoteState.reconcile(thirdZone, Optional<Version>(300), 360) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(thirdZone, Optional<Version>(400)), invalidVersion);
-	ASSERT(remoteState.reconcile(Optional<Key>{}, Optional<Version>(300), 450) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-
-	ASSERT(remoteState.reconcile(oldZone, Optional<Version>(500), 600) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 500);
-	ASSERT(remoteState.reconcile(newZone, Optional<Version>(700), 800) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>(700)), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>{}), invalidVersion);
-	ASSERT(remoteState.reconcile(newZone, Optional<Version>(700), 900) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT(remoteState.reconcile(newZone, Optional<Version>(750), 950) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 750);
-	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>(650)), 750);
-	ASSERT(remoteState.reconcile(oldZone, Optional<Version>(650), 1000) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(oldZone, Optional<Version>(650)), invalidVersion);
-	ASSERT(remoteState.reconcile(Optional<Key>{}, Optional<Version>(650), 1100) == State::Action::Preserve);
-	ASSERT(remoteState.reconcile(thirdZone, Optional<Version>(650), 1200) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(thirdZone, Optional<Version>(650)), invalidVersion);
-	ASSERT(remoteState.reconcile(thirdZone, Optional<Version>(900), 1250) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 900);
-
-	State unknownStart(oldZone, false);
-	ASSERT(unknownStart.reconcile(oldZone, Optional<Version>{}, 1300) == State::Action::Preserve);
-	ASSERT(unknownStart.reconcile(newZone, Optional<Version>(1400), 1500) == State::Action::Preserve);
-	ASSERT_EQ(unknownStart.startVersion(), invalidVersion);
-	ASSERT(unknownStart.reconcile(newZone, Optional<Version>(1400), 1600) == State::Action::Preserve);
-	ASSERT_EQ(unknownStart.startVersion(), invalidVersion);
-	ASSERT(unknownStart.reconcile(newZone, Optional<Version>(1700), 1800) == State::Action::Preserve);
-	ASSERT_EQ(unknownStart.startVersion(), 1700);
-	return Void();
-}
-
-TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionRejectsStaleStartAfterWindowClears") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> oldZone(Key("zone-a"_sr));
-	const Optional<Key> newZone(Key("zone-b"_sr));
-	const Optional<Key> thirdZone(Key("zone-c"_sr));
-	State restartedWindow(oldZone, false);
-
-	ASSERT(restartedWindow.reconcile(oldZone, Optional<Version>(100), 200) == State::Action::Preserve);
-	ASSERT_EQ(restartedWindow.endingStartVersion(oldZone, Optional<Version>(100)), 100);
-	ASSERT(restartedWindow.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Preserve);
-	ASSERT(restartedWindow.reconcile(Optional<Key>{}, Optional<Version>(100), 400) == State::Action::Preserve);
-	ASSERT(restartedWindow.reconcile(newZone, Optional<Version>(100), 500) == State::Action::Preserve);
-	ASSERT_EQ(restartedWindow.startVersion(), invalidVersion);
-	ASSERT_EQ(restartedWindow.endingStartVersion(newZone, Optional<Version>(100)), invalidVersion);
-	ASSERT_EQ(restartedWindow.endingStartVersion(newZone, Optional<Version>(600)), invalidVersion);
-	ASSERT(restartedWindow.reconcile(newZone, Optional<Version>(600), 700) == State::Action::Preserve);
-	ASSERT_EQ(restartedWindow.startVersion(), 600);
-
-	ASSERT_EQ(restartedWindow.endingStartVersion(newZone, Optional<Version>(800)), 600);
-	ASSERT(restartedWindow.reconcile(Optional<Key>{}, Optional<Version>(800), 900) == State::Action::Preserve);
-	ASSERT(restartedWindow.reconcile(thirdZone, Optional<Version>(800), 1000) == State::Action::Preserve);
-	ASSERT_EQ(restartedWindow.startVersion(), invalidVersion);
-	ASSERT_EQ(restartedWindow.endingStartVersion(thirdZone, Optional<Version>(800)), invalidVersion);
-	ASSERT(restartedWindow.reconcile(Optional<Key>{}, Optional<Version>{}, 1100) == State::Action::Preserve);
-	ASSERT(restartedWindow.reconcile(oldZone, Optional<Version>(800), 1200) == State::Action::Preserve);
-	ASSERT_EQ(restartedWindow.startVersion(), 800);
-	return Void();
-}
-
-TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionRejectsSkippedIntermediateWindowStart") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> oldZone(Key("zone-a"_sr));
-	const Optional<Key> latestZone(Key("zone-c"_sr));
-	State remoteState(oldZone, false);
-
-	ASSERT(remoteState.reconcile(oldZone, Optional<Version>(100), 200) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 100);
-	ASSERT(remoteState.reconcile(latestZone, Optional<Version>(300), 400) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(latestZone, Optional<Version>(300)), invalidVersion);
-	ASSERT(remoteState.reconcile(latestZone, Optional<Version>(300), 450) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(latestZone, Optional<Version>(500)), invalidVersion);
-	ASSERT(remoteState.reconcile(latestZone, Optional<Version>(500), 600) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 500);
-	return Void();
-}
-
-TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionRejectsUnattributedEndAfterReplacement") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> oldZone(Key("zone-a"_sr));
-	const Optional<Key> newZone(Key("zone-b"_sr));
-	State remoteState(oldZone, false);
-
-	ASSERT(remoteState.reconcile(oldZone, Optional<Version>(100), 200) == State::Action::Preserve);
-	ASSERT(remoteState.reconcile(newZone, Optional<Version>(100), 250) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>(300)), invalidVersion);
-	ASSERT(remoteState.reconcile(newZone, Optional<Version>(300), 350) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.endingStartVersion(newZone, Optional<Version>(300)), 300);
-	return Void();
-}
-
-TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionRejectsChangedStartForSameZone") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> zone(Key("zone-a"_sr));
-	State remoteState(zone, false);
-
-	ASSERT(remoteState.reconcile(zone, Optional<Version>(100), 200) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 100);
-	ASSERT(remoteState.reconcile(zone, Optional<Version>(300), 400) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(zone, Optional<Version>(300)), invalidVersion);
-	ASSERT(remoteState.reconcile(zone, Optional<Version>(300), 450) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT(remoteState.reconcile(zone, Optional<Version>(500), 600) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 500);
-	return Void();
-}
-
-TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionNeverClearsDurableStart") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> zone(Key("zone-a"_sr));
-	State remoteState(zone, false);
-
-	ASSERT(remoteState.reconcile(zone, Optional<Version>(100), 200) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), 100);
-	ASSERT(remoteState.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	return Void();
-}
-
-TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionRecoversDurableStartBeforeWindowEnds") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> zone(Key("zone-a"_sr));
-	State remoteState(Optional<Key>{}, false);
-
-	ASSERT(remoteState.reconcile(zone, Optional<Version>{}, 100) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(zone, Optional<Version>{}), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(Optional<Key>{}, Optional<Version>(200)), invalidVersion);
-	ASSERT_EQ(remoteState.endingStartVersion(zone, Optional<Version>(200)), 200);
-	ASSERT(remoteState.reconcile(Optional<Key>{}, Optional<Version>(200), 300) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.endingStartVersion(Optional<Key>{}, Optional<Version>(200)), invalidVersion);
-
-	ASSERT(remoteState.reconcile(zone, Optional<Version>(400), 500) == State::Action::Preserve);
-	ASSERT_EQ(remoteState.endingStartVersion(zone, Optional<Version>(200)), 400);
-	return Void();
-}
-
-TEST_CASE("/DataDistribution/Maintenance/PrimaryCollectionRecoversDurableStartAfterFailedEndRetry") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> zone(Key("zone-a"_sr));
-	State primaryState(zone, true);
-
-	ASSERT_EQ(primaryState.endingStartVersion(zone, Optional<Version>(100)), 100);
-	ASSERT(primaryState.reconcile(Optional<Key>{}, Optional<Version>(100), 200) == State::Action::Clear);
-	ASSERT_EQ(primaryState.startVersion(), invalidVersion);
-	ASSERT_EQ(primaryState.endingStartVersion(zone, Optional<Version>(100)), 100);
-	ASSERT(primaryState.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Clear);
-	return Void();
-}
-
 TEST_CASE("/DataDistribution/Maintenance/FailedClearRetriesWithoutLocalZone") {
-	using State = MaintenanceStartVersionState;
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
 	const Optional<Key> zone(Key("zone-a"_sr));
 	State maintenanceState(zone);
 
@@ -8086,18 +7685,8 @@ TEST_CASE("/DataDistribution/Maintenance/FailedClearRetriesWithoutLocalZone") {
 	return Void();
 }
 
-TEST_CASE("/DataDistribution/Maintenance/ExternallyClearedZoneRemovesStaleStart") {
-	using State = MaintenanceStartVersionState;
-	State maintenanceState(Optional<Key>{});
-
-	ASSERT(maintenanceState.reconcile(Optional<Key>{}, Optional<Version>(100), 200) == State::Action::Clear);
-	ASSERT(maintenanceState.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Clear);
-	ASSERT(maintenanceState.reconcile(Optional<Key>{}, Optional<Version>{}, 400) == State::Action::Preserve);
-	return Void();
-}
-
 TEST_CASE("/DataDistribution/Maintenance/ZoneChangeReplacesStaleStart") {
-	using State = MaintenanceStartVersionState;
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
 	const Optional<Key> oldZone(Key("zone-a"_sr));
 	const Optional<Key> newZone(Key("zone-b"_sr));
 	State maintenanceState(oldZone);
@@ -8112,36 +7701,18 @@ TEST_CASE("/DataDistribution/Maintenance/ZoneChangeReplacesStaleStart") {
 	return Void();
 }
 
-TEST_CASE("/DataDistribution/Maintenance/SameZoneRestartAfterFailedClear") {
-	using State = MaintenanceStartVersionState;
+TEST_CASE("/DataDistribution/Maintenance/RecruitmentPreservesOrRepairsStart") {
+	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
 	const Optional<Key> zone(Key("zone-a"_sr));
-	State maintenanceState(zone);
+	State adoptedStart(zone);
 
-	ASSERT(maintenanceState.reconcile(zone, Optional<Version>(100), 200) == State::Action::Preserve);
-	ASSERT(maintenanceState.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Clear);
-	ASSERT(maintenanceState.reconcile(zone, Optional<Version>(100), 400) == State::Action::Record);
-	ASSERT_EQ(maintenanceState.startVersion(), 400);
-	return Void();
-}
+	ASSERT(adoptedStart.reconcile(zone, Optional<Version>(100), 500) == State::Action::Preserve);
+	ASSERT_EQ(adoptedStart.startVersion(), 100);
 
-TEST_CASE("/DataDistribution/Maintenance/RecruitmentAdoptsDurableStart") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> zone(Key("zone-a"_sr));
-	State maintenanceState(zone);
-
-	ASSERT(maintenanceState.reconcile(zone, Optional<Version>(100), 500) == State::Action::Preserve);
-	ASSERT_EQ(maintenanceState.startVersion(), 100);
-	return Void();
-}
-
-TEST_CASE("/DataDistribution/Maintenance/RecruitmentRepairsMissingStart") {
-	using State = MaintenanceStartVersionState;
-	const Optional<Key> zone(Key("zone-a"_sr));
-	State maintenanceState(zone);
-
-	ASSERT(maintenanceState.reconcile(zone, Optional<Version>{}, 500) == State::Action::Record);
-	ASSERT_EQ(maintenanceState.startVersion(), 500);
-	ASSERT(maintenanceState.reconcile(zone, Optional<Version>{}, 600) == State::Action::Record);
-	ASSERT_EQ(maintenanceState.startVersion(), 500);
+	State repairedStart(zone);
+	ASSERT(repairedStart.reconcile(zone, Optional<Version>{}, 500) == State::Action::Record);
+	ASSERT_EQ(repairedStart.startVersion(), 500);
+	ASSERT(repairedStart.reconcile(zone, Optional<Version>{}, 600) == State::Action::Record);
+	ASSERT_EQ(repairedStart.startVersion(), 500);
 	return Void();
 }

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -48,6 +48,67 @@ auto get(MapContainer& m, K const& k) -> decltype(m.at(k)) {
 	return it->second;
 }
 
+class MaintenanceStartVersionState {
+public:
+	enum class Action { Preserve, Record, Clear };
+
+	explicit MaintenanceStartVersionState(Optional<Key> observedZone) : observedZone_(std::move(observedZone)) {}
+
+	Action reconcile(const Optional<Key>& zone, const Optional<Version>& durableStart, Version readVersion) {
+		if (zone != observedZone_) {
+			observedZone_ = zone;
+			startVersion_ = invalidVersion;
+			pendingRecord_ = false;
+			if (zone.present()) {
+				startVersion_ = readVersion;
+				originalDurableStart_ = durableStart;
+				pendingRecord_ = true;
+				return Action::Record;
+			}
+		}
+
+		if (!zone.present()) {
+			startVersion_ = invalidVersion;
+			pendingRecord_ = false;
+			return durableStart.present() ? Action::Clear : Action::Preserve;
+		}
+
+		if (pendingRecord_) {
+			if (durableStart.present() && durableStart.get() == startVersion_) {
+				pendingRecord_ = false;
+				return Action::Preserve;
+			}
+
+			// A different newly durable value belongs to the DD collection that won the transaction conflict.
+			if (durableStart.present() && durableStart != originalDurableStart_) {
+				startVersion_ = durableStart.get();
+				pendingRecord_ = false;
+				return Action::Preserve;
+			}
+			return Action::Record;
+		}
+
+		if (durableStart.present()) {
+			startVersion_ = durableStart.get();
+			return Action::Preserve;
+		}
+
+		startVersion_ = readVersion;
+		originalDurableStart_ = durableStart;
+		pendingRecord_ = true;
+		return Action::Record;
+	}
+
+	void committed() { pendingRecord_ = false; }
+	Version startVersion() const { return startVersion_; }
+
+private:
+	Optional<Key> observedZone_;
+	Optional<Version> originalDurableStart_;
+	Version startVersion_ = invalidVersion;
+	bool pendingRecord_ = false;
+};
+
 } // namespace
 
 namespace data_distribution {
@@ -2649,67 +2710,6 @@ public:
 			}
 		}
 	}
-
-	class MaintenanceStartVersionState {
-	public:
-		enum class Action { Preserve, Record, Clear };
-
-		explicit MaintenanceStartVersionState(Optional<Key> observedZone) : observedZone_(std::move(observedZone)) {}
-
-		Action reconcile(const Optional<Key>& zone, const Optional<Version>& durableStart, Version readVersion) {
-			if (zone != observedZone_) {
-				observedZone_ = zone;
-				startVersion_ = invalidVersion;
-				pendingRecord_ = false;
-				if (zone.present()) {
-					startVersion_ = readVersion;
-					originalDurableStart_ = durableStart;
-					pendingRecord_ = true;
-					return Action::Record;
-				}
-			}
-
-			if (!zone.present()) {
-				startVersion_ = invalidVersion;
-				pendingRecord_ = false;
-				return durableStart.present() ? Action::Clear : Action::Preserve;
-			}
-
-			if (pendingRecord_) {
-				if (durableStart.present() && durableStart.get() == startVersion_) {
-					pendingRecord_ = false;
-					return Action::Preserve;
-				}
-
-				// A different newly durable value belongs to the DD collection that won the transaction conflict.
-				if (durableStart.present() && durableStart != originalDurableStart_) {
-					startVersion_ = durableStart.get();
-					pendingRecord_ = false;
-					return Action::Preserve;
-				}
-				return Action::Record;
-			}
-
-			if (durableStart.present()) {
-				startVersion_ = durableStart.get();
-				return Action::Preserve;
-			}
-
-			startVersion_ = readVersion;
-			originalDurableStart_ = durableStart;
-			pendingRecord_ = true;
-			return Action::Record;
-		}
-
-		void committed() { pendingRecord_ = false; }
-		Version startVersion() const { return startVersion_; }
-
-	private:
-		Optional<Key> observedZone_;
-		Optional<Version> originalDurableStart_;
-		Version startVersion_ = invalidVersion;
-		bool pendingRecord_ = false;
-	};
 
 	static void recordMaintenanceStart(ReadYourWritesTransaction* tr, Version version) {
 		BinaryWriter bw(Unversioned());
@@ -7633,7 +7633,7 @@ TEST_CASE("/DataDistribution/TeamTracker/RechecksHealthyZone") {
 }
 
 TEST_CASE("/DataDistribution/Maintenance/FailedStartRetriesOriginalVersion") {
-	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	using State = MaintenanceStartVersionState;
 	const Optional<Key> zone(Key("zone-a"_sr));
 	State maintenanceState(Optional<Key>{});
 
@@ -7648,7 +7648,7 @@ TEST_CASE("/DataDistribution/Maintenance/FailedStartRetriesOriginalVersion") {
 }
 
 TEST_CASE("/DataDistribution/Maintenance/AmbiguousCommitPreservesDurableStart") {
-	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	using State = MaintenanceStartVersionState;
 	const Optional<Key> zone(Key("zone-a"_sr));
 	State maintenanceState(Optional<Key>{});
 
@@ -7659,7 +7659,7 @@ TEST_CASE("/DataDistribution/Maintenance/AmbiguousCommitPreservesDurableStart") 
 }
 
 TEST_CASE("/DataDistribution/Maintenance/ConcurrentWriterPreservesCommittedStart") {
-	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	using State = MaintenanceStartVersionState;
 	const Optional<Key> oldZone(Key("zone-a"_sr));
 	const Optional<Key> newZone(Key("zone-b"_sr));
 	State maintenanceState(oldZone);
@@ -7673,7 +7673,7 @@ TEST_CASE("/DataDistribution/Maintenance/ConcurrentWriterPreservesCommittedStart
 }
 
 TEST_CASE("/DataDistribution/Maintenance/FailedClearRetriesWithoutLocalZone") {
-	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	using State = MaintenanceStartVersionState;
 	const Optional<Key> zone(Key("zone-a"_sr));
 	State maintenanceState(zone);
 
@@ -7686,7 +7686,7 @@ TEST_CASE("/DataDistribution/Maintenance/FailedClearRetriesWithoutLocalZone") {
 }
 
 TEST_CASE("/DataDistribution/Maintenance/ExternallyClearedZoneRemovesStaleStart") {
-	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	using State = MaintenanceStartVersionState;
 	State maintenanceState(Optional<Key>{});
 
 	ASSERT(maintenanceState.reconcile(Optional<Key>{}, Optional<Version>(100), 200) == State::Action::Clear);
@@ -7696,7 +7696,7 @@ TEST_CASE("/DataDistribution/Maintenance/ExternallyClearedZoneRemovesStaleStart"
 }
 
 TEST_CASE("/DataDistribution/Maintenance/ZoneChangeReplacesStaleStart") {
-	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	using State = MaintenanceStartVersionState;
 	const Optional<Key> oldZone(Key("zone-a"_sr));
 	const Optional<Key> newZone(Key("zone-b"_sr));
 	State maintenanceState(oldZone);
@@ -7712,7 +7712,7 @@ TEST_CASE("/DataDistribution/Maintenance/ZoneChangeReplacesStaleStart") {
 }
 
 TEST_CASE("/DataDistribution/Maintenance/SameZoneRestartAfterFailedClear") {
-	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	using State = MaintenanceStartVersionState;
 	const Optional<Key> zone(Key("zone-a"_sr));
 	State maintenanceState(zone);
 
@@ -7724,7 +7724,7 @@ TEST_CASE("/DataDistribution/Maintenance/SameZoneRestartAfterFailedClear") {
 }
 
 TEST_CASE("/DataDistribution/Maintenance/RecruitmentAdoptsDurableStart") {
-	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	using State = MaintenanceStartVersionState;
 	const Optional<Key> zone(Key("zone-a"_sr));
 	State maintenanceState(zone);
 
@@ -7734,7 +7734,7 @@ TEST_CASE("/DataDistribution/Maintenance/RecruitmentAdoptsDurableStart") {
 }
 
 TEST_CASE("/DataDistribution/Maintenance/RecruitmentRepairsMissingStart") {
-	using State = DDTeamCollectionImpl::MaintenanceStartVersionState;
+	using State = MaintenanceStartVersionState;
 	const Optional<Key> zone(Key("zone-a"_sr));
 	State maintenanceState(zone);
 

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -48,6 +48,15 @@ auto get(MapContainer& m, K const& k) -> decltype(m.at(k)) {
 	return it->second;
 }
 
+bool ownsMaintenanceLock(const MoveKeysLock& lock, const Optional<Value>& durableOwner) {
+	return durableOwner.present() &&
+	       BinaryReader::fromStringRef<UID>(durableOwner.get(), Unversioned()) == lock.myOwner;
+}
+
+} // namespace
+
+namespace data_distribution {
+
 class MaintenanceStartVersionState {
 public:
 	enum class Action { Preserve, Record, Clear };
@@ -108,6 +117,12 @@ public:
 
 	void committed() { pendingRecord_ = false; }
 	Version startVersion() const { return startVersion_; }
+	Version endingStartVersion(const Optional<Key>& localZone, const Optional<Version>& durableStart) const {
+		if (startVersion_ != invalidVersion || !localZone.present() || !durableStart.present()) {
+			return startVersion_;
+		}
+		return durableStart.get();
+	}
 
 private:
 	const bool primary_;
@@ -117,14 +132,6 @@ private:
 	bool pendingRecord_ = false;
 };
 
-bool ownsMaintenanceLock(const MoveKeysLock& lock, const Optional<Value>& durableOwner) {
-	return durableOwner.present() &&
-	       BinaryReader::fromStringRef<UID>(durableOwner.get(), Unversioned()) == lock.myOwner;
-}
-
-} // namespace
-
-namespace data_distribution {
 int EligibilityCounter::fromGetTeamRequest(GetTeamRequest const& req) {
 	// equivalent to bit set operation
 	return req.preferLowerDiskUtil * EligibilityCounter::LOW_DISK_UTIL +
@@ -152,6 +159,8 @@ int EligibilityCounter::getCount(int combinedType) const {
 }
 
 } // namespace data_distribution
+
+using data_distribution::MaintenanceStartVersionState;
 
 static TxnCounters* updateNextWigglingStorageIDCounters() {
 	static auto* c = makeCounters("/dd/updateNextWigglingStorageID");
@@ -2766,7 +2775,8 @@ public:
 					}
 				}
 
-				Version previousStartVersion = maintenanceStart.startVersion();
+				Version previousStartVersion =
+				    maintenanceStart.endingStartVersion(self->healthyZone.get(), durableStart);
 				auto action = maintenanceStart.reconcile(activeZone, durableStart, tr.getReadVersion().get());
 				if (action != MaintenanceStartVersionState::Action::Preserve) {
 					Optional<Value> durableOwner = co_await tr.get(moveKeysLockOwnerKey);
@@ -7773,6 +7783,37 @@ TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionNeverClearsDurableStart
 	ASSERT_EQ(remoteState.startVersion(), 100);
 	ASSERT(remoteState.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Preserve);
 	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/RemoteCollectionRecoversDurableStartBeforeWindowEnds") {
+	using State = MaintenanceStartVersionState;
+	const Optional<Key> zone(Key("zone-a"_sr));
+	State remoteState(Optional<Key>{}, false);
+
+	ASSERT(remoteState.reconcile(zone, Optional<Version>{}, 100) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.startVersion(), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(zone, Optional<Version>{}), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(Optional<Key>{}, Optional<Version>(200)), invalidVersion);
+	ASSERT_EQ(remoteState.endingStartVersion(zone, Optional<Version>(200)), 200);
+	ASSERT(remoteState.reconcile(Optional<Key>{}, Optional<Version>(200), 300) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.endingStartVersion(Optional<Key>{}, Optional<Version>(200)), invalidVersion);
+
+	ASSERT(remoteState.reconcile(zone, Optional<Version>(400), 500) == State::Action::Preserve);
+	ASSERT_EQ(remoteState.endingStartVersion(zone, Optional<Version>(200)), 400);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/PrimaryCollectionRecoversDurableStartAfterFailedEndRetry") {
+	using State = MaintenanceStartVersionState;
+	const Optional<Key> zone(Key("zone-a"_sr));
+	State primaryState(zone, true);
+
+	ASSERT_EQ(primaryState.endingStartVersion(zone, Optional<Version>(100)), 100);
+	ASSERT(primaryState.reconcile(Optional<Key>{}, Optional<Version>(100), 200) == State::Action::Clear);
+	ASSERT_EQ(primaryState.startVersion(), invalidVersion);
+	ASSERT_EQ(primaryState.endingStartVersion(zone, Optional<Version>(100)), 100);
+	ASSERT(primaryState.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Clear);
 	return Void();
 }
 

--- a/fdbserver/datadistributor/DDTeamCollection.actor.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.actor.cpp
@@ -117,6 +117,11 @@ private:
 	bool pendingRecord_ = false;
 };
 
+bool ownsMaintenanceLock(const MoveKeysLock& lock, const Optional<Value>& durableOwner) {
+	return durableOwner.present() &&
+	       BinaryReader::fromStringRef<UID>(durableOwner.get(), Unversioned()) == lock.myOwner;
+}
+
 } // namespace
 
 namespace data_distribution {
@@ -2763,10 +2768,17 @@ public:
 
 				Version previousStartVersion = maintenanceStart.startVersion();
 				auto action = maintenanceStart.reconcile(activeZone, durableStart, tr.getReadVersion().get());
-				if (action == MaintenanceStartVersionState::Action::Record) {
-					recordMaintenanceStart(&tr, maintenanceStart.startVersion());
-				} else if (action == MaintenanceStartVersionState::Action::Clear) {
-					tr.clear(healthyZoneStartVersionKey);
+				if (action != MaintenanceStartVersionState::Action::Preserve) {
+					Optional<Value> durableOwner = co_await tr.get(moveKeysLockOwnerKey);
+					if (!ownsMaintenanceLock(self->lock, durableOwner)) {
+						throw movekeys_conflict();
+					}
+					if (action == MaintenanceStartVersionState::Action::Record) {
+						recordMaintenanceStart(&tr, maintenanceStart.startVersion());
+					} else {
+						ASSERT(action == MaintenanceStartVersionState::Action::Clear);
+						tr.clear(healthyZoneStartVersionKey);
+					}
 				}
 
 				Future<Void> healthyZoneTimeout = Never();
@@ -7680,6 +7692,29 @@ TEST_CASE("/DataDistribution/Maintenance/ConcurrentWriterPreservesCommittedStart
 	ASSERT_EQ(maintenanceState.startVersion(), 100);
 	ASSERT(maintenanceState.reconcile(newZone, Optional<Version>(125), 300) == State::Action::Preserve);
 	ASSERT_EQ(maintenanceState.startVersion(), 125);
+	return Void();
+}
+
+TEST_CASE("/DataDistribution/Maintenance/SupersededPrimaryCannotMutateMaintenanceStart") {
+	using State = MaintenanceStartVersionState;
+	const Optional<Key> zone(Key("zone-a"_sr));
+	MoveKeysLock previousLock;
+	MoveKeysLock currentLock;
+	previousLock.myOwner = UID(1, 1);
+	currentLock.myOwner = UID(2, 2);
+	const Optional<Value> durableOwner(BinaryWriter::toValue(currentLock.myOwner, Unversioned()));
+	State currentPrimary(zone, true);
+	State previousPrimary(Optional<Key>{}, true);
+
+	ASSERT(currentPrimary.reconcile(zone, Optional<Version>(100), 150) == State::Action::Preserve);
+	ASSERT_EQ(currentPrimary.startVersion(), 100);
+	ASSERT(previousPrimary.reconcile(zone, Optional<Version>(100), 200) == State::Action::Record);
+	ASSERT_EQ(previousPrimary.startVersion(), 200);
+	ASSERT(ownsMaintenanceLock(currentLock, durableOwner));
+	ASSERT(!ownsMaintenanceLock(previousLock, durableOwner));
+	ASSERT(!ownsMaintenanceLock(currentLock, Optional<Value>{}));
+	ASSERT(previousPrimary.reconcile(Optional<Key>{}, Optional<Version>(100), 300) == State::Action::Clear);
+	ASSERT(!ownsMaintenanceLock(previousLock, durableOwner));
 	return Void();
 }
 


### PR DESCRIPTION
## Summary

- Preserve the first observed maintenance-window start version when a transaction must be retried.
- Adopt an already committed start after ambiguous commits, concurrent writers, or data-distributor recruitment.
- Retry stale-start cleanup when maintenance ends while preserving the existing maintenance tracing and durable storage format.
- Cover failed starts, ambiguous commits, competing writers, failed clears, changed maintenance zones, and recruitment with six focused regression tests.

## Testing

- GCC 13, `-DUSE_WERROR=ON -DWITH_ROCKSDB=OFF`: `fdbserver_datadistributor_test -f /DataDistribution/Maintenance/` - 6 passed, 0 failed.
- GCC 13, `-DUSE_WERROR=ON -DWITH_ROCKSDB=OFF`: `fdbserver_datadistributor_test` - 56 passed, 0 failed.
- `clang-format` 19 and `git diff --check` passed.
