### PR TITLE
BulkLoad: only require file containment for the range this fetchKeys owns

### DIFF
--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -1661,7 +1661,11 @@ Future<Void> dataDistributionRelocator(DDQueue* self,
 						// rd with bulkLoadTask set.
 						// TODO(BulkLoad): reset rd.bulkLoadTask here for the risk of overloading the source
 						// servers.
-						TraceEvent(SevWarn, "DDBulkLoadTaskFallbackToNormalDataMove", self->distributorId)
+						//
+						// An expected race, not a bulkload failure: rd's task snapshot was Triggered/Running, but
+						// the persisted phase has moved on since -- usually to Complete. An ordinary move is then
+						// the correct outcome and loses no bulkload work.
+						TraceEvent(SevInfo, "DDBulkLoadTaskFallbackToNormalDataMove", self->distributorId)
 						    .detail("TrackID", rd.randomId)
 						    .detail("DataMovePriority", rd.priority)
 						    .detail("JobID", rd.bulkLoadTask.get().coreState.getJobId())

--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -6838,6 +6838,107 @@ static Future<Void> processSampleFiles(StorageServer* data,
 	} // end file iteration loop
 }
 
+// Filter the whole task's file set down to what this fetchKeys owns. The set spans the task, while `keys` is a
+// single destination shard piece, so files outside `keys` are routine rather than a fault. A straddling file is
+// still returned -- it holds keys this fetch owns and only the KV-replay path can clip it to `keys` -- but it
+// clears *allOwnedContained, disqualifying the fetch from whole-file ingest.
+static BulkLoadFileSetKeyMap selectOwnedBulkLoadFileSets(const BulkLoadFileSetKeyMap& taskFileSets,
+                                                         KeyRangeRef keys,
+                                                         bool* allOwnedContained,
+                                                         KeyRange* firstUncontained) {
+	ASSERT(allOwnedContained != nullptr);
+	BulkLoadFileSetKeyMap owned;
+	*allOwnedContained = true;
+	for (const auto& fileSetPair : taskFileSets) {
+		if (!keys.intersects(fileSetPair.first)) {
+			continue;
+		}
+		if (!keys.contains(fileSetPair.first)) {
+			if (*allOwnedContained && firstUncontained != nullptr) {
+				*firstUncontained = fileSetPair.first;
+			}
+			*allOwnedContained = false;
+		}
+		owned.push_back(fileSetPair);
+	}
+	return owned;
+}
+
+TEST_CASE("/fdbserver/storageserver/selectOwnedBulkLoadFileSets") {
+	auto entry = [](StringRef begin, StringRef end) {
+		return std::make_pair(KeyRange(KeyRangeRef(begin, end)), BulkLoadFileSet());
+	};
+	bool allContained = false;
+	KeyRange uncontained;
+
+	// Fetch owns the whole task.
+	{
+		BulkLoadFileSetKeyMap task{ entry("a"_sr, "c"_sr), entry("c"_sr, "e"_sr) };
+		auto owned = selectOwnedBulkLoadFileSets(task, KeyRangeRef("a"_sr, "e"_sr), &allContained, &uncontained);
+		ASSERT_EQ(owned.size(), 2);
+		ASSERT(allContained);
+	}
+
+	// Disjoint ("e"-"g") and adjacent ("c"-"e") files are dropped without disqualifying the fetch.
+	{
+		BulkLoadFileSetKeyMap task{ entry("a"_sr, "c"_sr), entry("c"_sr, "e"_sr), entry("e"_sr, "g"_sr) };
+		auto owned = selectOwnedBulkLoadFileSets(task, KeyRangeRef("a"_sr, "c"_sr), &allContained, &uncontained);
+		ASSERT_EQ(owned.size(), 1);
+		ASSERT(owned[0].first == KeyRangeRef("a"_sr, "c"_sr));
+		ASSERT(allContained);
+	}
+
+	// A straddling file is retained, but disqualifies the fetch.
+	{
+		BulkLoadFileSetKeyMap task{ entry("a"_sr, "d"_sr) };
+		auto owned = selectOwnedBulkLoadFileSets(task, KeyRangeRef("a"_sr, "c"_sr), &allContained, &uncontained);
+		ASSERT_EQ(owned.size(), 1);
+		ASSERT(!allContained);
+		ASSERT(uncontained == KeyRangeRef("a"_sr, "d"_sr));
+	}
+
+	// As does one spanning it.
+	{
+		BulkLoadFileSetKeyMap task{ entry("a"_sr, "z"_sr) };
+		auto owned = selectOwnedBulkLoadFileSets(task, KeyRangeRef("c"_sr, "e"_sr), &allContained, &uncontained);
+		ASSERT_EQ(owned.size(), 1);
+		ASSERT(!allContained);
+	}
+
+	// Empty task file set is vacuously contained.
+	{
+		BulkLoadFileSetKeyMap task;
+		auto owned = selectOwnedBulkLoadFileSets(task, KeyRangeRef("a"_sr, "z"_sr), &allContained, &uncontained);
+		ASSERT_EQ(owned.size(), 0);
+		ASSERT(allContained);
+	}
+
+	// Across pieces partitioning the task range, every file must be claimed exactly once: zero loses it, twice
+	// ingests the same keys under two shards.
+	{
+		BulkLoadFileSetKeyMap task{
+			entry("a"_sr, "c"_sr), entry("c"_sr, "e"_sr), entry("e"_sr, "g"_sr), entry("g"_sr, "i"_sr)
+		};
+		const std::vector<KeyRangeRef> pieces{ KeyRangeRef("a"_sr, "c"_sr),
+			                                   KeyRangeRef("c"_sr, "g"_sr),
+			                                   KeyRangeRef("g"_sr, "i"_sr) };
+		std::map<std::string, int> owners;
+		for (const auto& piece : pieces) {
+			bool contained = false;
+			for (const auto& ownedPair : selectOwnedBulkLoadFileSets(task, piece, &contained, nullptr)) {
+				owners[ownedPair.first.begin.toString()]++;
+			}
+			ASSERT(contained); // the partition is manifest-aligned, so nothing straddles
+		}
+		ASSERT_EQ(owners.size(), task.size());
+		for (const auto& ownerPair : owners) {
+			ASSERT_EQ(ownerPair.second, 1);
+		}
+	}
+
+	return Void();
+}
+
 Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 	const UID fetchKeysID = deterministicRandom()->randomUniqueID();
 	TraceInterval interval("FetchKeys");
