### PR TITLE
Add AuditType::RangeDigest: a storage-server-side content fingerprint

### DIFF
--- a/design/range-digest.md
+++ b/design/range-digest.md
@@ -221,13 +221,16 @@ root — it makes the combine visibly incomplete rather than plausibly wrong.
   writes a known key-value set, then (a) cross-checks the audit's combined root against an
   **independent client-side computation** of the same additive digest — scanning every key-value and
   applying the canonical leaf encoding, which validates the storage-server fold *and* the combine —
-  and (b) runs a **second** audit and asserts the root is identical. Data distribution may have
-  moved shards in between, but nothing forces it to, so treat this as a determinism check that is
-  additionally partition-independent on the seeds where movement did occur. The workload waits for
-  the data to split into shards, but it does **not** wait for `moving_data -> 0`, so the precondition
-  is not established in simulation — a root mismatch caused by movement would surface as a hard
-  failure. The full backup → clear → restore → recompute cycle is exercised by the Kubernetes test
-  below, not in simulation.
+  and (b) runs a **second** audit and asserts the root is identical. Before each digest the workload
+  establishes the quiescence precondition, polling `getDataInFlight` and the data distribution queue
+  until both reach zero; on timeout it records `RangeDigestValidationInconclusive` and declines to
+  assert rather than digesting a moving cluster. Between the two digests it *forces* a repartition by
+  excluding a storage server that owns part of the range (`forceMovementBetweenDigests`, on by
+  default), so the second comparison tests partition-independence and not merely that a
+  deterministic fold is deterministic. On a cluster too small to spare a server the repartition is
+  skipped and `PartitionChanged=0` records that the run degraded to a determinism check. The full
+  backup → clear → restore → recompute cycle is exercised by the Kubernetes test below, not in
+  simulation.
 - **Skips are failures.** `runOneDigest` retries the transient audit errors itself; if the digest
   still never reaches `Complete` the workload records `RangeDigestValidationDidNotComplete` and
   `check()` fails, so a permanently broken digest cannot pass as a skip. `RangeDigest` is excluded

--- a/design/range-digest.md
+++ b/design/range-digest.md
@@ -258,8 +258,11 @@ root — it makes the combine visibly incomplete rather than plausibly wrong.
 
 ## Observability/Supportability Considerations
 
-- Per-range digests are progress metadata and are cleared when the audit completes; a mismatch is
-  localized by re-auditing narrower ranges rather than by inspecting them.
+- A root mismatch is localized from the per-range digests: live via `get_audit_status range_digest
+  progress <id>` while the audit is Running, and afterwards from the `SSAuditRangeDigestComplete`
+  trace events, which outlive the progress metadata cleared at `Complete`. Localization therefore
+  depends on log retention on *both* sides of a comparison. Re-auditing narrower ranges is the
+  fallback and needs both datasets to still exist.
 - The validation workload emits `RangeDigestValidationSuccess` with the root, key-value count and
   byte count on a successful comparison, and fails `check()` if the comparison never ran.
 - Because the digest reads at cluster scale, its throughput (MB/s) and duration are

--- a/design/range-digest.md
+++ b/design/range-digest.md
@@ -151,11 +151,33 @@ compares two settled states) but would generalize the primitive to a live cluste
 
 ### Mismatch localization
 
-Because the root is additive over any partition, a divergence can be bisected by
-re-running a digest over narrower key ranges, down to the offending region —
-without re-hashing the whole keyspace. The per-range digests are not available to
-bisect from: they are audit progress metadata, cleared once the audit reaches
-`Complete`, so localization is by re-audit rather than by inspection.
+Two roots differing tells you the datasets differ, not where. Localization works
+from the per-range digests, which each storage server emits as it finishes a task:
+
+    SSAuditRangeDigestComplete  AuditRange=<range> Digest=<hex> KVCount=<n> Bytes=<n>
+
+Diffing those events between the two runs identifies the ranges whose digests
+disagree. This is the primary mechanism, and it is how a 935,560 key-value
+shortfall was localized to a single bulkload task at 10B scale. Two consequences
+follow from it living in the trace logs: localization depends on log retention, and
+it needs the events from *both* runs, so the earlier run's logs must be kept as long
+as its root is still something you might compare against.
+
+While an audit is `Running` the same per-range digests are also queryable directly:
+
+    get_audit_status range_digest progress <id>
+
+That view disappears at `Complete`, when the progress metadata is cleared.
+
+Bisection by re-audit is the fallback: because the root is additive over any
+partition, a digest over a narrower range is directly comparable, so the divergent
+region can be found by halving. It costs about one extra full digest in total
+(`N/2 + N/4 + … ≈ N`) rather than a few cheap probes, and — the real limitation — it
+requires *both* datasets to still exist. That does not hold for the backup/restore
+case this feature was built for: the source keyspace is cleared before the restore,
+so only the restored side can be re-audited and the original survives solely as a
+32-byte root. Re-audit is therefore available when fingerprinting a live cluster
+that is still around, and the trace events are what remain otherwise.
 
 ### Failure handling
 

--- a/design/range-digest.md
+++ b/design/range-digest.md
@@ -1,0 +1,251 @@
+# RangeDigest: a storage-server-side content fingerprint for backup/restore validation
+
+## Objective
+
+Provide a way to prove that a FoundationDB backup and restore preserved the user
+data *exactly* — every key-value present, none added, dropped, or corrupted —
+without shipping the entire dataset to an external verifier. The mechanism is a
+256-bit **content fingerprint** ("RangeDigest") of the key-value multiset, computed
+in parallel by the storage servers that already hold the data, such that a single
+root taken **before backup** equals the root taken **after restore** if and only if
+the restored data is identical as a set, *regardless of how the two clusters shard
+the keyspace*.
+
+## Background
+
+Validating a restore at scale is hard precisely where it matters most. A backup of
+a multi-terabyte database is only trustworthy if we can cheaply and rigorously
+confirm the restore reproduced it. The obvious approach — have a client read the
+whole keyspace and hash it — does not scale: at 10 TB it means moving 10 TB across
+the network through one process, taking many hours and stressing exactly the read
+path we are trying to trust.
+
+FDB already distributes data across storage servers and moves it continuously
+(shard splits, merges, rebalancing, exclusions). A restore in particular lands the
+same logical data under a completely different shard layout than the original. So
+any integrity check must be **independent of the physical partition** — two clusters
+holding the identical key-value set must produce the identical fingerprint even
+though no shard boundary lines up.
+
+An external Phase-0 prototype (`fdbfingerprint`) established the per-key-value leaf
+encoding and validated the idea end-to-end from a client, with matching before/after
+roots at 1B and 3B. It was abandoned on measured cost: fingerprinting the 3B dataset
+took **9h11m at ~79 MB/s aggregate**, and it put that entire read load on the very
+path under validation. At 10B and beyond, a pre- and post-restore pair of those runs
+is not a check anyone will wait for.
+
+Two honest qualifications. First, that 79 MB/s was **not a hard client ceiling**: it
+worked out to ~4 MB/s per disk across 20 disks that sat ~98% idle, so the prototype
+was under-parallelized — 8 pods, each a single-network-thread client that could not
+hide cold-read latency — and a tuned client would have gone considerably faster.
+Second, the server-side digest measured ~2770 MB/s at 10B, but against that untuned
+client, so the ~35× gap is not a like-for-like comparison.
+
+The architectural argument does not rest on those numbers. An external fingerprint
+scales with whatever bandwidth one client pool is given and consumes read capacity
+that production traffic needs, whereas hashing on the servers that already hold the
+data scales with storage-server count and moves only 32-byte digests. RangeDigest
+keeps the Phase-0 leaf encoding byte-for-byte (so the two agree) but makes the
+fingerprint an `AuditType` computed in parallel by the storage servers.
+
+## Requirements
+
+1. **Set-exactness.** Two datasets produce equal roots iff they are equal as
+   multisets of key-value pairs. Any missing, extra, or modified key-value changes
+   the root. (Keys in FDB user space are unique, so "multiset" and "set" coincide.)
+2. **Partition independence.** The root is a function of the key-value set only —
+   not of shard boundaries, storage-server assignment, or the order data is read.
+   This is mandatory for before-backup vs after-restore comparison.
+3. **Scales with the cluster, not a client.** Per-server data is hashed locally on
+   the server that owns it; only fixed-size digests cross the network. No user data
+   is moved to compute the root.
+4. **Localizable mismatch.** When two roots differ, the divergent key range can be
+   narrowed down without re-reading everything.
+5. **Bounded, tunable footprint.** The audit must not starve the foreground
+   workload; it runs rate-limited and in batches.
+6. **Sufficient collision resistance for a non-adversarial integrity check.**
+   Accidental collisions between distinct honest datasets must be astronomically
+   unlikely at realistic scale (billions of keys).
+
+Explicit non-goal: defense against an adversary who deliberately crafts colliding
+datasets (see Alternatives / security posture).
+
+## Design Overview
+
+Defined terms:
+
+- **Leaf** — the SHA-256 hash of one canonically-encoded key-value pair.
+- **RangeDigest** — a 256-bit accumulator (`std::array<uint8_t,32>`, big-endian)
+  holding the sum, modulo 2²⁵⁶, of the leaves folded into it. Zero is the identity
+  and the digest of the empty set.
+- **combine** — addition of two RangeDigests modulo 2²⁵⁶.
+- **Root** — the RangeDigest of the entire user keyspace: the combine of every
+  storage server's per-range digest.
+
+The construction is an incremental **multiset hash** ("AdHash"): hash each element,
+sum the hashes in a large modular group. Because the group operation (addition mod
+2²⁵⁶) is associative and commutative, the sum is independent of grouping and order —
+which is exactly the partition-independence requirement.
+
+## Detailed Design
+
+### Leaf encoding and accumulation
+
+Implemented in `fdbclient/RangeDigest.{h,cpp}`. For each key-value pair:
+
+```
+leaf = SHA-256( u32be len(key) | key | u32be len(value) | value )
+```
+
+The explicit big-endian length prefixes make the encoding unambiguous (no
+key/value boundary confusion), and it is identical to the `fdbfingerprint` Phase-0
+tool so client-side and server-side computations agree.
+
+`addKeyValue` folds a leaf into the accumulator as a 256-bit big-endian add with
+carry from the least-significant byte (index 31). `combine` adds two accumulators
+the same way. `root = ( Σ over all kv of leaf(kv) ) mod 2²⁵⁶`.
+
+### Why 256 bits
+
+The accumulator width matches the SHA-256 leaf so leaves add with no truncation.
+256 bits gives a birthday bound of ~2¹²⁸ against *accidental* collision between
+distinct honest datasets — dwarfing any real dataset (10 billion keys ≈ 2³³), at a
+trivial 32 bytes on the wire per range. A wider accumulator would only add cost;
+the width is driven by collision margin, not by network size.
+
+### Server-side computation and audit integration
+
+RangeDigest is exposed as `AuditType::RangeDigest`, dispatched to
+`auditRangeDigestQ` on the storage server (`serveAuditStorageRequests`). Each
+storage server folds the key-values it owns into a per-range RangeDigest locally,
+rate-limited and batched so the audit yields to foreground traffic. Per-range
+digests are persisted and combined up to a single cluster root. Only 32-byte
+digests — never user data — cross the network, so throughput scales with the
+number of storage servers and their disks.
+
+### Precondition: quiescence
+
+The digest must be taken over a **quiescent** cluster: writes stopped and data
+distribution settled (`moving_data → 0`). Two independent invariants require this:
+
+1. **Single version.** Each server folds its owned key-values at *its own* current
+   read version; there is no single cluster-wide pinned version. Concurrent writes
+   would let servers hash at inconsistent versions, so the root would not
+   correspond to any one snapshot.
+2. **Exactly-once.** The additive combine assumes every key-value is folded exactly
+   once cluster-wide. During in-flight shard movement a key can be counted by both
+   the losing and the gaining server (double-counted) or by neither at the instant
+   it is read (missed) — either yields a wrong root. This was observed empirically
+   as a 100M-scale root mismatch traced to reading during data-distribution churn.
+
+Callers therefore wait for quiescence before reading, on *both* the before and
+after sides of a comparison. For backup/restore this is natural: both states are
+settled datasets.
+
+**Future work (see TODO in `RangeDigest.h`):** quiescence is an implementation
+choice, not inherent. Folding every server against a single pinned cluster read
+version, with an ownership snapshot consistent with that version, would make the
+digest correct **online** by re-establishing the single-version and exactly-once
+invariants MVCC-style. It is unnecessary for the backup/restore use case (which
+compares two settled states) but would generalize the primitive to a live cluster.
+
+### Mismatch localization
+
+Because the root is additive over any partition, a divergence can be bisected by
+re-running a digest over narrower key ranges, down to the offending region —
+without re-hashing the whole keyspace. The per-range digests are not available to
+bisect from: they are audit progress metadata, cleared once the audit reaches
+`Complete`, so localization is by re-audit rather than by inspection.
+
+### Failure handling
+
+The digest is a read-only audit; a partial or interrupted audit yields no root and
+is simply retried. A wrong-length or empty persisted state parses as the zero
+digest (no contribution), so a missing per-range digest cannot silently corrupt a
+root — it makes the combine visibly incomplete rather than plausibly wrong.
+
+## Alternatives Considered
+
+- **External client reads and hashes everything** (the Phase-0 `fdbfingerprint`
+  approach). Correct, simple, and actually built — it produced matching roots at 1B
+  and 3B. Rejected as the mechanism on measured cost: **9h11m at ~79 MB/s for the 3B
+  dataset**, with all of that read load falling on the path under validation, and a
+  comparison needs two such runs. As noted in Background, that rate reflected an
+  under-parallelized client (~4 MB/s across 20 mostly-idle disks) rather than a hard
+  client limit, so the objection is not "a client cannot go fast" but that a client
+  scales with the bandwidth you hand it while consuming capacity production needs. Its
+  leaf encoding is retained as the reference and an independent cross-check.
+- **Merkle tree / hash over a canonical shard list.** Order- and partition-*dependent*
+  by construction: a restore's different shard boundaries would change the root even
+  for identical data. Fails requirement 2. Additive hashing is chosen specifically
+  to be partition-independent.
+- **List of per-shard hashes compared pairwise.** Same problem — shard boundaries
+  differ across backup/restore, so there is no shard-to-shard correspondence to
+  compare, and it cannot produce a single stable root.
+- **Keyed/cryptographic MAC (adversarial collision resistance).** Additive multiset
+  hashes are not collision-resistant against an adversary who chooses inputs
+  (subset-sum / lattice structure). We deliberately do not defend against that: the
+  data is FDB's own, on a trusted cluster, and the threat is accidental corruption,
+  not a crafted collision. The 256-bit accidental-collision margin is what matters,
+  and a MAC would add key management and cost for a threat outside scope.
+- **Narrower digest (64/128-bit).** Cheaper on the wire but erodes the accidental-
+  collision margin; 32 bytes per range is already negligible, so there is no reason
+  to shrink it.
+
+## Testing Considerations
+
+- **Simulation** (`tests/fast/RangeDigestValidation.toml`, workload
+  `fdbserver/workloads/RangeDigestValidation.cpp`): under Sim2 with fault injection, the workload
+  writes a known key-value set, then (a) cross-checks the audit's combined root against an
+  **independent client-side computation** of the same additive digest — scanning every key-value and
+  applying the canonical leaf encoding, which validates the storage-server fold *and* the combine —
+  and (b) runs a **second** audit and asserts the root is identical. Data distribution may have
+  moved shards in between, but nothing forces it to, so treat this as a determinism check that is
+  additionally partition-independent on the seeds where movement did occur. The workload waits for
+  the data to split into shards, but it does **not** wait for `moving_data -> 0`, so the precondition
+  is not established in simulation — a root mismatch caused by movement would surface as a hard
+  failure. The full backup → clear → restore → recompute cycle is exercised by the Kubernetes test
+  below, not in simulation.
+- **Skips are failures.** `runOneDigest` retries the transient audit errors itself; if the digest
+  still never reaches `Complete` the workload records `RangeDigestValidationDidNotComplete` and
+  `check()` fails, so a permanently broken digest cannot pass as a skip. `RangeDigest` is excluded
+  from the DD-restart fault injection in `launchAudit` for the same reason. The content assertions
+  deliberately sit *outside* the `try` so a genuine mismatch can never be swallowed either.
+- **Shard coverage caveat.** The committed configuration is deliberately modest
+  (`nodeCount=10000`) to stay cheap across the Joshua matrix, so some seeds keep the data in a
+  single shard and do not exercise the cross-server combine. `strictShardCheck=true` turns
+  multi-shard coverage into a hard requirement for dedicated runs.
+- **Scale validation on Kubernetes** (`test_backup_restore_rangedigest`): the full
+  before/backup/clear/restore/after/compare cycle at 100M, 1B, 3B, and 10B. The 10B
+  dataset (~9.8 billion key-values, ~9.26 TB) was fingerprinted with
+  `root_before = fa1bee7a…` and retained as a reusable bulkdump baseline; a restore
+  passes iff `root_after` reproduces it.
+- **Measured throughput at 10B (2026-08-13).** Digesting 9,257,887,466,305 bytes over
+  9,808,347,148 key-values took **53m07s, ~2770 MB/s aggregate**, on a 30-machine cluster with
+  4 storage disks per machine. For scale, the external Phase-0 client fingerprinted the smaller
+  3B dataset in 9h11m at ~79 MB/s — but that client was under-parallelized (see Background), so
+  read the two as "server-side reaches cluster-scale rates" rather than as a tuned 35× speedup.
+- **Reproducibility across time.** The same 10B dataset re-digested to an identical root on a
+  later run against the same cluster, with no restore involved — so a matching root is not an
+  artifact of digesting twice in quick succession.
+- **Cross-implementation agreement:** the server-side leaf hash must match the
+  Phase-0 `fdbfingerprint` tool byte-for-byte.
+
+## Observability/Supportability Considerations
+
+- Per-range digests are progress metadata and are cleared when the audit completes; a mismatch is
+  localized by re-auditing narrower ranges rather than by inspecting them.
+- The validation workload emits `RangeDigestValidationSuccess` with the root, key-value count and
+  byte count on a successful comparison, and fails `check()` if the comparison never ran.
+- Because the digest reads at cluster scale, its throughput (MB/s) and duration are
+  worth tracking as a proxy for storage-server read health, especially since a low
+  block-cache-to-data ratio can make the read-heavy audit disk-bound.
+
+## Rollout/Migration Considerations
+
+RangeDigest is additive and opt-in: a new `AuditType` invoked on demand, with no
+on-disk format change to existing data and no effect on clusters that never request
+it. There is nothing to migrate. Rollback is simply not issuing the audit. The
+online (pinned-version) generalization in Future Work can land later without
+changing the leaf encoding or the root of a quiesced dataset, so fingerprints taken
+today remain comparable.

