### PR TITLE
Bound the post-move destination metrics refresh in DD

### DIFF
--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -2345,9 +2345,30 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 			    error.code() != error_code_start_move_keys_too_many_retries) {
 				if (!error.code()) {
 					try {
-						co_await healthyDestinations
-						    .updateStorageMetrics(); // prevent a gap between the polling for an increase in
-						                             // storage metrics and decrementing data in flight
+						// Prevent a gap between the polling for an increase in storage metrics and
+						// decrementing data in flight: until that increase is observed the destination looks
+						// emptier than it is and can attract further moves.
+						//
+						// The refresh is bounded because updateServerMetrics() returns only once the server
+						// replies or leaves the team, and completing this relocation must not depend on
+						// either. Losing it only widens that gap to one STORAGE_METRICS_POLLING_DELAY; the
+						// decrement below is derived from the shard's own metrics and is exact regardless.
+						Optional<Void> refreshed = co_await timeout(healthyDestinations.updateStorageMetrics(),
+						                                            SERVER_KNOBS->DD_SHARD_METRICS_TIMEOUT,
+						                                            TaskPriority::DataDistributionLaunch);
+						if (!refreshed.present()) {
+							CODE_PROBE(true,
+							           "Destination metrics refresh timed out after a data move",
+							           probe::decoration::rare);
+							TraceEvent(SevWarn, "RelocateShardDestMetricsTimeout", distributorId)
+							    .suppressFor(5.0)
+							    .detail("TraceID", rd.randomId)
+							    .detail("Range", rd.keys)
+							    .detail("DataMoveID", rd.dataMoveId)
+							    .detail("Priority", rd.priority)
+							    .detail("Dest", describe(destIds))
+							    .detail("Timeout", SERVER_KNOBS->DD_SHARD_METRICS_TIMEOUT);
+						}
 					} catch (Error& e) {
 						error = e;
 					}


### PR DESCRIPTION
After a data move completes, dataDistributionRelocator awaited healthyDestinations.updateStorageMetrics() before decrementing data-in-flight. That await has no bound. It fans out through waitForAll twice -- over every destination team, then over every server in each team -- and the per-server TCServerInfo::updateServerMetrics loop only exits on a successful reply or on the server being removed from the team. A destination storage server that stops answering and is not yet removed therefore strands the relocator there indefinitely, and it logs nothing while doing so.

The consequences compound. The shard stays counted in flight and relocationComplete is never sent, so activeRelocations never drops. Any queued relocation overlapping that range is then skipped by design in launchQueuedWork, because the overlap check requires a live in-flight actor. With the relocation pipeline already at its cap, the admission gate stays shut, so no new relocation arrives to trigger the queue launcher either. Data distribution stops making progress entirely while appearing idle.

Bounding the refresh is safe because it was never load-bearing: it exists to narrow the window between observing the destination's storage growth and decrementing data-in-flight. The decrement itself is symmetric and derived from the shard's own metrics, not the servers', and serverMetricsPolling refreshes server metrics independently every STORAGE_METRICS_POLLING_DELAY. Skipping the early refresh costs at most one polling interval of staleness, during which a destination looks slightly emptier than it is.

For a server too slow to answer within the timeout the previous behaviour was strictly worse: serverMetricsPolling is stuck on the same request, so the metrics were already stale. Waiting did not obtain fresh data, it only withheld progress.

Reuses DD_SHARD_METRICS_TIMEOUT rather than adding a knob; it already covers DD metrics requests that must not hang, and DDShardTracker wraps its metric fetches the same way.

Expiry gets its own CODE_PROBE rather than reusing DDShardTracker's, which names a different path -- the tracker serving a metrics request, not the relocator refreshing destination server metrics. It is marked rare because nothing injects a timeout on this path. The trace event is SevWarn and suppressed: the knob buggifies to 0.1s while a failed per-server reply already costs METRIC_DELAY before retrying, so expiry is not exceptional under simulation, and this sits on the completion path of every data move. The three sibling DD_SHARD_METRICS_TIMEOUT sites in DDShardTracker log nothing at all on expiry for that reason; this one logs, but cheaply, and carries rd.randomId so it can be joined to the RelocateShard interval even when SHARD_ENCODE_LOCATION_METADATA leaves DataMoveID anonymous.

Diagnosed from tests/fast/DDPipelineSaturation.toml at seed 1228554846, where DD sat at InFlight=1 InQueue=21 PipelineSize=22 unchanged for over 16000 simulated seconds until the run died on TracedTooManyLines.

 This seed, 1781424174, also failed in nightlies.

`  20260813-171501-stack_metrics-3328bacfa60f8d05     compressed=True data_size=41720572 duration=2672692 ended=100000 fail=2 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=1:40:45 sanity=False started=100000 stopped=20260813-185546 submitted=20260813-171501 timeout=5400 username=stack_metrics`

Two failures are:

`RandomSeed="2127052354" SourceVersion="37fcf1c8ce087131db6edadb0dae307258ca4254" Time="1786644000" BuggifyEnabled="1" DeterminismCheck="0" OldBinary="fdbserver-7.3.69" FaultInjectionEnabled="1" TestFile="tests/restarting/from_7.3.29/ClientTransactionProfilingCorrectness-1.toml"`

and

`RandomSeed="4207856505" SourceVersion="24f6a3f1e868952e7cde986ff2611fed033ceede" Time="1786645977" BuggifyEnabled="1" DeterminismCheck="0" FaultInjectionEnabled="1" TestFile="tests/fast/MutationLogReaderCorrectness.toml"`