@@ -7122,19 +7223,21 @@ Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 				    .detail("Phase", "File download")
 				    .detail("FKID", fetchKeysID);
 				// Do SST ingestion if (1) the knob is enabled, (2) the storage engine supports SST ingestion, and
-				// (3) the task range is aligned with manifests' range, and (4) all file ranges fit within shard.
-				// Check (4) is needed because shard boundaries may differ between backup and restore time.
+				// (3) the task range is aligned with manifests' range, and (4) every file this fetch owns fits
+				// within the shard. Check (4) is needed because shard boundaries may differ between backup and
+				// restore time.
 				bool allFilesContained = true;
-				for (const auto& [range, fileSet] : *localBulkLoadFileSets) {
-					if (!keys.contains(range)) {
-						allFilesContained = false;
-						TraceEvent(SevInfo, "SSBulkLoadFileRangeMismatch", data->thisServerID)
-						    .detail("ShardRange", keys)
-						    .detail("FileRange", range)
-						    .detail("DataMoveId", dataMoveId.toString())
-						    .detail("FKID", fetchKeysID);
-						break;
-					}
+				KeyRange firstUncontainedFileRange;
+				auto ownedBulkLoadFileSets = std::make_shared<BulkLoadFileSetKeyMap>(selectOwnedBulkLoadFileSets(
+				    *localBulkLoadFileSets, keys, &allFilesContained, &firstUncontainedFileRange));
+				if (!allFilesContained) {
+					TraceEvent(SevInfo, "SSBulkLoadFileRangeMismatch", data->thisServerID)
+					    .detail("ShardRange", keys)
+					    .detail("FileRange", firstUncontainedFileRange)
+					    .detail("OwnedFileCount", ownedBulkLoadFileSets->size())
+					    .detail("TaskFileCount", localBulkLoadFileSets->size())
+					    .detail("DataMoveId", dataMoveId.toString())
+					    .detail("FKID", fetchKeysID);
 				}
 				if (SERVER_KNOBS->BULK_LOAD_USE_SST_INGEST &&
 				    data->storage.getKeyValueStore()->supportsSstIngestion() && bulkloadCanIngestSSTFile &&
@@ -7157,7 +7260,7 @@ Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 					// Ingest the SST files.
 					// Measure duration at this level so we capture the inter-thread handoff time.
 					double ingestStartTime = g_network->timer(); // Record start time
-					co_await data->storage.getKeyValueStore()->ingestSSTFiles(localBulkLoadFileSets);
+					co_await data->storage.getKeyValueStore()->ingestSSTFiles(ownedBulkLoadFileSets);
 					const double ingestDuration = g_network->timer() - ingestStartTime;
 					data->counters.ingestDurationLatencySample->addMeasurement(ingestDuration);
 
@@ -7165,7 +7268,7 @@ Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 					co_await data->storage.getKeyValueStore()->compactRange(keys);
 
 					// Process sample files after SST ingestion
-					co_await processSampleFiles(data, keys, bulkLoadLocalDir, localBulkLoadFileSets);
+					co_await processSampleFiles(data, keys, bulkLoadLocalDir, ownedBulkLoadFileSets);
 
 					// NOTICE: We break the 'fetchKeys' loop here if we successfully ingest the SST files.
 					// EARLY EXIT FROM 'fetchKeys' LOOP!!!
@@ -7184,7 +7287,7 @@ Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 						    .detail("AllFilesContained", allFilesContained)
 						    .detail("FKID", fetchKeysID);
 					}
-					hold = tryGetRangeForBulkLoad(results, keys, localBulkLoadFileSets);
+					hold = tryGetRangeForBulkLoad(results, keys, ownedBulkLoadFileSets);
 					rangeEnd = keys.end;
 				}
 			} else {


### PR DESCRIPTION
A bulkload fetchKeys was rejecting the SST ingest fast path whenever any file in its task set fell outside the range being fetched, and falling back to key-value replay for the whole batch causing bulkload to take longer.

The mismatch is structural, not a fault: two different range granularities meet in fetchKeys. bulkLoadFetchKeyValueFileToLoad builds localBulkLoadFileSets from the whole *task*, while `keys` is one destination shard piece. startMoveShards cuts the destination at pre-existing keyServers boundaries, so a task spanning several of them becomes several fetches -- and every one of those fetches is handed the task's entire file set, most of which belongs to the other pieces.

Classifying all 3,428 mismatches on a 1B-key restore by how the offending file sits against the range being fetched:

    87.0%  no overlap       54.9% disjoint, 32.1% touching a boundary only
    13.0%  partial overlap  10.3% straddling an edge, 2.7% spanning it

The 87% are not this fetch's files at all, so it can drop them and still ingest. Only the 13% are real conflicts -- ingesting those would write outside the range -- and they must still force the fallback.

The all-or-nothing check was a deliberate guard, not an oversight: ingestSSTFiles was unfiltered, so ingesting a set containing unowned files would have written keys outside the shard. Fix the guard rather than remove it -- selectOwnedBulkLoadFileSets() keeps only the file sets whose range this fetch owns, and the fast path is then taken for those. Files that straddle or span a boundary still force the fallback, because ingesting them would write outside the range.

selectOwnedBulkLoadFileSets() is pure and unit tested, including the exactly-once invariant: every file set must be claimed by exactly one fetch across the task's pieces, since dropping one silently loses data and duplicating one ingests the same keys twice. The test was confirmed red against the old behaviour (3 == 1).

Measured effect on SSBulkLoadFileRangeMismatch at 100M scale: 342 before, then 85 and 199 in two later runs whose bulkload path was byte-identical. So the direction is established but the magnitude is not -- that counter has at least 2.3x run-to-run spread, driven by shard geometry rather than by this code.

Also demote DDBulkLoadTaskFallbackToNormalDataMove from SevWarn to SevInfo. All 654 occurrences in the same run were Reason=PhaseMismatch on tasks already in phase Complete, at rebalance priorities 120 and 122 and never at the bulkload priority of 140. It is a benign race between a rebalance data move and task completion, not a bulkload fallback, and at SevWarn it was read as evidence of one. The attached task phase is deliberately not logged: it is a snapshot from when the task was Triggered/Running and can never show the Complete that caused the mismatch, which getBulkLoadTask already logs at SevWarn.

`  20260813-204050-stack_restore-bf06cb6ae1c0cb07     compressed=True data_size=38566706 duration=3617644 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:27:55 sanity=False started=100000 stopped=20260813-210845 submitted=20260813-204050 timeout=5400 username=stack_restore`