--- a/documentation/sphinx/source/auditstorage.rst
+++ b/documentation/sphinx/source/auditstorage.rst
@@ -39,27 +39,32 @@ How to use?
 -----------
 Start new audit job
 
-``audit_storage [replica\|locationmetadata\|ssshard] [BeginKey] [EndKey]``
+``audit_storage [replica\|locationmetadata\|ssshard\|range_digest] [BeginKey] [EndKey]``
 
 For example, to check all replicas, we can run ``audit_storage replica "" \xff\xff``.
 
 List recent jobs
 
-``get_audit_status [replica\|locationmetadata\|ssshard] recent``
+``get_audit_status [replica\|locationmetadata\|ssshard\|range_digest] recent``
 
 Check a job progress
 
-``get_audit_status [replica\|locationmetadata\|ssshard] progress [AuditID]``
+``get_audit_status [replica\|locationmetadata\|ssshard\|range_digest] progress [AuditID]``
 
 Cancel an audit
 
-``audit_storage cancel [replica\|locationmetadata\|ssshard] [AuditID]``
+``audit_storage cancel [replica\|locationmetadata\|ssshard\|range_digest] [AuditID]``
 
-There three auditTypes:
+The auditTypes are:
 
 1. ``replica``: This audit checks the consistency of user data between replicas of all DCs. ``SSAuditStorageShardReplicaError`` trace event is generated if any inconsistency is detected.
 2. ``locationmetadata``: This audit checks the consistency between ``KeyServer`` and ``ServerKey`` space. ``DDDoAuditLocationMetadataError`` trace event is generated if any inconsistency is detected.
 3. ``ssshard``: This audit checks the consistency between ``KeyServer`` and storage server in-memory shard information. ``SSAuditStorageSsShardError`` trace event is generated if any inconsistency is detected.
+4. ``range_digest``: This audit computes a 256-bit content fingerprint of the key-value data, hashed locally by each storage server and combined into a single cluster root. It detects no inconsistency by itself; instead two roots are compared, most usefully before a backup and after the corresponding restore. Because the roots are combined by modular addition they depend only on the set of key-values and not on shard boundaries or storage server assignment, so the two sides remain comparable even though a restore lands data on a completely different layout.
+
+   The audit assumes a **quiescent** cluster: each server hashes at its own read version and each key-value must be folded exactly once, so reading during data movement yields a root that corresponds to no single snapshot.
+
+   ``get_audit_status range_digest id [AuditID]`` reports the combined cluster root as ``[Digest]``, with ``[KVCount]`` and ``[Bytes]``; it is final once ``[Phase]`` is ``Complete=2``. While the audit is running, ``get_audit_status range_digest progress [AuditID]`` additionally reports the per-range digests, which is how a mismatch between two roots is narrowed to the ranges responsible. That per-range detail is discarded when the audit completes, but the same values remain in the ``SSAuditRangeDigestComplete`` trace events.
 
 ``BeginKey`` and ``EndKey`` decide the scope of the consistency check of user data (replica). Note that the ``locationmetadata`` and ``ssshard`` always check the consistency on all key space no matter the user input. 
 

