### PR TITLE
Document why bulkload needs DD pipeline headroom

### DIFF
--- a/documentation/sphinx/source/bulkload-user.rst
+++ b/documentation/sphinx/source/bulkload-user.rst
@@ -251,3 +251,5 @@ Troubleshooting
 As for backup, enable '--knob_http_verbose_level 10' to debug connection issues: the http request/response will be dumped on STDOUT.
 
 To watch your job in operation, search 'DDBulkLoad*', 'SSBulkLoad*', 'DDBulkDump*', 'SSBulkDump*', 'S3Client*' in trace events to see more details. 
+
+If a job makes no progress and you see 'DDPipelineFull' trace events, the data distribution pipeline is full and bulkload moves are waiting for admission rather than for capacity. Raise '--knob_dd_max_pipeline_moves' above the job's expected relocation demand, but keep it low enough that the data distributor can hold that many relocations in memory; see :doc:`bulkload` under "DD Pipeline Headroom" for sizing. A load into a previously empty range generates enough shard splits to fill a pipeline sized at the default of 1000.

--- a/documentation/sphinx/source/bulkload.rst
+++ b/documentation/sphinx/source/bulkload.rst
@@ -140,3 +140,34 @@ Performance Considerations
 - **Network Bandwidth**: Large SST files may saturate network bandwidth during downloads
 - **Storage Engine Impact**: Direct SST ingestion bypasses normal write paths for better performance
 - **Memory Usage**: SST files are typically loaded into memory for validation before application
+- **DD Pipeline Headroom**: ``DD_MAX_PIPELINE_MOVES`` must stay well above the cluster's peak relocation demand, or bulkload data moves are starved. See below.
+
+DD Pipeline Headroom
+~~~~~~~~~~~~~~~~~~~~
+``DD_MAX_PIPELINE_MOVES`` caps the total relocations DD tracks at once, queued plus in-flight.
+Bulkload is the workload most exposed to that cap, for three reasons that do not apply to ordinary data movement.
+
+**Bulkload moves are not throttled by source servers.**
+They read from blob storage rather than from source storage servers, so ``canLaunchSrc()`` admits them unconditionally and they consume no source work factor.
+Every other relocation is self-limiting through the per-server busyness ledger; bulkload is not, which can leave a pipeline cap as the only thing gating it.
+
+**Bulkload moves run at a low priority.**
+They use ``PRIORITY_TEAM_HEALTHY`` (140), while shard splits use ``PRIORITY_SPLIT_SHARD`` (950).
+Unlike other low-priority movement such as background rebalance, a bulkload job has a caller waiting on it.
+
+**A bulkload restore generates its own higher-priority competition.**
+Loading a large dataset into a previously empty, contiguous range causes DD to split that range, producing thousands of split relocations that then occupy the pipeline ahead of the bulkload moves that created them.
+
+``pipelineGateActor`` is priority-blind, so once the cap binds, admission becomes first-come-first-served in arrival order and a bulkload move cannot be reordered ahead of the splits it caused.
+This is an admission delay rather than a capacity limit: raising the cap adds no concurrency, which fetch, team and per-server budgets continue to bound, it only stops work being parked where the scheduler cannot see it.
+
+Measured on a 1B-key restore with the cap at 1000, no bulkload data move launched for 1h54m, 43% of the run, with ``InQueue`` 893 plus ``InFlight`` 107 pinned at exactly the cap.
+With headroom the first move launched in 7.15s, and in-flight moves were essentially unchanged at 107 to 114, showing the capacity to run them had been available throughout.
+A 3B-key restore reached 6041 to 6815 queued relocations during the same phase, roughly six times the default of 1000.
+
+**Raise the knob before starting a large bulkload job.**
+The default of 1000 corresponds to roughly 500 storage servers at two concurrent moves each, which a large load exceeds.
+Size it above the job's expected relocation demand but below what the data distributor can hold in memory: DD resident memory grows at roughly 4 GB plus 0.11 GB per 1000 tracked relocations, and in-flight moves converge on the cap while data movement is storming, so an excessive value stops functioning as a backstop.
+At 100000 the distributor needs roughly 15 GB and can exhaust an 8 GB or 12 GB memory limit before the cap ever engages, whereas 20000 costs roughly 6.2 GB and leaves ample headroom over the demand measured above.
+
+The symptom of an undersized cap is ``DDPipelineFull`` trace events during a load, with ``InQueue`` plus ``InFlight`` sitting at exactly the cap.


### PR DESCRIPTION
DD_MAX_PIPELINE_MOVES caps the relocations DD tracks (queued + in-flight), and its default of 1000 is below what a large bulkload job generates. Bulkload is the workload most exposed to that cap, because of three properties that ordinary data movement does not share:

  - Bulkload moves consume no source work factor. They read from blob storage rather than from source storage servers, so canLaunchSrc() admits them unconditionally. Every other relocation is self-limiting through the per-server busyness ledger, which can leave the pipeline cap as the only thing gating bulkload.

  - They run at PRIORITY_TEAM_HEALTHY (140) against splits at PRIORITY_SPLIT_SHARD (950), but unlike background rebalance a bulkload job has a caller waiting on it.

  - A restore into a previously empty contiguous range makes DD split that range, so the job manufactures the higher-priority relocations that then precede it.

pipelineGateActor is priority-blind, so a cap sized near real demand turns admission into arrival-order FIFO, and bulkload moves cannot be reordered ahead of the splits they caused. The note records the measurement behind this (1B restore: no bulkload movement for 1h54m at cap 1000, 7.15s with headroom, in-flight unchanged at 107 -> 114, so the capacity was present throughout; 3B restore: 6041-6815 queued relocations in the same phase) and the distinction that matters when tuning, namely that raising the cap adds no concurrency.

It also gives a sizing rule, because the knob has a ceiling as well as a floor: DD resident memory is roughly 4 GB + 0.11 GB per 1000 tracked relocations and in-flight converges on the cap while movement is storming, so 100000 needs ~15 GB and can OOM an 8 GB or 12 GB distributor before the cap engages, while 20000 costs ~6.2 GB and clears the demand measured above. Raising the default is therefore not the fix; the guidance is per-job.

Adds the operator-facing symptom to the bulkload troubleshooting page as well: DDPipelineFull events during a load with InQueue plus InFlight sitting at the cap. Applies to 7.3, 7.4 and main alike, whose default is 1000.