### PR TITLE
[release-7.4] Fix an old exclude failed bug

### DIFF
--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -3058,7 +3058,7 @@ ACTOR Future<Void> removeKeysFromFailedServer(Database cx,
 							}
 						}
 
-						const UID shardId = newDataMoveId(deterministicRandom()->randomUInt64(),
+						state UID shardId = newDataMoveId(deterministicRandom()->randomUInt64(),
 						                                  AssignEmptyRange::True,
 						                                  DataMoveType::LOGICAL,
 						                                  DataMovementReason::ASSIGN_EMPTY_RANGE);
@@ -3077,20 +3077,22 @@ ACTOR Future<Void> removeKeysFromFailedServer(Database cx,
 							actors.push_back(
 							    krmSetRangeCoalescing(&tr, serverKeysPrefixFor(id), range, allKeys, serverKeysFalse));
 						}
+						wait(waitForAll(actors));
 
 						// Assign the shard to the new team as an empty range.
 						// Note, there could be data loss.
+						std::vector<Future<Void>> emptyRangeActors;
 						for (const UID& id : teamForDroppedRange) {
 							if (SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
-								actors.push_back(krmSetRangeCoalescing(
+								emptyRangeActors.push_back(krmSetRangeCoalescing(
 								    &tr, serverKeysPrefixFor(id), range, allKeys, serverKeysValue(shardId)));
 							} else {
-								actors.push_back(krmSetRangeCoalescing(
+								emptyRangeActors.push_back(krmSetRangeCoalescing(
 								    &tr, serverKeysPrefixFor(id), range, allKeys, serverKeysTrueEmptyRange));
 							}
 						}
 
-						wait(waitForAll(actors));
+						wait(waitForAll(emptyRangeActors));
 
 						TraceEvent trace(SevWarnAlways, "ShardLossAllReplicasDropShard", serverID);
 						trace.detail("Begin", it.key);


### PR DESCRIPTION
Port apple/foundationdb#13645 to release-7.4.

Problem: In removeKeysFromFailedServer, the writes that unassign a dropped shard from the dest servers (serverKeysFalse) and the writes that reassign it to the new team as an empty range were pushed into a single actors vector and awaited together. krmSetRangeCoalescing performs a read-modify-write on the serverKeys map, so when a server appears in both the dest set and the new team, running the two batches concurrently lets the coalescing reads observe stale state and produce an incorrect serverKeys assignment.

Solution: await the unassign batch first, then run the empty-range assignment in a separate batch, ensuring the serverKey map assignment is correct.

Same fix already backported to release-7.3 in apple/foundationdb#13662. release-7.4 still used the wait()/actor-compiler style rather than main's co_await, and shardId needed to become state since it now crosses the new wait() boundary -- same conflict resolution as the 7.3 backport.

100K: 20260813-171407-praza-port-7.4-pr13645-817f-e3951c728b485de6 pass=100000 fail=0 ended=100000 max_runs=100000