--- a/fdbcli/AuditStorageCommand.cpp
+++ b/fdbcli/AuditStorageCommand.cpp
@@ -95,6 +95,8 @@ Future<UID> auditStorageCommandActor(Reference<IClusterConnectionRecord> cluster
 			type = AuditType::ValidateStorageServerShard;
 		} else if (tokencmp(tokens[2], "validate_restore")) {
 			type = AuditType::ValidateRestore;
+		} else if (tokencmp(tokens[2], "range_digest")) {
+			type = AuditType::RangeDigest;
 		} else {
 			printUsage(tokens[0]);
 			co_return UID();
@@ -117,6 +119,8 @@ Future<UID> auditStorageCommandActor(Reference<IClusterConnectionRecord> cluster
 			type = AuditType::ValidateRestore;
 		} else if (tokencmp(tokens[1], "metadata_encoding")) {
 			type = AuditType::ValidateMetadataEncoding;
+		} else if (tokencmp(tokens[1], "range_digest")) {
+			type = AuditType::RangeDigest;
 		} else {
 			printUsage(tokens[0]);
 			co_return UID();
@@ -171,7 +175,8 @@ CommandFactory auditStorageFactory(
     CommandHelp("audit_storage <Type> [BeginKey EndKey] <EngineType>",
                 "Start an audit storage",
                 "Specify audit `Type' (only `ha' and `replica' and `locationmetadata' and "
-                "`ssshard' and `validate_restore' and `metadata_encoding' `Type' are supported currently), and\n"
+                "`ssshard' and `validate_restore' and `metadata_encoding' and `range_digest' `Type' are supported "
+                "currently), and\n"
                 "optionally a sub-range with `BeginKey' and `EndKey'.\n"
                 "Specify audit `EngineType' when auditType is `ha' or `replica'\n"
                 "(only `ssd-rocksdb-v1' and `ssd-sharded-rocksdb' and `ssd-2' are supported).\n"

--- a/fdbcli/GetAuditStatusCommand.cpp
+++ b/fdbcli/GetAuditStatusCommand.cpp
@@ -137,7 +137,8 @@ Future<AuditPhase> getAuditProgressByServer(Database cx,
 
 Future<Void> getAuditProgress(Database cx, AuditType auditType, UID auditId, KeyRange auditRange) {
 	if (auditType == AuditType::ValidateHA || auditType == AuditType::ValidateReplica ||
-	    auditType == AuditType::ValidateLocationMetadata || auditType == AuditType::ValidateRestore) {
+	    auditType == AuditType::ValidateLocationMetadata || auditType == AuditType::ValidateRestore ||
+	    auditType == AuditType::RangeDigest) {
 		co_await getAuditProgressByRange(cx, auditType, auditId, auditRange);
 	} else if (auditType == AuditType::ValidateStorageServerShard) {
 		std::vector<Future<Void>> fs;
@@ -193,6 +194,8 @@ Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef> toke
 		type = AuditType::ValidateRestore;
 	} else if (tokencmp(tokens[1], "metadata_encoding")) {
 		type = AuditType::ValidateMetadataEncoding;
+	} else if (tokencmp(tokens[1], "range_digest")) {
+		type = AuditType::RangeDigest;
 	} else {
 		printUsage(tokens[0]);
 		co_return false;
@@ -218,6 +221,26 @@ Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef> toke
 		} else {
 			fmt::println("Already complete");
 		}
+	} else if (tokencmp(tokens[2], "root")) {
+		// The combined RangeDigest cluster root is stored in the top-level audit record when the
+		// audit completes (per-range progress is cleared at that point).
+		if (tokens.size() != 4 || type != AuditType::RangeDigest) {
+			printUsage(tokens[0]);
+			co_return false;
+		}
+		const UID id = UID::fromString(tokens[3].toString());
+		AuditStorageState res = co_await getAuditState(cx, type, id);
+		if (res.getPhase() != AuditPhase::Complete) {
+			fmt::println("RangeDigest audit {} is not complete (phase {}); root is only final when complete.",
+			             id.toString(),
+			             static_cast<int>(res.getPhase()));
+			co_return true;
+		}
+		RangeDigest root = RangeDigest::fromBytes(res.digest);
+		fmt::println("RangeDigest root : {}", root.toHex());
+		fmt::println("KV count         : {}", res.kvCount);
+		fmt::println("Bytes            : {}", res.byteCount);
+		fmt::println("Audit range      : {}", res.range.toString());
 	} else if (tokencmp(tokens[2], "recent")) {
 		int count = CLIENT_KNOBS->TOO_MANY;
 		if (tokens.size() == 4) {
@@ -251,17 +274,19 @@ Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef> toke
 
 CommandFactory getAuditStatusFactory(
     "get_audit_status",
-    CommandHelp(
-        "get_audit_status [ha|replica|locationmetadata|ssshard|validate_restore] [id|recent|phase|progress] [ARGs]",
-        "Retrieve audit storage status",
-        "To fetch audit status via ID: `get_audit_status [Type] id [ID]'\n"
-        "To fetch status of most recent audit: `get_audit_status [Type] recent [Count]'\n"
-        "To fetch status of audits in a specific phase: `get_audit_status [Type] phase "
-        "[running|complete|failed|error] count'\n"
-        "To fetch audit progress via ID: `get_audit_status [Type] progress [ID]'\n"
-        "Supported types include: 'ha', `replica`, `locationmetadata`, `ssshard`, `validate_restore`. \n"
-        "If specified, `Count' is how many rows to audit.\n"
-        "If not specified, check all rows in audit.\n"
-        "Phase can be `Invalid=0', `Running=1', `Complete=2', `Error=3', or `Failed=4'.\n"
-        "See also `audit_storage' command."));
+    CommandHelp("get_audit_status [ha|replica|locationmetadata|ssshard|validate_restore|range_digest] "
+                "[id|recent|phase|progress|root] [ARGs]",
+                "Retrieve audit storage status",
+                "To fetch audit status via ID: `get_audit_status [Type] id [ID]'\n"
+                "To fetch status of most recent audit: `get_audit_status [Type] recent [Count]'\n"
+                "To fetch status of audits in a specific phase: `get_audit_status [Type] phase "
+                "[running|complete|failed|error] count'\n"
+                "To fetch audit progress via ID: `get_audit_status [Type] progress [ID]'\n"
+                "To fetch the combined RangeDigest cluster root: `get_audit_status range_digest root [ID]'\n"
+                "Supported types include: 'ha', `replica`, `locationmetadata`, `ssshard`, `validate_restore`, "
+                "`range_digest`. \n"
+                "If specified, `Count' is how many rows to audit.\n"
+                "If not specified, check all rows in audit.\n"
+                "Phase can be `Invalid=0', `Running=1', `Complete=2', `Error=3', or `Failed=4'.\n"
+                "See also `audit_storage' command."));
 } // namespace fdb_cli

--- a/fdbcli/GetAuditStatusCommand.cpp
+++ b/fdbcli/GetAuditStatusCommand.cpp
@@ -135,10 +135,41 @@ Future<AuditPhase> getAuditProgressByServer(Database cx,
 	co_return AuditPhase::Complete;
 }
 
+// Per-range view for a RangeDigest audit. Reports the digest of each audited range so that a root
+// mismatch can be localized to the ranges whose digests differ, rather than only to the whole
+// keyspace. Only available while the audit is Running: the progress metadata is cleared at Complete.
+Future<Void> getRangeDigestProgressByRange(Database cx, UID auditId, KeyRange auditRange) {
+	std::vector<RangeDigestRangeEntry> entries = co_await getRangeDigestProgress(cx, auditId, auditRange);
+	int64_t counted = 0;
+	int64_t kvCount = 0;
+	int64_t byteCount = 0;
+	for (const auto& entry : entries) {
+		if (!entry.present) {
+			fmt::println("( Ongoing    ) {}", entry.boundaryRange.toString());
+			continue;
+		}
+		if (entry.rejectReason != nullptr) {
+			fmt::println("( {:<10} ) {}", entry.rejectReason, entry.boundaryRange.toString());
+			continue;
+		}
+		++counted;
+		kvCount += entry.state.kvCount;
+		byteCount += entry.state.byteCount;
+		fmt::println("( Complete   ) {} digest {} kv {} bytes {}",
+		             entry.boundaryRange.toString(),
+		             entry.state.digestToHex(),
+		             entry.state.kvCount,
+		             entry.state.byteCount);
+	}
+	fmt::println("Countable ranges: {}/{}, kv {}, bytes {}", counted, entries.size(), kvCount, byteCount);
+	co_return;
+}
+
 Future<Void> getAuditProgress(Database cx, AuditType auditType, UID auditId, KeyRange auditRange) {
-	if (auditType == AuditType::ValidateHA || auditType == AuditType::ValidateReplica ||
-	    auditType == AuditType::ValidateLocationMetadata || auditType == AuditType::ValidateRestore ||
-	    auditType == AuditType::RangeDigest) {
+	if (auditType == AuditType::RangeDigest) {
+		co_await getRangeDigestProgressByRange(cx, auditId, auditRange);
+	} else if (auditType == AuditType::ValidateHA || auditType == AuditType::ValidateReplica ||
+	           auditType == AuditType::ValidateLocationMetadata || auditType == AuditType::ValidateRestore) {
 		co_await getAuditProgressByRange(cx, auditType, auditId, auditRange);
 	} else if (auditType == AuditType::ValidateStorageServerShard) {
 		std::vector<Future<Void>> fs;
@@ -218,29 +249,17 @@ Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef> toke
 		AuditStorageState res = co_await getAuditState(cx, type, id);
 		if (res.getPhase() == AuditPhase::Running) {
 			co_await getAuditProgress(cx, res.getType(), res.id, res.range);
+		} else if (res.getType() == AuditType::RangeDigest) {
+			// Per-range progress is cleared once the audit reaches Complete, so the per-range digests
+			// are no longer readable here. The combined root survives on the top-level record, and the
+			// per-range history remains in the SSAuditRangeDigestComplete trace events.
+			fmt::println("Already complete; `get_audit_status range_digest id {}' reports the combined "
+			             "cluster root. Per-range digests are no longer stored -- see the "
+			             "SSAuditRangeDigestComplete trace events.",
+			             id.toString());
 		} else {
 			fmt::println("Already complete");
 		}
-	} else if (tokencmp(tokens[2], "root")) {
-		// The combined RangeDigest cluster root is stored in the top-level audit record when the
-		// audit completes (per-range progress is cleared at that point).
-		if (tokens.size() != 4 || type != AuditType::RangeDigest) {
-			printUsage(tokens[0]);
-			co_return false;
-		}
-		const UID id = UID::fromString(tokens[3].toString());
-		AuditStorageState res = co_await getAuditState(cx, type, id);
-		if (res.getPhase() != AuditPhase::Complete) {
-			fmt::println("RangeDigest audit {} is not complete (phase {}); root is only final when complete.",
-			             id.toString(),
-			             static_cast<int>(res.getPhase()));
-			co_return true;
-		}
-		RangeDigest root = RangeDigest::fromBytes(res.digest);
-		fmt::println("RangeDigest root : {}", root.toHex());
-		fmt::println("KV count         : {}", res.kvCount);
-		fmt::println("Bytes            : {}", res.byteCount);
-		fmt::println("Audit range      : {}", res.range.toString());
 	} else if (tokencmp(tokens[2], "recent")) {
 		int count = CLIENT_KNOBS->TOO_MANY;
 		if (tokens.size() == 4) {
@@ -275,14 +294,16 @@ Future<bool> getAuditStatusCommandActor(Database cx, std::vector<StringRef> toke
 CommandFactory getAuditStatusFactory(
     "get_audit_status",
     CommandHelp("get_audit_status [ha|replica|locationmetadata|ssshard|validate_restore|range_digest] "
-                "[id|recent|phase|progress|root] [ARGs]",
+                "[id|recent|phase|progress] [ARGs]",
                 "Retrieve audit storage status",
                 "To fetch audit status via ID: `get_audit_status [Type] id [ID]'\n"
                 "To fetch status of most recent audit: `get_audit_status [Type] recent [Count]'\n"
                 "To fetch status of audits in a specific phase: `get_audit_status [Type] phase "
                 "[running|complete|failed|error] count'\n"
                 "To fetch audit progress via ID: `get_audit_status [Type] progress [ID]'\n"
-                "To fetch the combined RangeDigest cluster root: `get_audit_status range_digest root [ID]'\n"
+                "For `range_digest', the record reported by `id' carries the combined cluster root as\n"
+                "[Digest], along with [KVCount] and [Bytes]; it is final once [Phase] is Complete=2.\n"
+                "While the audit is Running, `progress' additionally reports the per-range digests.\n"
                 "Supported types include: 'ha', `replica`, `locationmetadata`, `ssshard`, `validate_restore`, "
                 "`range_digest`. \n"
                 "If specified, `Count' is how many rows to audit.\n"

--- a/fdbclient/AuditUtils.cpp
+++ b/fdbclient/AuditUtils.cpp
@@ -46,6 +46,8 @@ void clearAuditProgressMetadata(Transaction* tr, AuditType auditType, UID auditI
 		tr->clear(auditRangeBasedProgressRangeFor(auditType, auditId));
 	} else if (auditType == AuditType::ValidateRestore) {
 		tr->clear(auditRangeBasedProgressRangeFor(auditType, auditId));
+	} else if (auditType == AuditType::RangeDigest) {
+		tr->clear(auditRangeBasedProgressRangeFor(auditType, auditId));
 	} else {
 		UNREACHABLE();
 	}
@@ -675,7 +677,8 @@ Future<std::vector<AuditStorageState>> getAuditStateByServer(Database cx,
 
 Future<bool> checkAuditProgressCompleteByRange(Database cx, AuditType auditType, UID auditId, KeyRange auditRange) {
 	ASSERT(auditType == AuditType::ValidateHA || auditType == AuditType::ValidateReplica ||
-	       auditType == AuditType::ValidateLocationMetadata || auditType == AuditType::ValidateRestore);
+	       auditType == AuditType::ValidateLocationMetadata || auditType == AuditType::ValidateRestore ||
+	       auditType == AuditType::RangeDigest);
 	KeyRange rangeToRead = auditRange;
 	Key rangeToReadBegin = auditRange.begin;
 	int retryCount = 0;
@@ -721,6 +724,95 @@ Future<bool> checkAuditProgressCompleteByRange(Database cx, AuditType auditType,
 	    .detail("AuditRange", auditRange)
 	    .detail("AuditType", auditType);
 	co_return true;
+}
+
+Future<RangeDigestSummary> getRangeDigestSummary(Database cx, UID auditId, KeyRange range) {
+	RangeDigestSummary summary;
+	Key rangeToReadBegin = range.begin;
+	int retryCount = 0;
+	Transaction tr(cx);
+	while (rangeToReadBegin < range.end) {
+		while (true) {
+			Error err;
+			try {
+				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+				tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+				// Read the raw per-range progress. Unlike getAuditStateByRange, we need the digest
+				// fields, so decode the full persisted AuditStorageState here.
+				RangeResult auditStates =
+				    co_await krmGetRanges(&tr,
+				                          auditRangeBasedProgressPrefixFor(AuditType::RangeDigest, auditId),
+				                          KeyRangeRef(rangeToReadBegin, range.end),
+				                          CLIENT_KNOBS->KRM_GET_RANGE_LIMIT,
+				                          CLIENT_KNOBS->KRM_GET_RANGE_LIMIT_BYTES);
+				for (int i = 0; i < auditStates.size() - 1; ++i) {
+					KeyRange currentRange = KeyRangeRef(auditStates[i].key, auditStates[i + 1].key);
+					if (auditStates[i].value.empty()) {
+						// No progress persisted for this sub-range yet.
+						if (summary.complete) {
+							summary.complete = false;
+							summary.incompleteRange = currentRange;
+						}
+						continue;
+					}
+					AuditStorageState s = decodeAuditStorageState(auditStates[i].value);
+					// A row is countable only if it is Complete, carries a real digest, and still
+					// describes exactly the boundary range it was read at. The latter two read as
+					// Complete without being audited data: skipAuditOnRange persists Complete with no
+					// digest, which fromBytes parses as the additive identity and would silently
+					// under-count; and a row whose range differs from its boundary range is a wider
+					// entry re-anchored by a later narrower krmSetRange, which would count a region
+					// twice. Anything uncountable is incomplete coverage, never a zero contribution.
+					const char* rejectReason = nullptr;
+					if (s.getPhase() != AuditPhase::Complete) {
+						rejectReason = "PhaseNotComplete";
+					} else if (s.digest.size() != sizeof(RangeDigest::state)) {
+						rejectReason = "NoDigest";
+					} else if (s.range != currentRange) {
+						rejectReason = "RangeMismatch";
+					}
+					if (rejectReason != nullptr) {
+						if (summary.complete) {
+							summary.complete = false;
+							summary.incompleteRange = currentRange;
+							TraceEvent(SevWarn, "AuditUtilGetRangeDigestSummaryIncomplete")
+							    .detail("AuditID", auditId)
+							    .detail("Reason", rejectReason)
+							    .detail("BoundaryRange", currentRange)
+							    .detail("StateRange", s.range)
+							    .detail("Phase", s.getPhase());
+						}
+						continue;
+					}
+					summary.root.combine(RangeDigest::fromBytes(s.digest));
+					summary.kvCount += s.kvCount;
+					summary.byteCount += s.byteCount;
+				}
+				rangeToReadBegin = auditStates.back().key;
+				break;
+			} catch (Error& e) {
+				err = e;
+			}
+			if (err.code() == error_code_actor_cancelled) {
+				throw err;
+			}
+			if (retryCount > 30) {
+				TraceEvent(SevWarn, "AuditUtilGetRangeDigestSummaryFailed").detail("AuditID", auditId);
+				throw audit_storage_failed();
+			}
+			co_await tr.onError(err);
+			retryCount++;
+		}
+	}
+	TraceEvent(SevInfo, "AuditUtilGetRangeDigestSummary")
+	    .detail("AuditID", auditId)
+	    .detail("Range", range)
+	    .detail("Root", summary.root.toHex())
+	    .detail("KVCount", summary.kvCount)
+	    .detail("Bytes", summary.byteCount)
+	    .detail("Complete", summary.complete);
+	co_return summary;
 }
 
 Future<bool> checkAuditProgressCompleteByServer(Database cx,

--- a/fdbclient/AuditUtils.cpp
+++ b/fdbclient/AuditUtils.cpp
@@ -726,12 +726,36 @@ Future<bool> checkAuditProgressCompleteByRange(Database cx, AuditType auditType,
 	co_return true;
 }
 
+// Countability rules for one persisted per-range RangeDigest row, read at boundary `boundaryRange`.
+// Returns nullptr when the row may be counted, otherwise a static reason string.
+//
+// A row is countable only if it is Complete, carries a real digest, and still describes exactly the
+// boundary range it was read at. The latter two read as Complete without being audited data:
+// skipAuditOnRange persists Complete with no digest, which fromBytes parses as the additive identity
+// and would silently under-count; and a row whose range differs from its boundary range is a wider
+// entry re-anchored by a later narrower krmSetRange, which would count a region twice. Anything
+// uncountable is incomplete coverage, never a zero contribution.
+const char* rangeDigestRowRejectReason(const AuditStorageState& s, KeyRange boundaryRange) {
+	if (s.getPhase() != AuditPhase::Complete) {
+		return "PhaseNotComplete";
+	}
+	if (s.digest.size() != sizeof(RangeDigest::state)) {
+		return "NoDigest";
+	}
+	if (s.range != boundaryRange) {
+		return "RangeMismatch";
+	}
+	return nullptr;
+}
+
 Future<RangeDigestSummary> getRangeDigestSummary(Database cx, UID auditId, KeyRange range) {
 	RangeDigestSummary summary;
 	Key rangeToReadBegin = range.begin;
 	int retryCount = 0;
 	Transaction tr(cx);
-	while (rangeToReadBegin < range.end) {
+	// Stop at the first uncountable range: the caller discards an incomplete summary and re-audits, so
+	// combining the remainder only burns krmGetRanges round trips over the rest of the keyspace.
+	while (summary.complete && rangeToReadBegin < range.end) {
 		while (true) {
 			Error err;
 			try {
@@ -746,44 +770,32 @@ Future<RangeDigestSummary> getRangeDigestSummary(Database cx, UID auditId, KeyRa
 				                          KeyRangeRef(rangeToReadBegin, range.end),
 				                          CLIENT_KNOBS->KRM_GET_RANGE_LIMIT,
 				                          CLIENT_KNOBS->KRM_GET_RANGE_LIMIT_BYTES);
+				// krmGetRanges returns a boundary map: n+1 entries describing n ranges, where entry i
+				// carries the value covering [key(i), key(i+1)) and the last entry is only a terminator.
+				// An entry with an empty value is a region the map has no row for at all.
 				for (int i = 0; i < auditStates.size() - 1; ++i) {
 					KeyRange currentRange = KeyRangeRef(auditStates[i].key, auditStates[i + 1].key);
 					if (auditStates[i].value.empty()) {
-						// No progress persisted for this sub-range yet.
-						if (summary.complete) {
-							summary.complete = false;
-							summary.incompleteRange = currentRange;
-						}
-						continue;
+						summary.complete = false;
+						summary.incompleteRange = currentRange;
+						TraceEvent(SevWarn, "AuditUtilGetRangeDigestSummaryIncomplete")
+						    .detail("AuditID", auditId)
+						    .detail("Reason", "NoProgressRow")
+						    .detail("BoundaryRange", currentRange);
+						break;
 					}
 					AuditStorageState s = decodeAuditStorageState(auditStates[i].value);
-					// A row is countable only if it is Complete, carries a real digest, and still
-					// describes exactly the boundary range it was read at. The latter two read as
-					// Complete without being audited data: skipAuditOnRange persists Complete with no
-					// digest, which fromBytes parses as the additive identity and would silently
-					// under-count; and a row whose range differs from its boundary range is a wider
-					// entry re-anchored by a later narrower krmSetRange, which would count a region
-					// twice. Anything uncountable is incomplete coverage, never a zero contribution.
-					const char* rejectReason = nullptr;
-					if (s.getPhase() != AuditPhase::Complete) {
-						rejectReason = "PhaseNotComplete";
-					} else if (s.digest.size() != sizeof(RangeDigest::state)) {
-						rejectReason = "NoDigest";
-					} else if (s.range != currentRange) {
-						rejectReason = "RangeMismatch";
-					}
+					const char* rejectReason = rangeDigestRowRejectReason(s, currentRange);
 					if (rejectReason != nullptr) {
-						if (summary.complete) {
-							summary.complete = false;
-							summary.incompleteRange = currentRange;
-							TraceEvent(SevWarn, "AuditUtilGetRangeDigestSummaryIncomplete")
-							    .detail("AuditID", auditId)
-							    .detail("Reason", rejectReason)
-							    .detail("BoundaryRange", currentRange)
-							    .detail("StateRange", s.range)
-							    .detail("Phase", s.getPhase());
-						}
-						continue;
+						summary.complete = false;
+						summary.incompleteRange = currentRange;
+						TraceEvent(SevWarn, "AuditUtilGetRangeDigestSummaryIncomplete")
+						    .detail("AuditID", auditId)
+						    .detail("Reason", rejectReason)
+						    .detail("BoundaryRange", currentRange)
+						    .detail("StateRange", s.range)
+						    .detail("Phase", s.getPhase());
+						break;
 					}
 					summary.root.combine(RangeDigest::fromBytes(s.digest));
 					summary.kvCount += s.kvCount;
@@ -813,6 +825,53 @@ Future<RangeDigestSummary> getRangeDigestSummary(Database cx, UID auditId, KeyRa
 	    .detail("Bytes", summary.byteCount)
 	    .detail("Complete", summary.complete);
 	co_return summary;
+}
+
+Future<std::vector<RangeDigestRangeEntry>> getRangeDigestProgress(Database cx, UID auditId, KeyRange range) {
+	std::vector<RangeDigestRangeEntry> entries;
+	Key rangeToReadBegin = range.begin;
+	int retryCount = 0;
+	Transaction tr(cx);
+	while (rangeToReadBegin < range.end) {
+		while (true) {
+			Error err;
+			try {
+				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+				tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+				RangeResult auditStates =
+				    co_await krmGetRanges(&tr,
+				                          auditRangeBasedProgressPrefixFor(AuditType::RangeDigest, auditId),
+				                          KeyRangeRef(rangeToReadBegin, range.end),
+				                          CLIENT_KNOBS->KRM_GET_RANGE_LIMIT,
+				                          CLIENT_KNOBS->KRM_GET_RANGE_LIMIT_BYTES);
+				for (int i = 0; i < auditStates.size() - 1; ++i) {
+					RangeDigestRangeEntry entry;
+					entry.boundaryRange = KeyRangeRef(auditStates[i].key, auditStates[i + 1].key);
+					entry.present = !auditStates[i].value.empty();
+					if (entry.present) {
+						entry.state = decodeAuditStorageState(auditStates[i].value);
+						entry.rejectReason = rangeDigestRowRejectReason(entry.state, entry.boundaryRange);
+					}
+					entries.push_back(entry);
+				}
+				rangeToReadBegin = auditStates.back().key;
+				break;
+			} catch (Error& e) {
+				err = e;
+			}
+			if (err.code() == error_code_actor_cancelled) {
+				throw err;
+			}
+			if (retryCount > 30) {
+				TraceEvent(SevWarn, "AuditUtilGetRangeDigestProgressFailed").detail("AuditID", auditId);
+				throw audit_storage_failed();
+			}
+			co_await tr.onError(err);
+			retryCount++;
+		}
+	}
+	co_return entries;
 }
 
 Future<bool> checkAuditProgressCompleteByServer(Database cx,

--- a/fdbclient/RangeDigest.cpp
+++ b/fdbclient/RangeDigest.cpp
@@ -1,0 +1,97 @@
+/*
+ * RangeDigest.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbclient/RangeDigest.h"
+
+#include <cstring>
+#include <openssl/sha.h>
+
+namespace {
+
+// Write a big-endian uint32 length prefix into the SHA-256 context.
+void updateLengthPrefix(SHA256_CTX& ctx, uint32_t n) {
+	uint8_t lb[4];
+	lb[0] = static_cast<uint8_t>(n >> 24);
+	lb[1] = static_cast<uint8_t>(n >> 16);
+	lb[2] = static_cast<uint8_t>(n >> 8);
+	lb[3] = static_cast<uint8_t>(n);
+	SHA256_Update(&ctx, lb, sizeof(lb));
+}
+
+} // namespace
+
+void RangeDigest::addKeyValue(StringRef key, StringRef value) {
+	// leaf = SHA-256( u32be len(key) | key | u32be len(value) | value )
+	SHA256_CTX ctx;
+	SHA256_Init(&ctx);
+	updateLengthPrefix(ctx, static_cast<uint32_t>(key.size()));
+	SHA256_Update(&ctx, key.begin(), key.size());
+	updateLengthPrefix(ctx, static_cast<uint32_t>(value.size()));
+	SHA256_Update(&ctx, value.begin(), value.size());
+	uint8_t leaf[SHA256_DIGEST_LENGTH];
+	SHA256_Final(leaf, &ctx);
+
+	static_assert(SHA256_DIGEST_LENGTH == 32, "RangeDigest state is 256 bits");
+
+	// state = (state + leaf) mod 2^256, big-endian with carry from LSB (byte 31).
+	uint16_t carry = 0;
+	for (int i = 31; i >= 0; --i) {
+		uint16_t sum = static_cast<uint16_t>(state[i]) + static_cast<uint16_t>(leaf[i]) + carry;
+		state[i] = static_cast<uint8_t>(sum & 0xff);
+		carry = sum >> 8;
+	}
+}
+
+void RangeDigest::combine(const RangeDigest& other) {
+	uint16_t carry = 0;
+	for (int i = 31; i >= 0; --i) {
+		uint16_t sum = static_cast<uint16_t>(state[i]) + static_cast<uint16_t>(other.state[i]) + carry;
+		state[i] = static_cast<uint8_t>(sum & 0xff);
+		carry = sum >> 8;
+	}
+}
+
+std::string RangeDigest::toHex() const {
+	static const char* hexDigits = "0123456789abcdef";
+	std::string out;
+	out.reserve(64);
+	for (uint8_t b : state) {
+		out.push_back(hexDigits[b >> 4]);
+		out.push_back(hexDigits[b & 0xf]);
+	}
+	return out;
+}
+
+RangeDigest RangeDigest::fromBytes(StringRef raw) {
+	RangeDigest d;
+	if (raw.size() == d.state.size()) {
+		memcpy(d.state.data(), raw.begin(), d.state.size());
+	}
+	return d;
+}
+
+bool RangeDigest::isZero() const {
+	for (uint8_t b : state) {
+		if (b != 0) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/fdbclient/include/fdbclient/Audit.h
+++ b/fdbclient/include/fdbclient/Audit.h
@@ -41,6 +41,7 @@ enum class AuditType : uint8_t {
 	ValidateStorageServerShard = 4,
 	ValidateRestore = 5,
 	ValidateMetadataEncoding = 6,
+	RangeDigest = 7,
 };
 
 struct AuditStorageState {
@@ -56,7 +57,9 @@ struct AuditStorageState {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, id, auditServerId, range, type, phase, error, ddId, engineType);
+		// New fields must be appended (flatbuffers with IncludeVersion): old readers
+		// ignore trailing fields and new readers default-init them for old values.
+		serializer(ar, id, auditServerId, range, type, phase, error, ddId, engineType, digest, kvCount, byteCount);
 	}
 
 	inline void setType(AuditType type) { this->type = static_cast<uint8_t>(type); }
@@ -69,11 +72,27 @@ struct AuditStorageState {
 		std::string res = "AuditStorageState: [ID]: " + id.toString() +
 		                  ", [Range]: " + Traceable<KeyRangeRef>::toString(range) +
 		                  ", [Type]: " + std::to_string(type) + ", [Phase]: " + std::to_string(phase);
+		if (getType() == AuditType::RangeDigest) {
+			res += ", [KVCount]: " + std::to_string(kvCount) + ", [Bytes]: " + std::to_string(byteCount) +
+			       ", [Digest]: " + digestToHex();
+		}
 		if (!error.empty()) {
 			res += ", [Error]: " + error;
 		}
 
 		return res;
+	}
+
+	// Lower-case hex of the raw 32-byte RangeDigest state (empty string if unset).
+	std::string digestToHex() const {
+		static const char* hexDigits = "0123456789abcdef";
+		std::string out;
+		out.reserve(digest.size() * 2);
+		for (unsigned char b : digest) {
+			out.push_back(hexDigits[b >> 4]);
+			out.push_back(hexDigits[b & 0xf]);
+		}
+		return out;
 	}
 
 	UID id;
@@ -90,6 +109,10 @@ struct AuditStorageState {
 	uint8_t phase;
 	KeyValueStoreType engineType;
 	std::string error;
+	// RangeDigest results (unused/empty for other audit types):
+	std::string digest; // raw 32-byte big-endian RangeDigest state for `range`
+	int64_t kvCount = 0; // number of key-values folded into `digest`
+	int64_t byteCount = 0; // sum of key+value bytes folded into `digest`
 };
 
 struct AuditStorageRequest {

--- a/fdbclient/include/fdbclient/AuditUtils.h
+++ b/fdbclient/include/fdbclient/AuditUtils.h
@@ -26,6 +26,7 @@
 #include "fdbclient/Audit.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/NativeAPI.h"
+#include "fdbclient/RangeDigest.h"
 #include "fdbrpc/fdbrpc.h"
 
 struct MoveKeyLockInfo {
@@ -86,6 +87,20 @@ AuditPhase stringToAuditPhase(std::string auditPhaseStr);
 
 // Check whether all sub-ranges of auditRange have completed range-based audit progress.
 Future<bool> checkAuditProgressCompleteByRange(Database cx, AuditType auditType, UID auditId, KeyRange auditRange);
+
+// Combined result of a RangeDigest audit over a key range.
+struct RangeDigestSummary {
+	RangeDigest root; // sum (mod 2^256) of all persisted per-range digests
+	int64_t kvCount = 0;
+	int64_t byteCount = 0;
+	bool complete = true; // false if some sub-range has no persisted digest yet
+	KeyRange incompleteRange; // first sub-range lacking a digest, when !complete
+};
+
+// Read the persisted per-range RangeDigest progress for `auditId` over `range` and combine it
+// into a single cluster root (plus kv/byte totals). Because the combine is additive, this is
+// independent of how the ranges were partitioned across storage servers.
+Future<RangeDigestSummary> getRangeDigestSummary(Database cx, UID auditId, KeyRange range);
 
 // Check whether a specific server's audit progress is complete for the given range.
 Future<bool> checkAuditProgressCompleteByServer(Database cx,

--- a/fdbclient/include/fdbclient/AuditUtils.h
+++ b/fdbclient/include/fdbclient/AuditUtils.h
@@ -100,7 +100,28 @@ struct RangeDigestSummary {
 // Read the persisted per-range RangeDigest progress for `auditId` over `range` and combine it
 // into a single cluster root (plus kv/byte totals). Because the combine is additive, this is
 // independent of how the ranges were partitioned across storage servers.
+//
+// Stops at the first range it cannot count, so on !complete the totals are partial by construction
+// and only `incompleteRange` is meaningful.
 Future<RangeDigestSummary> getRangeDigestSummary(Database cx, UID auditId, KeyRange range);
+
+// One entry of the persisted per-range RangeDigest progress, as read at a krm boundary.
+struct RangeDigestRangeEntry {
+	KeyRange boundaryRange; // the range this row was read at
+	AuditStorageState state; // decoded row; meaningful only when `present`
+	bool present = false; // false when the progress map has no row covering `boundaryRange`
+	const char* rejectReason = nullptr; // nullptr when the row may be counted into a root
+};
+
+// Per-range detail behind getRangeDigestSummary, for operator inspection while an audit is Running.
+// Unlike the summary this reads every range, so a partially covered audit still reports what it has.
+// The progress metadata is cleared once the audit reaches Complete, after which this reads empty and
+// the per-range history survives only in the SSAuditRangeDigestComplete trace events.
+Future<std::vector<RangeDigestRangeEntry>> getRangeDigestProgress(Database cx, UID auditId, KeyRange range);
+
+// Countability rules for one persisted per-range row; nullptr means the row may be counted.
+// Shared so the summary and the operator-facing progress view cannot disagree about what counts.
+const char* rangeDigestRowRejectReason(const AuditStorageState& s, KeyRange boundaryRange);
 
 // Check whether a specific server's audit progress is complete for the given range.
 Future<bool> checkAuditProgressCompleteByServer(Database cx,

--- a/fdbclient/include/fdbclient/RangeDigest.h
+++ b/fdbclient/include/fdbclient/RangeDigest.h
@@ -66,10 +66,18 @@
 // and single-version invariants the MVCC way. Unnecessary for the backup/restore
 // use case (which compares two settled states) but would generalize the primitive.
 //
-// A mismatch of two roots can be localized by re-running a digest over narrower
-// key ranges to bisect the divergent region, which the additive combine makes
-// valid at any granularity. The per-range digests are not available for this:
-// they are progress metadata, cleared when the audit reaches Complete.
+// A mismatch of two roots says the datasets differ, not where. Localization works
+// from the per-range digests: queryable while the audit is Running via
+// `get_audit_status range_digest progress`, and durable in the
+// SSAuditRangeDigestComplete trace events, which outlive the progress metadata the
+// audit clears at Complete. Diffing those between the two runs names the divergent
+// ranges directly, so it needs the earlier run's logs retained as long as its root
+// is still worth comparing against.
+//
+// Re-running a digest over narrower ranges to bisect is the fallback -- valid at any
+// granularity because the combine is additive, but it costs about one extra full
+// digest and requires both datasets to still exist, which the backup/restore case
+// usually cannot offer.
 struct RangeDigest {
 	// Big-endian 256-bit accumulator (most-significant byte first). Zero is the
 	// identity for combine and the digest of the empty set.

--- a/fdbclient/include/fdbclient/RangeDigest.h
+++ b/fdbclient/include/fdbclient/RangeDigest.h
@@ -1,0 +1,83 @@
+/*
+ * RangeDigest.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBCLIENT_RANGEDIGEST_H
+#define FDBCLIENT_RANGEDIGEST_H
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+#include "fdbclient/FDBTypes.h"
+
+// RangeDigest is a content fingerprint over a set of key-value pairs, designed
+// so that storage servers can each hash the data they own locally and the
+// per-range results can be combined into a single cluster-wide root over the
+// network without moving any user data.
+//
+// Construction (an incremental multiset / "AdHash" hash):
+//   - Per key-value pair, the canonical leaf encoding is, byte-for-byte:
+//         uint32 big-endian len(key) | key | uint32 big-endian len(value) | value
+//     and leaf = SHA-256(that encoding). This leaf encoding is identical to the
+//     Phase-0 external fingerprint tool (fdbfingerprint) so the two agree on the
+//     per-key-value hash.
+//   - The digest of a range is the sum, modulo 2^256, of the leaf hashes of the
+//     key-values in that range. Interpreting the 32-byte state as a big-endian
+//     256-bit integer, `combine` is modular addition.
+//
+// Because addition is associative and commutative, the digest of a range equals
+// the sum of the digests of any partition of that range, regardless of how the
+// data is physically sharded. This is what makes before-backup vs after-restore
+// roots comparable even though shard boundaries move: the root depends only on
+// the multiset of key-value pairs (and keys are unique), not on the partition.
+//
+// A mismatch of two roots can be localized by comparing the persisted per-range
+// digests and, because the combine is additive, by re-running a digest over a
+// narrower key range to bisect the divergent region.
+struct RangeDigest {
+	// Big-endian 256-bit accumulator (most-significant byte first). Zero is the
+	// identity for combine and the digest of the empty set.
+	std::array<uint8_t, 32> state{};
+
+	RangeDigest() = default;
+
+	// Fold one key-value pair into the accumulator.
+	void addKeyValue(StringRef key, StringRef value);
+
+	// this = (this + other) mod 2^256.
+	void combine(const RangeDigest& other);
+
+	// Raw 32-byte big-endian state, for serialization/persistence.
+	std::string bytes() const { return std::string(reinterpret_cast<const char*>(state.data()), state.size()); }
+
+	// Lower-case hex of the 32-byte state (64 chars).
+	std::string toHex() const;
+
+	// Parse a 32-byte raw state produced by bytes(). An empty or wrong-length
+	// input yields the zero digest (treated as "no contribution").
+	static RangeDigest fromBytes(StringRef raw);
+
+	bool operator==(const RangeDigest& o) const { return state == o.state; }
+	bool operator!=(const RangeDigest& o) const { return state != o.state; }
+	bool isZero() const;
+};
+
+#endif

--- a/fdbclient/include/fdbclient/RangeDigest.h
+++ b/fdbclient/include/fdbclient/RangeDigest.h
@@ -49,9 +49,27 @@
 // roots comparable even though shard boundaries move: the root depends only on
 // the multiset of key-value pairs (and keys are unique), not on the partition.
 //
-// A mismatch of two roots can be localized by comparing the persisted per-range
-// digests and, because the combine is additive, by re-running a digest over a
-// narrower key range to bisect the divergent region.
+// Precondition: the digest must be taken over a QUIESCENT cluster. Each storage
+// server folds the key-values it currently owns at its own current read version,
+// and the additive combine assumes every key-value is folded exactly once. Both
+// assumptions break under activity: concurrent writes let servers hash at
+// inconsistent versions, and in-flight data-distribution movement lets a key be
+// double-counted (by both the losing and the gaining server) or missed (owned by
+// neither at the instant it is read) -- either yields a wrong root. Callers must
+// wait for writes to stop and data movement to drain (moving_data -> 0) before
+// reading, on both the before and after sides of a comparison.
+//
+// TODO: the quiescence requirement is an implementation choice, not inherent to
+// the construction. Folding every server against a single pinned cluster read
+// version, with an ownership snapshot consistent with that version, would make
+// the digest correct online (no quiescence needed) by restoring the exactly-once
+// and single-version invariants the MVCC way. Unnecessary for the backup/restore
+// use case (which compares two settled states) but would generalize the primitive.
+//
+// A mismatch of two roots can be localized by re-running a digest over narrower
+// key ranges to bisect the divergent region, which the additive combine makes
+// valid at any granularity. The per-range digests are not available for this:
+// they are progress metadata, cleared when the audit reaches Complete.
 struct RangeDigest {
 	// Big-endian 256-bit accumulator (most-significant byte first). Zero is the
 	// identity for combine and the digest of the empty set.

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -1197,8 +1197,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	// crawling through tiny batches.
 	init( AUDIT_RESTORE_BATCH_BYTE_LIMIT_MIN,                  256e3 ); if( randomize && buggify() ) AUDIT_RESTORE_BATCH_BYTE_LIMIT_MIN = 1000;
 	// Max bytes of keyspace one audit task covers, for every audit type (ValidateHA, ValidateReplica,
-	// ValidateRestore). Tasks default to one keyServers shard, and a shard bigger than this is subdivided
-	// so that no single task dominates.
+	// ValidateRestore, RangeDigest). Tasks default to one keyServers shard, and a shard bigger than this
+	// is subdivided so that no single task dominates.
 	//
 	// This bounds the audit phase's wall-clock: a task is scanned start to finish by one storage server,
 	// so the phase cannot end before its largest task does, and making individual tasks faster cannot help.

--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -1180,7 +1180,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	// An audit divides its range into TASKS; each task is handled by one storage server, which walks it in
 	// BATCHES of reads. The knobs below bound those two units independently:
 	//   AUDIT_TASK_MAX_BYTES     -- how much keyspace one task covers
-	//   AUDIT_RESTORE_BATCH_*    -- how much one read inside a task fetches (validate_restore only)
+	//   AUDIT_RESTORE_BATCH_*    -- how much one read inside a task fetches (validate_restore, RangeDigest)
 
 	// Max bytes one comparison batch fetches from each side. This is an upper bound, not the size used:
 	// the actual budget moves between AUDIT_RESTORE_BATCH_BYTE_LIMIT_MIN and this value, halving whenever a

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -4898,7 +4898,8 @@ static Future<std::vector<KeyRange>> boundAuditTaskRange(Reference<IDDTxnProcess
 }
 
 // Partition the input range into multiple subranges according to the range ownership, and
-// schedule ha/replica/restore audit tasks of each subrange on the server which owns the subrange
+// schedule ha/replica/restore/range_digest audit tasks of each subrange on the server which owns
+// the subrange
 // Automatically retry until complete or timed out
 Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
                                   std::shared_ptr<DDAudit> audit,

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -432,6 +432,7 @@ public:
 	FlowLock auditStorageLocationMetadataLaunchingLock;
 	FlowLock auditStorageSsShardLaunchingLock;
 	FlowLock auditStorageRestoreLaunchingLock;
+	FlowLock auditStorageRangeDigestLaunchingLock;
 	Promise<Void> auditStorageInitialized;
 	bool auditStorageInitStarted;
 
@@ -3959,7 +3960,8 @@ Future<Void> auditStorageCore(Reference<DataDistributor> self,
 			// Check audit persist progress to double check if any range omitted to be check
 			if (audit->coreState.getType() == AuditType::ValidateHA ||
 			    audit->coreState.getType() == AuditType::ValidateReplica ||
-			    audit->coreState.getType() == AuditType::ValidateRestore) {
+			    audit->coreState.getType() == AuditType::ValidateRestore ||
+			    audit->coreState.getType() == AuditType::RangeDigest) {
 				bool allFinish = co_await checkAuditProgressCompleteByRange(self->txnProcessor->context(),
 				                                                            audit->coreState.getType(),
 				                                                            audit->coreState.id,
@@ -3993,6 +3995,36 @@ Future<Void> auditStorageCore(Reference<DataDistributor> self,
 					    .detail("AuditType", auditType);
 					throw retry();
 				}
+			}
+			if (!audit->foundError && audit->coreState.getType() == AuditType::RangeDigest) {
+				// Combine the per-range digests into the cluster root and store it in the top-level
+				// audit record, which makes the root durable and readable via `get_audit_status`. This
+				// must happen while the phase is still Running: the per-range progress metadata is
+				// cleared once Complete is persisted, and the retry below re-enters runAuditStorage(),
+				// which requires Running.
+				RangeDigestSummary summary = co_await getRangeDigestSummary(
+				    self->txnProcessor->context(), audit->coreState.id, audit->coreState.range);
+				// Coverage guard: a fingerprint must never be reported over a partially-covered
+				// keyspace. If the persisted per-range digests do not tile the whole audit range (e.g. a
+				// shard was skipped because its team was briefly unavailable under data movement), retry
+				// rather than publish a root that silently omits keys.
+				if (!summary.complete) {
+					TraceEvent(SevInfo, "DDAuditStorageCoreRetry", self->ddId)
+					    .detail("Reason", "RangeDigestIncompleteCoverage")
+					    .detail("AuditID", auditID)
+					    .detail("IncompleteRange", summary.incompleteRange)
+					    .detail("RetryCount", audit->retryCount)
+					    .detail("AuditType", auditType);
+					throw retry();
+				}
+				audit->coreState.digest = summary.root.bytes();
+				audit->coreState.kvCount = summary.kvCount;
+				audit->coreState.byteCount = summary.byteCount;
+				TraceEvent(SevInfo, "DDAuditStorageRangeDigestRoot", self->ddId)
+				    .detail("AuditID", audit->coreState.id)
+				    .detail("Root", summary.root.toHex())
+				    .detail("KVCount", summary.kvCount)
+				    .detail("Bytes", summary.byteCount);
 			}
 			if (!audit->foundError) {
 				audit->coreState.setPhase(AuditPhase::Complete);
@@ -4136,7 +4168,7 @@ void runAuditStorage(Reference<DataDistributor> self,
 	if (auditState.getType() != AuditType::ValidateHA && auditState.getType() != AuditType::ValidateReplica &&
 	    auditState.getType() != AuditType::ValidateLocationMetadata &&
 	    auditState.getType() != AuditType::ValidateStorageServerShard &&
-	    auditState.getType() != AuditType::ValidateRestore) {
+	    auditState.getType() != AuditType::ValidateRestore && auditState.getType() != AuditType::RangeDigest) {
 		throw not_implemented();
 	}
 	TraceEvent(SevDebug, "DDRunAuditStorage", self->ddId)
@@ -4237,8 +4269,10 @@ Future<UID> launchAudit(Reference<DataDistributor> self,
 			// ValidateRestore is excluded because the current simulation test for restore validation
 			// is a simple end-to-end test that expects the audit to complete without DD restart.
 			// Future work could add more comprehensive fault injection testing for ValidateRestore.
+			// RangeDigest is excluded for the same reason: its test asserts the audit reached Complete,
+			// which a coin-flip restart per launch would turn into an unconditional skip.
 			if (g_network->isSimulated() && auditType != AuditType::ValidateRestore &&
-			    deterministicRandom()->coinflip()) {
+			    auditType != AuditType::RangeDigest && deterministicRandom()->coinflip()) {
 				TraceEvent(SevInfo, "DDAuditStorageLaunchFaultInjection", self->ddId)
 				    .detail("AuditID", auditID_)
 				    .detail("AuditType", auditType);
@@ -4291,6 +4325,9 @@ Future<Void> cancelAuditStorage(Reference<DataDistributor> self, TriggerAuditReq
 	} else if (req.getType() == AuditType::ValidateRestore) {
 		co_await self->auditStorageRestoreLaunchingLock.take(TaskPriority::DefaultYield);
 		holder = FlowLock::Releaser(self->auditStorageRestoreLaunchingLock);
+	} else if (req.getType() == AuditType::RangeDigest) {
+		co_await self->auditStorageRangeDigestLaunchingLock.take(TaskPriority::DefaultYield);
+		holder = FlowLock::Releaser(self->auditStorageRangeDigestLaunchingLock);
 	} else {
 		req.reply.sendError(not_implemented());
 		co_return;
@@ -4377,6 +4414,9 @@ Future<Void> auditStorage(Reference<DataDistributor> self, TriggerAuditRequest r
 	} else if (req.getType() == AuditType::ValidateRestore) {
 		co_await self->auditStorageRestoreLaunchingLock.take(TaskPriority::DefaultYield);
 		holder = FlowLock::Releaser(self->auditStorageRestoreLaunchingLock);
+	} else if (req.getType() == AuditType::RangeDigest) {
+		co_await self->auditStorageRangeDigestLaunchingLock.take(TaskPriority::DefaultYield);
+		holder = FlowLock::Releaser(self->auditStorageRangeDigestLaunchingLock);
 	} else {
 		req.reply.sendError(not_implemented());
 		co_return;
@@ -4451,6 +4491,8 @@ void loadAndDispatchAudit(Reference<DataDistributor> self, std::shared_ptr<DDAud
 	} else if (audit->coreState.getType() == AuditType::ValidateStorageServerShard) {
 		audit->actors.add(dispatchAuditStorageServerShard(self, audit));
 	} else if (audit->coreState.getType() == AuditType::ValidateRestore) {
+		audit->actors.add(dispatchAuditStorage(self, audit));
+	} else if (audit->coreState.getType() == AuditType::RangeDigest) {
 		audit->actors.add(dispatchAuditStorage(self, audit));
 	} else {
 		UNREACHABLE();
@@ -4685,7 +4727,7 @@ Future<Void> dispatchAuditStorage(Reference<DataDistributor> self, std::shared_p
 	const AuditType auditType = audit->coreState.getType();
 	const KeyRange range = audit->coreState.range;
 	ASSERT(auditType == AuditType::ValidateHA || auditType == AuditType::ValidateReplica ||
-	       auditType == AuditType::ValidateRestore);
+	       auditType == AuditType::ValidateRestore || auditType == AuditType::RangeDigest);
 	TraceEvent(SevInfo, "DDDispatchAuditStorageBegin", self->ddId)
 	    .detail("AuditID", audit->coreState.id)
 	    .detail("Range", range)
@@ -4863,7 +4905,7 @@ Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
                                   KeyRange rangeToSchedule) {
 	const AuditType auditType = audit->coreState.getType();
 	ASSERT(auditType == AuditType::ValidateHA || auditType == AuditType::ValidateReplica ||
-	       auditType == AuditType::ValidateRestore);
+	       auditType == AuditType::ValidateRestore || auditType == AuditType::RangeDigest);
 	TraceEvent(SevInfo, "DDScheduleAuditOnRangeBegin", self->ddId)
 	    .detail("AuditID", audit->coreState.id)
 	    .detail("AuditRange", audit->coreState.range)
@@ -5073,6 +5115,36 @@ Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 								taskRangeBegin = taskRange.end;
 								continue;
 							}
+						} else if (auditType == AuditType::RangeDigest) {
+							// Each shard is hashed exactly once by a single owning server; the SS reads
+							// only its local copy, so no comparison peers are needed (targetServers stays
+							// empty). Any replica holds identical content, so pick one from the primary DC.
+							if (rangeLocations[rangeLocationIndex].servers.empty()) {
+								TraceEvent(SevInfo, "DDScheduleAuditOnRangeSkipped", self->ddId)
+								    .detail("Reason", "No servers found for shard")
+								    .detail("AuditID", audit->coreState.id)
+								    .detail("AuditRange", audit->coreState.range)
+								    .detail("TaskRange", taskRange)
+								    .detail("AuditType", auditType);
+								++numSkippedShards;
+								taskRangeBegin = taskRange.end;
+								continue;
+							}
+							auto it = rangeLocations[rangeLocationIndex].servers.begin();
+							if (it->second.empty()) {
+								TraceEvent(SevInfo, "DDScheduleAuditOnRangeSkipped", self->ddId)
+								    .detail("Reason", "Primary DC server list empty")
+								    .detail("AuditID", audit->coreState.id)
+								    .detail("AuditRange", audit->coreState.range)
+								    .detail("TaskRange", taskRange)
+								    .detail("AuditType", auditType);
+								++numSkippedShards;
+								taskRangeBegin = taskRange.end;
+								continue;
+							}
+							const int idx = deterministicRandom()->randomInt(0, it->second.size());
+							targetServer = it->second[idx];
+							storageServersToCheck.push_back(it->second[idx]);
 						} else {
 							UNREACHABLE();
 						}
@@ -5193,7 +5265,7 @@ Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 Future<Void> skipAuditOnRange(Reference<DataDistributor> self, std::shared_ptr<DDAudit> audit, KeyRange rangeToSkip) {
 	AuditType auditType = audit->coreState.getType();
 	ASSERT(auditType == AuditType::ValidateHA || auditType == AuditType::ValidateReplica ||
-	       auditType == AuditType::ValidateRestore);
+	       auditType == AuditType::ValidateRestore || auditType == AuditType::RangeDigest);
 	try {
 		audit->overallIssuedDoAuditCount++;
 		AuditStorageState res(audit->coreState.id, rangeToSkip, auditType);
@@ -5255,7 +5327,8 @@ Future<Void> doAuditOnStorageServer(Reference<DataDistributor> self,
                                     AuditStorageRequest req) {
 	AuditType auditType = req.getType();
 	ASSERT(auditType == AuditType::ValidateHA || auditType == AuditType::ValidateReplica ||
-	       auditType == AuditType::ValidateStorageServerShard || auditType == AuditType::ValidateRestore);
+	       auditType == AuditType::ValidateStorageServerShard || auditType == AuditType::ValidateRestore ||
+	       auditType == AuditType::RangeDigest);
 	TraceEvent(SevInfo, "DDDoAuditOnStorageServerBegin", self->ddId)
 	    .detail("AuditID", req.id)
 	    .detail("Range", req.range)

--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -5078,17 +5078,39 @@ Future<Void> auditRangeDigestQ(StorageServer* data, AuditStorageRequest req) {
 	KeyRange rangeToRead = req.range;
 	Key rangeToReadBegin = req.range.begin;
 	int limit = SERVER_KNOBS->AUDIT_RESTORE_BATCH_KEY_LIMIT;
-	int limitBytes = CLIENT_KNOBS->REPLY_BYTE_LIMIT;
+	// Ceiling of an adaptive budget, not a fixed batch size. Deliberately not
+	// CLIENT_KNOBS->REPLY_BYTE_LIMIT, a per-RPC-reply cap reached long before the key limit above at any
+	// realistic record size, which would make that key limit unreachable; see nextAuditBatchBytes().
+	const int limitBytesCeiling = SERVER_KNOBS->AUDIT_RESTORE_BATCH_BYTE_LIMIT;
+	const int limitBytesFloor = std::min<int>(limitBytesCeiling, SERVER_KNOBS->AUDIT_RESTORE_BATCH_BYTE_LIMIT_MIN);
+	// Seeded through nextAuditBatchBytes() so a nonsensical knob pair cannot put the FIRST batch outside
+	// the window. Returns the ceiling unchanged for any sane configuration.
+	int limitBytes = nextAuditBatchBytes(limitBytesCeiling, true, limitBytesFloor, limitBytesCeiling);
 	int64_t readBytes = 0;
+	int consecutiveRetries = 0;
+	int64_t totalRetryableErrors = 0;
+	// Jittered geometric backoff on the house knobs, reset on success so an audit that hits an occasional
+	// retry does not ratchet to the maximum and stay there.
+	Backoff retryBackoff;
 	bool complete = false;
 	double startTime = now();
+	// Time blocked on the audit rate limiter, reported so a throttled digest is distinguishable from a
+	// slow one.
+	double rateLimiterTotalWaitTime = 0;
 	Error nonRetryableError;
-	Reference<IRateControl> rateLimiter = makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
+	// Server-wide, not per-task: see StorageServer::auditStorageRateLimiter.
+	Reference<IRateControl> rateLimiter = data->auditStorageRateLimiter;
 
 	{
 		Optional<Error> err;
 		try {
 			while (true) {
+				// Snapshot the accumulator: a retryable failure re-reads this same batch from the same
+				// start key, and the additive digest has no inverse, so the only way to undo a partial fold
+				// is to restore the pre-batch state.
+				const RangeDigest batchStartDigest = digest;
+				const int64_t batchStartKvCount = kvCount;
+				const int64_t batchStartByteCount = byteCount;
 				try {
 					readBytes = 0;
 					rangeToRead = KeyRangeRef(rangeToReadBegin, req.range.end);
@@ -5118,13 +5140,19 @@ Future<Void> auditRangeDigestQ(StorageServer* data, AuditStorageRequest req) {
 					}
 					readBytes = reply.data.expectedSize();
 
+					const double rateLimiterBeforeWaitTime = now();
 					co_await rateLimiter->getAllowance(readBytes);
+					rateLimiterTotalWaitTime += now() - rateLimiterBeforeWaitTime;
 
 					if (!reply.more || reply.data.empty()) {
 						complete = true;
 						break;
 					}
 					rangeToReadBegin = keyAfter(reply.data.back().key);
+					// The batch succeeded, so let the byte budget grow back toward its ceiling.
+					consecutiveRetries = 0;
+					retryBackoff = Backoff();
+					limitBytes = nextAuditBatchBytes(limitBytes, true, limitBytesFloor, limitBytesCeiling);
 					if (rangeToReadBegin >= req.range.end) {
 						complete = true;
 						break;
@@ -5140,13 +5168,28 @@ Future<Void> auditRangeDigestQ(StorageServer* data, AuditStorageRequest req) {
 					if (nonRetryableError.code() == error_code_future_version ||
 					    nonRetryableError.code() == error_code_transaction_too_old ||
 					    nonRetryableError.code() == error_code_server_overloaded) {
+						// This batch is retried from the same start key, so undo its partial fold.
+						digest = batchStartDigest;
+						kvCount = batchStartKvCount;
+						byteCount = batchStartByteCount;
+						const int retriedBytes = limitBytes;
+						limitBytes = nextAuditBatchBytes(limitBytes, false, limitBytesFloor, limitBytesCeiling);
+						++consecutiveRetries;
+						++totalRetryableErrors;
+						// Suppressed, with the running total reported in SSAuditRangeDigestComplete: retrying
+						// is an expected path, and the budget halving above is the actual remedy.
 						TraceEvent(SevWarn, "SSAuditRangeDigestRetryableError", data->thisServerID)
+						    .suppressFor(10.0)
 						    .detail("AuditID", req.id)
 						    .detail("Error", nonRetryableError.what())
 						    .detail("Version", version)
-						    .detail("Range", rangeToRead);
+						    .detail("Range", rangeToRead)
+						    .detail("BatchBytes", retriedBytes)
+						    .detail("NextBatchBytes", limitBytes)
+						    .detail("ConsecutiveRetries", consecutiveRetries)
+						    .detail("TotalRetryableErrors", totalRetryableErrors);
 						nonRetryableError = Error();
-						co_await delay(1.0);
+						co_await retryBackoff.onError();
 						continue;
 					}
 					throw nonRetryableError;
@@ -5167,7 +5210,9 @@ Future<Void> auditRangeDigestQ(StorageServer* data, AuditStorageRequest req) {
 			    .detail("KVCount", kvCount)
 			    .detail("Bytes", byteCount)
 			    .detail("Digest", digest.toHex())
-			    .detail("Duration", now() - startTime);
+			    .detail("Duration", now() - startTime)
+			    .detail("RateLimiterTotalWaitTime", rateLimiterTotalWaitTime)
+			    .detail("TotalRetryableErrors", totalRetryableErrors);
 			co_await persistAuditStateByRange(data->cx, res);
 
 		} catch (Error& e) {

--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -5002,24 +5002,221 @@ Future<Void> auditRestoreQ(StorageServer* data, AuditStorageRequest req) {
 			err = e;
 		}
 		if (err.present()) {
-			if (err.get().code() == error_code_actor_cancelled) {
-				throw err.get();
+			Error e = err.get();
+			if (e.code() == error_code_actor_cancelled) {
+				throw e;
+			}
+			// Cancellation / outdated: reply to DD and exit without crashing the storage server.
+			if (e.code() == error_code_audit_storage_cancelled) {
+				req.reply.sendError(audit_storage_cancelled());
+				co_return;
+			}
+			if (e.code() == error_code_audit_storage_task_outdated) {
+				req.reply.sendError(audit_storage_task_outdated());
+				co_return;
 			}
 			// Send retryable errors back to DD so it can retry with correct SS
-			if (err.get().code() == error_code_wrong_shard_server) {
-				req.reply.sendError(err.get());
+			if (e.code() == error_code_wrong_shard_server) {
+				req.reply.sendError(e);
 				co_return;
 			}
 			res.setPhase(AuditPhase::Error);
-			res.error = err.get().what();
+			res.error = e.what();
 			res.range = req.range;
 			TraceEvent(SevWarn, "SSAuditRestoreError", data->thisServerID)
-			    .errorUnsuppressed(err.get())
+			    .errorUnsuppressed(e)
 			    .detail("AuditID", req.id)
 			    .detail("AuditRange", req.range);
 			res.ddId = req.ddId;
 			res.auditServerId = data->thisServerID;
+			// Guard the error-persist so a cancellation racing the persist can't escape and fail the SS.
+			try {
+				co_await persistAuditStateByRange(data->cx, res);
+			} catch (Error& e2) {
+				if (e2.code() == error_code_actor_cancelled) {
+					throw e2;
+				}
+				req.reply.sendError(e2.code() == error_code_audit_storage_cancelled ? audit_storage_cancelled()
+				                                                                    : audit_storage_failed());
+				co_return;
+			}
+		}
+	}
+
+	req.reply.send(res);
+}
+
+// RangeDigest audit: fold every key-value the storage server locally owns in req.range into an
+// additive content digest (see RangeDigest.h). No data leaves the server; only the 32-byte digest
+// plus kv/byte counts are persisted per range. DD combines the per-range digests into a cluster
+// root. Assumes a quiescent cluster (each batch reads the server's current version).
+Future<Void> auditRangeDigestQ(StorageServer* data, AuditStorageRequest req) {
+	ASSERT(req.getType() == AuditType::RangeDigest);
+	co_await data->serveAuditStorageParallelismLock.take(TaskPriority::DefaultYield);
+	FlowLock::Releaser holder(data->serveAuditStorageParallelismLock);
+
+	TraceEvent(SevInfo, "SSAuditRangeDigestBegin", data->thisServerID)
+	    .detail("AuditID", req.id)
+	    .detail("AuditRange", req.range)
+	    .detail("AuditType", req.type);
+
+	// RangeDigest is only meaningful over user keys.
+	if (!normalKeys.contains(req.range)) {
+		TraceEvent(SevError, "SSAuditRangeDigestInvalidRange", data->thisServerID)
+		    .detail("AuditID", req.id)
+		    .detail("AuditRange", req.range)
+		    .detail("Error", "Range must be within normalKeys");
+		req.reply.sendError(audit_storage_failed());
+		co_return;
+	}
+
+	AuditStorageState res(req.id, req.getType());
+	RangeDigest digest; // additive accumulator over the whole of req.range
+	int64_t kvCount = 0;
+	int64_t byteCount = 0;
+	Version version{ 0 };
+	KeyRange rangeToRead = req.range;
+	Key rangeToReadBegin = req.range.begin;
+	int limit = SERVER_KNOBS->AUDIT_RESTORE_BATCH_KEY_LIMIT;
+	int limitBytes = CLIENT_KNOBS->REPLY_BYTE_LIMIT;
+	int64_t readBytes = 0;
+	bool complete = false;
+	double startTime = now();
+	Error nonRetryableError;
+	Reference<IRateControl> rateLimiter = makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
+
+	{
+		Optional<Error> err;
+		try {
+			while (true) {
+				try {
+					readBytes = 0;
+					rangeToRead = KeyRangeRef(rangeToReadBegin, req.range.end);
+					ASSERT(!rangeToRead.empty());
+
+					// Quiescent-cluster assumption: read this server's current version each batch.
+					version = data->version.get();
+
+					GetKeyValuesRequest localReq;
+					localReq.begin = firstGreaterOrEqual(rangeToRead.begin);
+					localReq.end = firstGreaterOrEqual(rangeToRead.end);
+					localReq.limit = limit;
+					localReq.limitBytes = limitBytes;
+					localReq.version = version;
+					localReq.tags = TagSet();
+					data->actors.add(getKeyValuesQ(data, localReq));
+					GetKeyValuesReply reply = co_await localReq.reply.getFuture();
+					if (reply.error.present()) {
+						throw reply.error.get();
+					}
+
+					for (int i = 0; i < reply.data.size(); ++i) {
+						const KeyValueRef& kv = reply.data[i];
+						digest.addKeyValue(kv.key, kv.value);
+						++kvCount;
+						byteCount += kv.key.size() + kv.value.size();
+					}
+					readBytes = reply.data.expectedSize();
+
+					co_await rateLimiter->getAllowance(readBytes);
+
+					if (!reply.more || reply.data.empty()) {
+						complete = true;
+						break;
+					}
+					rangeToReadBegin = keyAfter(reply.data.back().key);
+					if (rangeToReadBegin >= req.range.end) {
+						complete = true;
+						break;
+					}
+				} catch (Error& e) {
+					if (e.code() == error_code_actor_cancelled) {
+						throw e;
+					}
+					nonRetryableError = e;
+				}
+				// co_await is not allowed inside a catch handler; handle retry here.
+				if (nonRetryableError.isValid() && nonRetryableError.code() != error_code_success) {
+					if (nonRetryableError.code() == error_code_future_version ||
+					    nonRetryableError.code() == error_code_transaction_too_old ||
+					    nonRetryableError.code() == error_code_server_overloaded) {
+						TraceEvent(SevWarn, "SSAuditRangeDigestRetryableError", data->thisServerID)
+						    .detail("AuditID", req.id)
+						    .detail("Error", nonRetryableError.what())
+						    .detail("Version", version)
+						    .detail("Range", rangeToRead);
+						nonRetryableError = Error();
+						co_await delay(1.0);
+						continue;
+					}
+					throw nonRetryableError;
+				}
+			}
+
+			res.setPhase(AuditPhase::Complete);
+			res.range = req.range;
+			res.digest = digest.bytes();
+			res.kvCount = kvCount;
+			res.byteCount = byteCount;
+			res.ddId = req.ddId;
+			res.auditServerId = data->thisServerID;
+			TraceEvent(SevInfo, "SSAuditRangeDigestComplete", data->thisServerID)
+			    .detail("AuditID", req.id)
+			    .detail("AuditRange", req.range)
+			    .detail("Complete", complete)
+			    .detail("KVCount", kvCount)
+			    .detail("Bytes", byteCount)
+			    .detail("Digest", digest.toHex())
+			    .detail("Duration", now() - startTime);
 			co_await persistAuditStateByRange(data->cx, res);
+
+		} catch (Error& e) {
+			err = e;
+		}
+		if (err.present()) {
+			Error e = err.get();
+			if (e.code() == error_code_actor_cancelled) {
+				throw e;
+			}
+			// Cancellation / outdated / ownership shift: reply to DD and exit WITHOUT crashing the
+			// storage server. Every other SS audit actor handles these at the top level the same way
+			// (see auditStorageServerShardQ / auditStorageShardReplicaQ); letting audit_storage_cancelled
+			// escape here would surface as a SevError StorageServerFailed.
+			if (e.code() == error_code_audit_storage_cancelled) {
+				req.reply.sendError(audit_storage_cancelled());
+				co_return;
+			}
+			if (e.code() == error_code_audit_storage_task_outdated) {
+				req.reply.sendError(audit_storage_task_outdated());
+				co_return;
+			}
+			// Let DD retry against the correct server if ownership shifted mid-audit.
+			if (e.code() == error_code_wrong_shard_server) {
+				req.reply.sendError(e);
+				co_return;
+			}
+			res.setPhase(AuditPhase::Error);
+			res.error = e.what();
+			res.range = req.range;
+			TraceEvent(SevWarn, "SSAuditRangeDigestError", data->thisServerID)
+			    .errorUnsuppressed(e)
+			    .detail("AuditID", req.id)
+			    .detail("AuditRange", req.range);
+			res.ddId = req.ddId;
+			res.auditServerId = data->thisServerID;
+			// Guard the error-persist: if the audit was cancelled while we were recording the error,
+			// persistAuditStateByRange throws audit_storage_cancelled. Swallow it (reply + exit) so it
+			// cannot escape the actor and fail the storage server.
+			try {
+				co_await persistAuditStateByRange(data->cx, res);
+			} catch (Error& e2) {
+				if (e2.code() == error_code_actor_cancelled) {
+					throw e2;
+				}
+				req.reply.sendError(e2.code() == error_code_audit_storage_cancelled ? audit_storage_cancelled()
+				                                                                    : audit_storage_failed());
+				co_return;
+			}
 		}
 	}
 
@@ -12561,6 +12758,8 @@ Future<Void> serveAuditStorageRequests(StorageServer* self, FutureStream<AuditSt
 			self->actors.add(auditStorageServerShardQ(self, req));
 		} else if (req.getType() == AuditType::ValidateRestore) {
 			self->actors.add(auditRestoreQ(self, req));
+		} else if (req.getType() == AuditType::RangeDigest) {
+			self->actors.add(auditRangeDigestQ(self, req));
 		} else {
 			req.reply.sendError(not_implemented());
 		}

--- a/fdbserver/workloads/RangeDigestValidation.cpp
+++ b/fdbserver/workloads/RangeDigestValidation.cpp
@@ -189,9 +189,13 @@ struct RangeDigestValidationWorkload : TestWorkload {
 		int maxAuditRetries = 10;
 		while (true) {
 			Error retryErr;
+			// Distinguishes a launch timeout from a completion timeout: both surface as timed_out, but
+			// only the former is unambiguously transient (see the retry decision below).
+			bool auditScheduled = false;
 			try {
 				UID auditId = co_await auditStorage(
 				    clusterFile, normalKeys, AuditType::RangeDigest, KeyValueStoreType::END, maxWaitTime);
+				auditScheduled = true;
 				TraceEvent("RangeDigestValidationAuditScheduled")
 				    .detail("AuditID", auditId)
 				    .detail("RetryCount", auditRetryCount);
@@ -240,11 +244,16 @@ struct RangeDigestValidationWorkload : TestWorkload {
 			if (retryErr.code() == error_code_actor_cancelled) {
 				throw retryErr;
 			}
-			// audit_storage_failed and related transient conditions are retryable under buggify.
+			// audit_storage_failed and related transient conditions are retryable under buggify. A
+			// timed_out from auditStorage() means the CC never issued an audit ID -- no audit exists to
+			// be stuck, so it is equally transient. A timed_out from the completion wait is NOT retried:
+			// that audit was scheduled and stopped making progress, which is a finding, and re-arming it
+			// maxAuditRetries times would spend maxWaitTime on each before failing anyway.
 			if ((retryErr.code() == error_code_audit_storage_failed ||
 			     retryErr.code() == error_code_persist_new_audit_metadata_error ||
 			     retryErr.code() == error_code_audit_storage_cancelled ||
-			     retryErr.code() == error_code_audit_storage_task_outdated) &&
+			     retryErr.code() == error_code_audit_storage_task_outdated ||
+			     (retryErr.code() == error_code_timed_out && !auditScheduled)) &&
 			    auditRetryCount < maxAuditRetries) {
 				++auditRetryCount;
 				TraceEvent(SevWarn, "RangeDigestValidationAuditRetry")

--- a/fdbserver/workloads/RangeDigestValidation.cpp
+++ b/fdbserver/workloads/RangeDigestValidation.cpp
@@ -32,9 +32,13 @@
 #include "fdbclient/Audit.h"
 #include "fdbclient/AuditUtils.h"
 #include "fdbclient/ClusterConnectionFile.h"
+#include "fdbclient/DatabaseConfiguration.h"
+#include "fdbclient/KeyRangeMap.h"
 #include "fdbclient/ManagementAPI.h"
 #include "fdbclient/NativeAPI.h"
 #include "fdbclient/RangeDigest.h"
+#include "fdbclient/SystemData.h"
+#include "fdbserver/core/QuietDatabase.h"
 #include "fdbserver/tester/workloads.h"
 
 struct RangeDigestValidationWorkload : TestWorkload {
@@ -55,6 +59,9 @@ struct RangeDigestValidationWorkload : TestWorkload {
 	int expectMinShards;
 	double shardSettleTimeout;
 	bool strictShardCheck;
+	double quiesceTimeout;
+	double exclusionTimeout;
+	bool forceMovementBetweenDigests;
 	// A run is only meaningful if the content comparison actually executed. Absent this, every error
 	// path is a silent skip and a permanently broken digest still yields a green test.
 	bool validated = false;
@@ -75,6 +82,9 @@ struct RangeDigestValidationWorkload : TestWorkload {
 		expectMinShards = getOption(options, "expectMinShards"_sr, 2);
 		shardSettleTimeout = getOption(options, "shardSettleTimeout"_sr, 60.0);
 		strictShardCheck = getOption(options, "strictShardCheck"_sr, false);
+		quiesceTimeout = getOption(options, "quiesceTimeout"_sr, 120.0);
+		exclusionTimeout = getOption(options, "exclusionTimeout"_sr, 180.0);
+		forceMovementBetweenDigests = getOption(options, "forceMovementBetweenDigests"_sr, true);
 	}
 
 	Future<Void> setup(Database const& cx) override {
@@ -181,6 +191,184 @@ struct RangeDigestValidationWorkload : TestWorkload {
 			co_await tr.onError(err);
 		}
 	}
+
+	// Canonical description of how normalKeys is currently partitioned AND who owns each piece, so a
+	// repartition can be demonstrated rather than assumed. Ownership matters independently of
+	// boundaries: relocating a shard to a different team changes which server folds those keys while
+	// leaving the boundary list identical.
+	//
+	// `owners`, when non-null, collects the servers currently holding any of normalKeys. Excluding a
+	// server outside that set relocates nothing, which at this dataset size is the common case: ~1MB
+	// spread over a triple-replicated 18-machine cluster leaves most servers holding no rdv/ keys at all.
+	Future<std::string> capturePartition(Database cx, std::set<UID>* owners = nullptr) {
+		Transaction tr(cx);
+		tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+		tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+		while (true) {
+			Error err;
+			try {
+				RangeResult shards = co_await krmGetRanges(
+				    &tr, keyServersPrefix, normalKeys, CLIENT_KNOBS->TOO_MANY, CLIENT_KNOBS->TOO_MANY);
+				RangeResult UIDtoTagMap = co_await tr.getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY);
+				ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
+				std::string out;
+				if (owners != nullptr) {
+					owners->clear();
+				}
+				for (int i = 0; i + 1 < shards.size(); ++i) {
+					std::vector<UID> src, dest;
+					UID srcId, destId;
+					decodeKeyServersValue(UIDtoTagMap, shards[i].value, src, dest, srcId, destId);
+					std::sort(src.begin(), src.end());
+					out += shards[i].key.toString() + "=";
+					for (const UID& id : src) {
+						out += id.shortString() + ",";
+						if (owners != nullptr) {
+							owners->insert(id);
+						}
+					}
+					out += ";";
+				}
+				co_return out;
+			} catch (Error& e) {
+				err = e;
+			}
+			co_await tr.onError(err);
+		}
+	}
+
+	// Wait for data distribution to go idle. The digest requires a quiescent cluster: every server
+	// folds at its own read version, and the additive combine assumes each key-value is folded exactly
+	// once, so a shard in flight can be counted by both the losing and the gaining server or by
+	// neither. Digesting mid-movement is not a theoretical hazard -- at 100M scale it produced a root
+	// over-counting ~104.8M against a true ~100M.
+	//
+	// Returns false on timeout so the caller can decline to assert rather than digest a moving cluster.
+	Future<bool> waitForQuiescence(Database cx, double timeoutSeconds) {
+		double start = now();
+		while (now() - start < timeoutSeconds) {
+			Error err;
+			try {
+				int64_t inFlight = co_await getDataInFlight(cx, dbInfo);
+				int64_t queueSize = co_await getDataDistributionQueueSize(cx, dbInfo, /*reportInFlight=*/true);
+				if (inFlight == 0 && queueSize == 0) {
+					TraceEvent("RangeDigestValidationQuiesced").detail("Elapsed", now() - start);
+					co_return true;
+				}
+			} catch (Error& e) {
+				err = e;
+			}
+			if (err.code() == error_code_actor_cancelled) {
+				throw err;
+			}
+			if (err.code() != invalid_error_code) {
+				// These metrics come from per-worker event logs, so they throw (attribute_not_found when
+				// a server's worker cannot be found, timed_out when it does not answer) exactly while the
+				// cluster is churning -- which is when this is called. Not being able to observe
+				// quiescence is not evidence of it, so keep polling and let the timeout be the only exit.
+				TraceEvent(SevInfo, "RangeDigestValidationQuiesceProbeFailed")
+				    .error(err)
+				    .detail("Elapsed", now() - start);
+			}
+			co_await delay(1.0);
+		}
+		TraceEvent(SevWarn, "RangeDigestValidationQuiesceTimeout").detail("Timeout", timeoutSeconds);
+		co_return false;
+	}
+
+	// Force a repartition between the two digests by excluding one storage server, so DD relocates its
+	// shards onto other teams. Without this the second digest re-runs over the same layout and asserts
+	// only that a deterministic fold is deterministic -- it would pass even if the digest were
+	// partition-DEPENDENT, which is the one property the whole before/after comparison rests on.
+	//
+	// Uses exclusion rather than a direct moveKeys: this audit is driven by data distribution, so
+	// setDDMode(0) (which RandomMoveKeys needs to take the moveKeys lock) risks stalling the very
+	// mechanism under test.
+	//
+	// Returns false when no repartition was performed. That is never a failure: a simulated cluster
+	// that cannot spare a server must not turn this test red.
+	Future<bool> forceRepartition(Database cx) {
+		// Read the configured replication factor rather than assuming triple: excluding down to exactly
+		// the replica count leaves DD no destination team and the exclusion never completes.
+		DatabaseConfiguration configuration;
+		{
+			Transaction tr(cx);
+			while (true) {
+				Error err;
+				try {
+					tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+					tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+					RangeResult res = co_await tr.getRange(configKeys, 1000);
+					ASSERT(!res.more);
+					for (const auto& kv : res) {
+						configuration.set(kv.key, kv.value);
+					}
+					break;
+				} catch (Error& e) {
+					err = e;
+				}
+				co_await tr.onError(err);
+			}
+		}
+
+		// Only a server that actually holds part of normalKeys is worth excluding; draining a server
+		// with no rdv/ keys relocates nothing and leaves the layout identical, which is what happens on
+		// most seeds because the dataset is far smaller than the fleet.
+		std::set<UID> owners;
+		co_await capturePartition(cx, &owners);
+
+		std::vector<StorageServerInterface> servers = co_await getStorageServers(cx);
+		std::vector<StorageServerInterface> candidates;
+		int nonTssCount = 0;
+		for (const auto& ss : servers) {
+			if (ss.isTss()) {
+				continue;
+			}
+			++nonTssCount;
+			if (owners.count(ss.id()) > 0) {
+				candidates.push_back(ss);
+			}
+		}
+		if (nonTssCount <= configuration.storageTeamSize + 1 || candidates.empty()) {
+			TraceEvent(SevWarn, "RangeDigestValidationSkipRepartition")
+			    .detail("Reason", candidates.empty() ? "NoServerOwnsAuditRange" : "TooFewStorageServers")
+			    .detail("NonTssServers", nonTssCount)
+			    .detail("OwningCandidates", candidates.size())
+			    .detail("StorageTeamSize", configuration.storageTeamSize);
+			co_return false;
+		}
+
+		const StorageServerInterface victim = candidates[deterministicRandom()->randomInt(0, candidates.size())];
+		AddressExclusion exclusion(victim.address().ip, victim.address().port);
+		TraceEvent("RangeDigestValidationExcluding").detail("Server", victim.id()).detail("Address", victim.address());
+		try {
+			co_await excludeServers(cx, std::vector<AddressExclusion>{ exclusion });
+			// waitForAllExcluded: return only once the server holds no data, i.e. the relocation the
+			// repartition depends on has actually happened.
+			Optional<std::set<NetworkAddress>> excluded = co_await timeout(
+			    checkForExcludingServers(cx, std::vector<AddressExclusion>{ exclusion }, /*waitForAllExcluded=*/true),
+			    exclusionTimeout);
+			if (!excluded.present()) {
+				TraceEvent(SevWarn, "RangeDigestValidationSkipRepartition")
+				    .detail("Reason", "ExclusionTimedOut")
+				    .detail("Server", victim.id());
+				co_await includeServers(cx, std::vector<AddressExclusion>(1));
+				co_return false;
+			}
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw e;
+			}
+			TraceEvent(SevWarn, "RangeDigestValidationSkipRepartition")
+			    .error(e)
+			    .detail("Reason", "ExclusionFailed")
+			    .detail("Server", victim.id());
+			co_return false;
+		}
+		TraceEvent("RangeDigestValidationExcluded").detail("Server", victim.id());
+		co_return true;
+	}
+
 	// Retries the whole audit on transient cluster errors (e.g. movekeys_conflict during DD failover),
 	// mirroring RestoreValidation's tolerance for buggify-induced instability.
 	Future<RangeDigestSummary> runOneDigest(Database cx) {
@@ -305,13 +493,48 @@ struct RangeDigestValidationWorkload : TestWorkload {
 		ExpectedDigest expected;
 		RangeDigestSummary first;
 		RangeDigestSummary second;
+		bool repartitioned = false;
+		bool partitionActuallyChanged = false;
 		try {
+			// The audit requires a quiescent cluster. The load above is small enough that DD normally
+			// settles long before this, but relying on that is relying on the dataset staying small.
+			if (!co_await waitForQuiescence(cx, quiesceTimeout)) {
+				TraceEvent(SevWarnAlways, "RangeDigestValidationInconclusive")
+				    .detail("Reason", "Cluster never quiesced before the first digest");
+				co_return;
+			}
+
 			expected = co_await computeExpectedDigest(cx);
 			TraceEvent("RangeDigestValidationExpected")
 			    .detail("Root", expected.digest.toHex())
 			    .detail("KVCount", expected.kvCount)
 			    .detail("Bytes", expected.byteCount);
 			first = co_await runOneDigest(cx);
+
+			// Repartition between the digests so the second one is taken over a different physical
+			// layout. Without this the second digest only re-confirms determinism.
+			std::string partitionBefore = co_await capturePartition(cx);
+			if (forceMovementBetweenDigests) {
+				repartitioned = co_await forceRepartition(cx);
+			}
+			if (repartitioned) {
+				// The exclusion guarantees the excluded server is drained, not that the cluster as a
+				// whole is idle; DD keeps rebalancing after. Digesting now would re-create the 100M
+				// over-count, so settle before the second digest rather than after re-including.
+				if (!co_await waitForQuiescence(cx, quiesceTimeout)) {
+					TraceEvent(SevWarnAlways, "RangeDigestValidationInconclusive")
+					    .detail("Reason", "Cluster never re-quiesced after the forced repartition");
+					co_await includeServers(cx, std::vector<AddressExclusion>(1));
+					co_return;
+				}
+				std::string partitionAfter = co_await capturePartition(cx);
+				partitionActuallyChanged = partitionAfter != partitionBefore;
+				TraceEvent("RangeDigestValidationRepartitioned")
+				    .detail("PartitionChanged", partitionActuallyChanged)
+				    .detail("ShardsBefore", std::count(partitionBefore.begin(), partitionBefore.end(), ';'))
+				    .detail("ShardsAfter", std::count(partitionAfter.begin(), partitionAfter.end(), ';'));
+			}
+
 			second = co_await runOneDigest(cx);
 		} catch (Error& e) {
 			if (e.code() == error_code_actor_cancelled) {
@@ -336,10 +559,15 @@ struct RangeDigestValidationWorkload : TestWorkload {
 			    .detail("ExpectedBytes", expected.byteCount);
 			ASSERT(false);
 		}
+		// When the layout provably changed, this is a partition-independence assertion; otherwise it
+		// degrades to the determinism check it has always been. PartitionChanged distinguishes the two
+		// in the trace, so a green run cannot be mistaken for the stronger claim.
 		if (second.root != first.root) {
 			TraceEvent(SevError, "RangeDigestValidationNondeterministicRoot")
 			    .detail("FirstRoot", first.root.toHex())
-			    .detail("SecondRoot", second.root.toHex());
+			    .detail("SecondRoot", second.root.toHex())
+			    .detail("Repartitioned", repartitioned)
+			    .detail("PartitionChanged", partitionActuallyChanged);
 			ASSERT(false);
 		}
 
@@ -347,8 +575,15 @@ struct RangeDigestValidationWorkload : TestWorkload {
 		    .detail("Root", first.root.toHex())
 		    .detail("KVCount", first.kvCount)
 		    .detail("Bytes", first.byteCount)
-		    .detail("Shards", shards);
+		    .detail("Shards", shards)
+		    .detail("Repartitioned", repartitioned)
+		    .detail("PartitionChanged", partitionActuallyChanged);
 		validated = true;
+		if (repartitioned) {
+			// Leave the fleet as we found it for any workload that follows and for the end-of-test
+			// quiescence check.
+			co_await includeServers(cx, std::vector<AddressExclusion>(1));
+		}
 	}
 };
 

--- a/fdbserver/workloads/RangeDigestValidation.cpp
+++ b/fdbserver/workloads/RangeDigestValidation.cpp
@@ -25,9 +25,15 @@
 //      against an INDEPENDENT client-side computation of the same additive digest (scanning
 //      every key-value and applying the canonical leaf encoding). This validates the SS fold
 //      and the DD combine.
-//   4. It triggers a SECOND RangeDigest audit and asserts the root is identical. DD may have
-//      moved shards in between, but nothing here forces it to, so this is a determinism check
-//      that additionally covers partition-independence on the seeds where movement occurred.
+//   4. It forces a repartition (excluding a storage server that owns part of the range), then
+//      triggers a SECOND RangeDigest audit and asserts the root is identical. Because the layout
+//      really changed, this asserts partition-independence and not merely that a deterministic fold
+//      is deterministic. On a cluster too small to spare a server the repartition is skipped and the
+//      run degrades to a determinism check, recorded as PartitionChanged=0.
+//
+// Every digest is preceded by a wait for quiescence (data in flight and the DD queue both drained),
+// which is the precondition the digest requires; a timeout there is reported as inconclusive rather
+// than asserted on.
 
 #include "fdbclient/Audit.h"
 #include "fdbclient/AuditUtils.h"

--- a/fdbserver/workloads/RangeDigestValidation.cpp
+++ b/fdbserver/workloads/RangeDigestValidation.cpp
@@ -1,0 +1,346 @@
+/*
+ * RangeDigestValidation.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// RangeDigestValidationWorkload exercises the RangeDigest audit end to end in simulation:
+//   1. Client 0 writes a set of known key-values into the user keyspace.
+//   2. It triggers a RangeDigest audit over normalKeys and waits for completion.
+//   3. It reads the cluster root DD combined from the per-range digests and cross-checks it
+//      against an INDEPENDENT client-side computation of the same additive digest (scanning
+//      every key-value and applying the canonical leaf encoding). This validates the SS fold
+//      and the DD combine.
+//   4. It triggers a SECOND RangeDigest audit and asserts the root is identical. DD may have
+//      moved shards in between, but nothing here forces it to, so this is a determinism check
+//      that additionally covers partition-independence on the seeds where movement occurred.
+
+#include "fdbclient/Audit.h"
+#include "fdbclient/AuditUtils.h"
+#include "fdbclient/ClusterConnectionFile.h"
+#include "fdbclient/ManagementAPI.h"
+#include "fdbclient/NativeAPI.h"
+#include "fdbclient/RangeDigest.h"
+#include "fdbserver/tester/workloads.h"
+
+struct RangeDigestValidationWorkload : TestWorkload {
+	static constexpr auto NAME = "RangeDigestValidation";
+
+	// Independent expected-digest computation result.
+	struct ExpectedDigest {
+		RangeDigest digest;
+		int64_t kvCount = 0;
+		int64_t byteCount = 0;
+	};
+
+	int nodeCount;
+	int valueBytes;
+	double validateAfter;
+	double checkInterval;
+	double maxWaitTime;
+	int expectMinShards;
+	double shardSettleTimeout;
+	bool strictShardCheck;
+	// A run is only meaningful if the content comparison actually executed. Absent this, every error
+	// path is a silent skip and a permanently broken digest still yields a green test.
+	bool validated = false;
+
+	explicit RangeDigestValidationWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
+		// Defaults are modest so the dataset fits the simulation `memory` storage engine and the test
+		// stays cheap in the Joshua matrix. For a dedicated multi-shard/throughput run, override
+		// nodeCount/valueBytes/expectMinShards/strictShardCheck via the TOML.
+		nodeCount = getOption(options, "nodeCount"_sr, 10000);
+		valueBytes = getOption(options, "valueBytes"_sr, 100);
+		validateAfter = getOption(options, "validateAfter"_sr, 5.0);
+		checkInterval = getOption(options, "checkInterval"_sr, 2.0);
+		maxWaitTime = getOption(options, "maxWaitTime"_sr, 120.0);
+		// Splitting into several shards exercises the cross-shard/cross-server combine. In the
+		// randomized Joshua matrix a seed may keep everything in one shard (shard-size knob is forced
+		// to 400KB/2MB/10MB, not the min_shard_bytes knob), so by default this is best-effort (a warning,
+		// not a failure). strictShardCheck=true makes it a hard requirement for dedicated runs.
+		expectMinShards = getOption(options, "expectMinShards"_sr, 2);
+		shardSettleTimeout = getOption(options, "shardSettleTimeout"_sr, 60.0);
+		strictShardCheck = getOption(options, "strictShardCheck"_sr, false);
+	}
+
+	Future<Void> setup(Database const& cx) override {
+		if (clientId == 0) {
+			return loadData(cx);
+		}
+		return Void();
+	}
+
+	Future<Void> start(Database const& cx) override {
+		if (clientId == 0) {
+			return _start(cx);
+		}
+		return Void();
+	}
+
+	Future<bool> check(Database const& cx) override { return clientId != 0 || validated; }
+	void getMetrics(std::vector<PerfMetric>& m) override {}
+
+	static Key testKey(int i) { return StringRef(format("rdv/%08d", i)); }
+
+	// Deterministic, per-key-unique value of length valueBytes.
+	Value testValue(int i) {
+		std::string base = format("value-%08d-", i);
+		std::string v = base;
+		v.reserve(valueBytes);
+		// Pad with a repeating pattern seeded by the index so content is unique per key.
+		char fill = (char)('A' + (i % 26));
+		while ((int)v.size() < valueBytes) {
+			v.push_back(fill);
+		}
+		v.resize(std::max<int>(valueBytes, (int)base.size()));
+		return Value(StringRef(v));
+	}
+
+	Future<Void> loadData(Database cx) {
+		int i = 0;
+		int batchSize = 100;
+		while (i < nodeCount) {
+			Transaction tr(cx);
+			while (true) {
+				Error err;
+				try {
+					int end = std::min(i + batchSize, nodeCount);
+					for (int j = i; j < end; ++j) {
+						tr.set(testKey(j), testValue(j));
+					}
+					co_await tr.commit();
+					i = end;
+					break;
+				} catch (Error& e) {
+					err = e;
+				}
+				co_await tr.onError(err);
+			}
+		}
+		TraceEvent("RangeDigestValidationDataLoaded")
+		    .detail("NodeCount", nodeCount)
+		    .detail("ValueBytes", valueBytes)
+		    .detail("ApproxTotalBytes", (int64_t)nodeCount * (valueBytes + 12));
+	}
+
+	// Independently compute the expected additive digest by scanning every key-value in normalKeys.
+	Future<ExpectedDigest> computeExpectedDigest(Database cx) {
+		ExpectedDigest out;
+		Key begin = normalKeys.begin;
+		while (true) {
+			Transaction tr(cx);
+			Error err;
+			try {
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+				RangeResult res = co_await tr.getRange(KeyRangeRef(begin, normalKeys.end), 1000);
+				for (const auto& kv : res) {
+					out.digest.addKeyValue(kv.key, kv.value);
+					++out.kvCount;
+					out.byteCount += kv.key.size() + kv.value.size();
+				}
+				if (!res.more || res.empty()) {
+					co_return out;
+				}
+				begin = keyAfter(res.back().key);
+				continue;
+			} catch (Error& e) {
+				err = e;
+			}
+			co_await tr.onError(err);
+		}
+	}
+
+	// Count the shards spanning normalKeys. getRangeSplitPoints with a large chunk size returns only
+	// the shard boundaries (plus begin/end), so shardCount == splitPoints.size() - 1.
+	Future<int> countShards(Database cx) {
+		while (true) {
+			Transaction tr(cx);
+			Error err;
+			try {
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+				Standalone<VectorRef<KeyRef>> splitPoints =
+				    co_await tr.getRangeSplitPoints(normalKeys, /*chunkSize=*/10000000);
+				co_return std::max(0, (int)splitPoints.size() - 1);
+			} catch (Error& e) {
+				err = e;
+			}
+			co_await tr.onError(err);
+		}
+	}
+	// Retries the whole audit on transient cluster errors (e.g. movekeys_conflict during DD failover),
+	// mirroring RestoreValidation's tolerance for buggify-induced instability.
+	Future<RangeDigestSummary> runOneDigest(Database cx) {
+		Reference<IClusterConnectionRecord> clusterFile = cx->getConnectionRecord();
+		int auditRetryCount = 0;
+		int maxAuditRetries = 10;
+		while (true) {
+			Error retryErr;
+			try {
+				UID auditId = co_await auditStorage(
+				    clusterFile, normalKeys, AuditType::RangeDigest, KeyValueStoreType::END, maxWaitTime);
+				TraceEvent("RangeDigestValidationAuditScheduled")
+				    .detail("AuditID", auditId)
+				    .detail("RetryCount", auditRetryCount);
+
+				double startTime = now();
+				bool done = false;
+				AuditStorageState finalState;
+				while (!done) {
+					co_await delay(checkInterval);
+					AuditStorageState st = co_await getAuditState(cx, AuditType::RangeDigest, auditId);
+					if (st.getPhase() == AuditPhase::Complete) {
+						finalState = st;
+						done = true;
+						break;
+					}
+					if (st.getPhase() == AuditPhase::Error || st.getPhase() == AuditPhase::Failed) {
+						TraceEvent(SevWarn, "RangeDigestValidationAuditPhaseFailed")
+						    .detail("AuditID", auditId)
+						    .detail("Phase", (int)st.getPhase())
+						    .detail("Error", st.error);
+						throw audit_storage_failed();
+					}
+					if (now() - startTime > maxWaitTime) {
+						TraceEvent(SevWarn, "RangeDigestValidationTimeout").detail("AuditID", auditId);
+						throw timed_out();
+					}
+				}
+
+				// The combined root is stored in the top-level audit record on completion (the
+				// per-range progress is cleared by then).
+				RangeDigestSummary summary;
+				summary.root = RangeDigest::fromBytes(finalState.digest);
+				summary.kvCount = finalState.kvCount;
+				summary.byteCount = finalState.byteCount;
+				summary.complete = true;
+				TraceEvent("RangeDigestValidationAuditRoot")
+				    .detail("AuditID", auditId)
+				    .detail("Root", summary.root.toHex())
+				    .detail("KVCount", summary.kvCount)
+				    .detail("Bytes", summary.byteCount)
+				    .detail("Complete", summary.complete);
+				co_return summary;
+			} catch (Error& e) {
+				retryErr = e;
+			}
+			if (retryErr.code() == error_code_actor_cancelled) {
+				throw retryErr;
+			}
+			// audit_storage_failed and related transient conditions are retryable under buggify.
+			if ((retryErr.code() == error_code_audit_storage_failed ||
+			     retryErr.code() == error_code_persist_new_audit_metadata_error ||
+			     retryErr.code() == error_code_audit_storage_cancelled ||
+			     retryErr.code() == error_code_audit_storage_task_outdated) &&
+			    auditRetryCount < maxAuditRetries) {
+				++auditRetryCount;
+				TraceEvent(SevWarn, "RangeDigestValidationAuditRetry")
+				    .error(retryErr)
+				    .detail("RetryCount", auditRetryCount)
+				    .detail("MaxRetries", maxAuditRetries);
+				co_await delay(std::min(10.0, 2.0 * auditRetryCount));
+			} else {
+				throw retryErr;
+			}
+		}
+	}
+
+	Future<Void> _start(Database cx) {
+		co_await delay(validateAfter);
+
+		// Best-effort wait for DD to split the data into multiple shards so the additive combine is
+		// exercised across shards/servers. NOT reaching expectMinShards is not a correctness failure in
+		// the randomized Joshua matrix (some seeds keep one shard), so only warn -- unless
+		// strictShardCheck is set for a dedicated multi-shard run.
+		double settleStart = now();
+		int shards = 0;
+		while (true) {
+			shards = co_await countShards(cx);
+			if (shards >= expectMinShards) {
+				break;
+			}
+			if (now() - settleStart > shardSettleTimeout) {
+				if (strictShardCheck) {
+					TraceEvent(SevError, "RangeDigestValidationTooFewShards")
+					    .detail("Shards", shards)
+					    .detail("ExpectMinShards", expectMinShards);
+					ASSERT(false);
+				}
+				TraceEvent(SevWarn, "RangeDigestValidationFewShards")
+				    .detail("Shards", shards)
+				    .detail("ExpectMinShards", expectMinShards);
+				break;
+			}
+			co_await delay(2.0);
+		}
+		TraceEvent("RangeDigestValidationShardsReady").detail("Shards", shards).detail("ExpectMin", expectMinShards);
+
+		// Run the independent computation and the two SS-side audits. runOneDigest already retries the
+		// transient audit errors, so an error escaping to here means the digest never completed and the
+		// comparison never ran -- check() fails on !validated rather than reporting a green skip. The
+		// strict content asserts below run OUTSIDE this try so a genuine mismatch (which throws
+		// internal_error via ASSERT) is never swallowed.
+		ExpectedDigest expected;
+		RangeDigestSummary first;
+		RangeDigestSummary second;
+		try {
+			expected = co_await computeExpectedDigest(cx);
+			TraceEvent("RangeDigestValidationExpected")
+			    .detail("Root", expected.digest.toHex())
+			    .detail("KVCount", expected.kvCount)
+			    .detail("Bytes", expected.byteCount);
+			first = co_await runOneDigest(cx);
+			second = co_await runOneDigest(cx);
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) {
+				throw e;
+			}
+			TraceEvent(SevWarnAlways, "RangeDigestValidationDidNotComplete")
+			    .error(e)
+			    .detail("Reason", "Audit never reached Complete; content comparison did not run");
+			co_return;
+		}
+
+		// Both audits completed, and DD publishes a root only over fully-tiled coverage, so any
+		// disagreement here is a genuine correctness violation -> hard fail.
+		if (first.root != expected.digest || first.kvCount != expected.kvCount ||
+		    first.byteCount != expected.byteCount) {
+			TraceEvent(SevError, "RangeDigestValidationMismatchVsExpected")
+			    .detail("AuditRoot", first.root.toHex())
+			    .detail("ExpectedRoot", expected.digest.toHex())
+			    .detail("AuditKV", first.kvCount)
+			    .detail("ExpectedKV", expected.kvCount)
+			    .detail("AuditBytes", first.byteCount)
+			    .detail("ExpectedBytes", expected.byteCount);
+			ASSERT(false);
+		}
+		if (second.root != first.root) {
+			TraceEvent(SevError, "RangeDigestValidationNondeterministicRoot")
+			    .detail("FirstRoot", first.root.toHex())
+			    .detail("SecondRoot", second.root.toHex());
+			ASSERT(false);
+		}
+
+		TraceEvent("RangeDigestValidationSuccess")
+		    .detail("Root", first.root.toHex())
+		    .detail("KVCount", first.kvCount)
+		    .detail("Bytes", first.byteCount)
+		    .detail("Shards", shards);
+		validated = true;
+	}
+};
+
+WorkloadFactory<RangeDigestValidationWorkload> RangeDigestValidationWorkloadFactory;

--- a/fdbserver/workloads/RangeDigestValidation.cpp
+++ b/fdbserver/workloads/RangeDigestValidation.cpp
@@ -325,7 +325,7 @@ struct RangeDigestValidationWorkload : TestWorkload {
 				continue;
 			}
 			++nonTssCount;
-			if (owners.count(ss.id()) > 0) {
+			if (owners.contains(ss.id())) {
 				candidates.push_back(ss);
 			}
 		}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -150,6 +150,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES fast/BackupToDBCorrectness.toml)
   add_fdb_test(TEST_FILES fast/BackupToDBCorrectnessClean.toml)
   add_fdb_test(TEST_FILES fast/RestoreValidation.toml)
+  add_fdb_test(TEST_FILES fast/RangeDigestValidation.toml)
 
   add_fdb_test(TEST_FILES fast/BulkDumping.toml)
   add_fdb_test(TEST_FILES slow/BulkDumpingS3.toml)

--- a/tests/fast/RangeDigestValidation.toml
+++ b/tests/fast/RangeDigestValidation.toml
@@ -1,0 +1,21 @@
+[configuration]
+config = 'triple'
+# No fearless/multi-region configs: RangeDigest is region-agnostic (SS-local fold + additive combine),
+# and multi-region (usable_regions=2, two_satellite_*) configs are prone to QuietDatabaseNeverFullyRecovered
+# quiescence timeouts unrelated to the audit. Multi-region audit paths are covered by ValidateStorage.
+generateFearless = false
+machineCount = 18
+
+[[test]]
+testTitle = 'RangeDigestValidation'
+useDB = true
+
+    # Modest dataset so it fits the simulation `memory` storage engine and stays cheap across the
+    # Joshua matrix. Shard spread is best-effort here (some seeds keep a single shard); the strict
+    # multi-shard/throughput exercise is a dedicated run with larger nodeCount/valueBytes +
+    # strictShardCheck=true. Correctness (root == independent computation, determinism) is validated
+    # at any shard count.
+    [[test.workload]]
+    testName = 'RangeDigestValidation'
+    nodeCount = 10000
+    valueBytes = 100


### PR DESCRIPTION
# Add AuditType::RangeDigest: a storage-server-side content fingerprint

## Summary

Adds `AuditType::RangeDigest`, a 256-bit **content fingerprint** of the key-value multiset computed
in parallel by the storage servers that already hold the data. A root taken before a backup equals
the root taken after a restore **iff** the restored data is identical as a set — regardless of how
the two clusters shard the keyspace.

This gives backup/restore validation a check that is both rigorous (every key-value, no sampling)
and affordable at multi-terabyte scale: only 32-byte digests cross the network, never user data, so
throughput scales with the number of storage servers rather than one client's bandwidth.

Design doc: `design/range-digest.md` (included in this PR).

## Since review (@neethuhaneesha)

Rebased onto current `main`, which now includes #13886.

- **`root` subcommand removed.** You were right that it was redundant: everything it printed is on
  the record `id` reports, which also shows the phase. It was worse than redundant — it rendered the
  digest via `RangeDigest::fromBytes(...).toHex()`, which zero-fills a wrong-length state to 64 hex
  characters, so an ungated read would print a well-formed all-zero root. `id` prints the raw bytes,
  which are empty when unset, so removing the subcommand also removed the reason its `Complete` gate
  existed. The companion harness now parses the record instead ([PR #897]) — compatible with old and
  new `fdbcli`, so the two can land in either order.
- **Empty value at a krm boundary** (`AuditUtils.cpp`): normal boundary-map encoding — `krmGetRanges`
  returns n+1 entries for n ranges and an empty value means no row covers that region. Comment now
  says so rather than just "not persisted yet".
- **The `continue`**: also right. Only the *first* offending range was ever retained, so the rest of
  the walk fed a summary the caller discards on retry — which post-#13886 means re-reading ~72,000
  rows for a 9 TB dataset on every retry. It now stops at the first uncountable range, while still
  emitting its terminal trace event. Applied at both rejection sites, not just the one flagged.
- **Data movement between the two digests**: added, and it mattered more than expected. The old
  second digest re-ran over the *same* layout on most seeds, so it would have passed even if the
  digest were partition-dependent — the one property the before/after comparison rests on. The
  workload now excludes a server that actually owns part of the audited range and asserts over the
  resulting layout. Two findings while doing it: excluding a *random* server changes nothing at this
  dataset size (most hold no `rdv/` keys, and the run then reports `PartitionChanged=0`), and the
  workload had **no quiescence gate at all** — it satisfied the documented precondition only because
  the dataset was too small to churn. Forcing movement without one reproduces the 100M over-count,
  so a `moving_data → 0` gate went in with it.
- **Pinpointing corrupt keys**: the per-range digests are what you localize with, and every server
  already emits them as `SSAuditRangeDigestComplete`. `get_audit_status range_digest progress <id>`
  now prints them too while the audit is Running. The design doc had claimed re-audit bisection was
  the mechanism; that needs *both* datasets to still exist, which is false for the backup/restore
  case this was built for, since the source keyspace is cleared before the restore. Corrected.
- Documentation: `documentation/sphinx/source/auditstorage.rst` now covers `range_digest`.

[PR #897]: https://github.com/FoundationDB/fdb-kubernetes-tests/pull/897

## Motivation

A backup of a multi-terabyte database is only trustworthy if the restore can be confirmed to
reproduce it. The obvious check — a client reads the whole keyspace and hashes it — was built first
as an external prototype (`fdbfingerprint`) and produced matching roots at 1B and 3B. It was
abandoned as the mechanism on **measured** cost: the 3B dataset took **9h11m at ~79 MB/s
aggregate**, with all of that read load landing on the very path under validation, and a
before/after comparison needs two such runs.

One qualification, since the numbers invite an overclaim: that 79 MB/s was **not a hard client
ceiling** — it was ~4 MB/s across 20 disks that sat ~98% idle, i.e. an under-parallelized prototype
(8 pods, each a single-network-thread client unable to hide cold-read latency). A tuned client would
be considerably faster, so no ratio between it and the server-side digest is like-for-like and none
is claimed here.

The architectural argument stands without the ratio: an external fingerprint scales with whatever
bandwidth one client pool is given and spends read capacity production traffic needs, while hashing
on the servers that already hold the data scales with storage-server count and moves only 32-byte
digests.

The check must also be **partition-independent**: a restore lands the same logical data under
completely different shard boundaries, so any fingerprint that depends on the physical partition
(Merkle tree over a shard list, per-shard hash comparison) cannot be compared across a restore at
all. Hence an additive multiset hash.

## Design

```
leaf  = SHA-256( u32be len(key) | key | u32be len(value) | value )
digest = ( Σ leaf ) mod 2^256          # 256-bit big-endian accumulator, 0 = empty set
root   = combine of every storage server's per-range digest
```

Addition mod 2²⁵⁶ is associative and commutative, so the root is independent of grouping, ordering
and shard layout — the partition-independence requirement — and per-range digests combine upward
with no boundary replay. 256 bits matches the SHA-256 leaf (no truncation) and leaves a ~2¹²⁸
accidental-collision margin against datasets of ~2³³ keys, for 32 bytes per range on the wire.

The leaf encoding is byte-for-byte identical to the Phase-0 `fdbfingerprint` tool, which is retained
as an independent cross-check.

**Explicit non-goal:** collision resistance against an adversary who *chooses* inputs. Additive
multiset hashes are vulnerable to subset-sum/lattice attacks; the threat model here is accidental
corruption of FDB's own data on a trusted cluster, so a keyed MAC's key management and cost buy
nothing in scope. This is stated in the design doc rather than left implicit.

## Precondition: quiescence

The digest must be taken over a quiescent cluster (writes stopped, `moving_data → 0`). Two
independent invariants require it:

1. **Single version** — each server folds its own key-values at *its own* current read version;
   there is no cluster-wide pinned version, so concurrent writes would hash at inconsistent
   versions and the root would correspond to no single snapshot.
2. **Exactly-once** — the additive combine assumes each key-value is folded exactly once
   cluster-wide. Under in-flight shard movement a key can be folded by both the losing and gaining
   server, or by neither at the instant it is read.

This is not theoretical: at 100M scale, digesting during data-distribution churn produced a root
mismatch, with both sides counting ~104.8M key-values against a true ~100M. Callers must settle
first — natural for backup/restore, where both sides are settled datasets.

`RangeDigest.h` carries a TODO for the generalization: folding every server against a single pinned
cluster read version, with an ownership snapshot consistent with that version, would restore both
invariants online. Unnecessary for backup/restore, and it would not change the leaf encoding or the
root of a quiesced dataset, so fingerprints taken today stay comparable.

## What's in the PR

| area | change |
|---|---|
| `fdbclient/RangeDigest.{h,cpp}` | new: leaf encoding, 256-bit accumulator, `addKeyValue`/`combine` |
| `fdbserver/storageserver/storageserver.cpp` | `auditRangeDigestQ`, dispatched from `serveAuditStorageRequests`; batched and rate-limited |
| `fdbserver/datadistributor/DataDistribution.cpp` | dispatch, per-range persistence, combine to a cluster root on Complete |
| `fdbclient/AuditUtils.cpp`, `Audit.h`, `AuditUtils.h` | `AuditType::RangeDigest = 7`; digest/kvCount/byteCount on the audit record; range-digest summary read |
| `fdbcli/AuditStorageCommand.cpp`, `GetAuditStatusCommand.cpp` | `range_digest` audit type; per-range digests in `get_audit_status range_digest progress <id>` |
| `fdbserver/workloads/RangeDigestValidation.cpp`, `tests/fast/RangeDigestValidation.toml` | simulation workload + test registration |
| `design/range-digest.md` | design doc |

Rate limiting and batching reuse the existing audit controls
(`AUDIT_STORAGE_RATE_PER_SERVER_MAX` via `SpeedLimit`, `AUDIT_RESTORE_BATCH_KEY_LIMIT`,
`REPLY_BYTE_LIMIT`) rather than introducing new knobs.

CLI surface:

```
audit_storage range_digest "" \xff          # start; prints the audit ID
get_audit_status range_digest id <id>       # phase, plus KVCount/Bytes/Digest for this type
get_audit_status range_digest progress <id> # per-range digests (while Running)
```

There is no separate root subcommand: `id` reports the record, whose `[Digest]` is the combined
cluster root once `[Phase]` is `Complete`. It renders the raw persisted bytes, so an audit that has
not published a root shows an empty `[Digest]` rather than a well-formed all-zero one. The combine
itself is guarded — if the persisted per-range digests do not tile the whole audit range, the audit
retries rather than publishing a root that silently omits keys.

## Compatibility

`AuditStorageState::serialize` gains three **appended** fields (`digest`, `kvCount`, `byteCount`).
With flatbuffers + `IncludeVersion`, old readers ignore trailing fields and new readers
default-initialize them for records written by older versions; existing field order is untouched.
The fields are empty/zero for every other audit type.

Otherwise additive and opt-in: a new `AuditType` invoked on demand, no on-disk format change to user
data, no effect on a cluster that never requests it. Rollback is simply not issuing the audit.

## Testing

- **Simulation** (`tests/fast/RangeDigestValidation.toml`): the workload writes a known key-value
  set, then (a) cross-checks the audit's combined root against an **independent client-side
  computation** of the same additive digest — scanning every key-value and applying the canonical
  leaf encoding, which validates the storage-server fold *and* the combine — and (b) **forces a
  repartition** by excluding a server that owns part of the audited range, re-quiesces, and asserts
  the root is unchanged over the new layout. It waits for `moving_data → 0` before each digest, and
  records `PartitionChanged` so a run that failed to relocate anything is visibly the weaker
  determinism check rather than silently passing as the stronger claim. Inability to repartition is
  reported, never asserted, so a cluster that cannot spare a server does not turn the test red. The
  backup → clear → restore → recompute cycle is covered by the Kubernetes test, not in simulation.
- **Local runs on this branch:** 18 seeds green, no `SevError`. Half were run with
  `AUDIT_TASK_MAX_BYTES=20000` so #13886 subdivides each shard into ~112 audit tasks (vs 2–5 by
  default); every one reported `PartitionChanged=1` with zero coverage-guard retries, which also
  confirms subdivided tasks still tile their audit range exactly — the condition the `RangeMismatch`
  check enforces.
- **Multi-shard combine** exercised on seeds 12345 / 777 / 424242 / 9001 (4–9 shards, up to 18 SS
  digest tasks): 0 `SevError`, all roots matching the independent computation.
- **Scale validation** via the companion Kubernetes test (`test_backup_restore_rangedigest`):
  `root_after == root_before` verified end-to-end at 100M, 1B, 3B and ~4.3B key-values.
- **It found a real data-loss bug at 10B.** A 9.26 TB run's roots disagreed by 935,560 key-values
  (0.0095%) while the restore reported success. The shortfall was 0.99x exactly one bulkload task; trace
  events named the task, and the range was empty on the restored cluster. Root cause and fix are #13873.
  A discrepancy that small is precisely what sampling or row counts would miss.
- **Measured throughput at 10B:** 9,257,887,466,305 bytes over 9,808,347,148 key-values digested in
  **53m07s — ~2770 MB/s aggregate** — on a 30-machine cluster with 4 storage disks per machine. The
  external Phase-0 client did the smaller 3B dataset in 9h11m at ~79 MB/s (see Motivation for why
  that is context, not a comparison).
- **Reproducibility:** that same 10B dataset re-digested to a byte-identical root on a later run
  against the same cluster, with no restore involved — so a matching root is not an artifact of
  digesting twice in quick succession.

### Reviewer notes — known gaps, stated rather than glossed

- **A skipped run is also green.** If an audit cannot complete under harness churn, the workload
  logs `RangeDigestValidationInconclusive` and returns without asserting. The content assertions sit
  deliberately *outside* that `try`, so a genuine mismatch is never swallowed — but it does mean a
  green result should be confirmed by the presence of `RangeDigestValidationSuccess` rather than the
  absence of errors. Worth deciding whether inconclusive runs should be made noisier.
- The committed `.toml` uses a modest dataset (`nodeCount=10000`) so it stays cheap across the
  Joshua matrix; **some seeds will keep the data in a single shard**, in which case that seed does
  not exercise the cross-server combine. The multi-shard evidence above comes from a larger
  dedicated run with `strictShardCheck=true`. Worth deciding whether a strict variant should gate
  here.
- Joshua gating: the earlier clean 100k ensemble predates both this review round and #13886, which
  subdivides audit tasks by `AUDIT_TASK_MAX_BYTES` (buggified on in simulation), so it did not
  exercise the current code. A fresh ensemble on the rebased branch should gate the merge.
- The digest is read-heavy, so its throughput is sensitive to the block-cache-to-data ratio; a
  low-memory configuration makes it disk-bound. An observability note, not a defect.

## Companion PR

The Kubernetes scale test that drives this (`test_backup_restore_rangedigest` in
`FoundationDB/fdb-kubernetes-tests`) is a separate PR and cannot run until this lands and is imaged.

