### PR TITLE
Backport four bug fixes from main to release-7.4 (#12318, #12643, #12750, #12755)

### DIFF
--- a/bindings/go/src/fdb/snapshot.go
+++ b/bindings/go/src/fdb/snapshot.go
@@ -118,5 +118,5 @@ func (s Snapshot) GetRangeSplitPoints(r ExactRange, chunkSize int64) FutureKeyAr
 // Snapshot returns the receiver and allows Snapshot to satisfy the
 // ReadTransaction interface.
 func (s Snapshot) Options() TransactionOptions {
-	return s.Options()
+	return TransactionOptions{s.transaction}
 }

--- a/fdbclient/S3Client.actor.cpp
+++ b/fdbclient/S3Client.actor.cpp
@@ -72,7 +72,7 @@ struct PartConfig {
 ACTOR Future<std::string> calculateFileChecksum(Reference<IAsyncFile> file, int64_t size) {
 	state int64_t pos = 0;
 	state XXH64_state_t* hashState = XXH64_createState();
-	state std::vector<uint8_t> buffer(65536);
+	state std::shared_ptr<std::vector<uint8_t>> buffer = std::make_shared<std::vector<uint8_t>>(65536);
 	state int readSize;
 
 	XXH64_reset(hashState, 0);
@@ -84,8 +84,8 @@ ACTOR Future<std::string> calculateFileChecksum(Reference<IAsyncFile> file, int6
 		}
 
 		while (pos < size) {
-			readSize = std::min<int64_t>(buffer.size(), size - pos);
-			int bytesRead = wait(file->read(buffer.data(), readSize, pos));
+			readSize = std::min<int64_t>(buffer->size(), size - pos);
+			int bytesRead = wait(uncancellable(holdWhile(buffer, file->read(buffer->data(), readSize, pos))));
 			if (bytesRead != readSize) {
 				XXH64_freeState(hashState);
 				TraceEvent(SevError, "S3ClientCalculateChecksumReadError")
@@ -94,7 +94,7 @@ ACTOR Future<std::string> calculateFileChecksum(Reference<IAsyncFile> file, int6
 				    .detail("Position", pos);
 				throw io_error();
 			}
-			XXH64_update(hashState, buffer.data(), bytesRead);
+			XXH64_update(hashState, buffer->data(), bytesRead);
 			pos += bytesRead;
 		}
 

--- a/fdbserver/DDShardTracker.actor.cpp
+++ b/fdbserver/DDShardTracker.actor.cpp
@@ -1679,6 +1679,8 @@ struct DataDistributionTrackerImpl {
 
 		try {
 			wait(trackInitialShards(self, initData));
+			if (*self->trackerCancelled)
+				return Void();
 			initData.clear(); // Release reference count.
 
 			state PromiseStream<TenantCacheTenantCreated> tenantCreationSignal;

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -521,7 +521,9 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 	Version durableKnownCommittedVersion, minKnownCommittedVersion;
 	Version queuePoppedVersion; // The disk queue has been popped up until the location which represents this version.
 	Version minPoppedTagVersion;
-	Tag minPoppedTag; // The tag that makes tLog hold its data and cause tLog's disk queue increasing.
+	Tag minPoppedTag; // The tag (locality >= 0) that makes tLog hold its data and cause tLog's disk queue increasing.
+	Version minSysPopTagVersion;
+	Tag minSysPopTag; // The system locality tag (locality < 0) with the minimum popped version.
 
 	// For each version above knownCommittedVersion, track:
 	// <Version, PrevVersion (that the sequencer provided), TLogs that the version has been sent to (the tLogs
@@ -658,8 +660,9 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 	                 std::string context)
 	  : initialized(false), queueCommittingVersion(0), knownCommittedVersion(0), durableKnownCommittedVersion(0),
 	    minKnownCommittedVersion(0), queuePoppedVersion(0), minPoppedTagVersion(0), minPoppedTag(invalidTag),
-	    unpoppedRecoveredTagCount(0), cc("TLog", interf.id().toString()), bytesInput("BytesInput", cc),
-	    tagMessageCount("TagMessageCount", cc), bytesDurable("BytesDurable", cc), blockingPeeks("BlockingPeeks", cc),
+	    minSysPopTagVersion(0), minSysPopTag(invalidTag), unpoppedRecoveredTagCount(0),
+	    cc("TLog", interf.id().toString()), bytesInput("BytesInput", cc), tagMessageCount("TagMessageCount", cc),
+	    bytesDurable("BytesDurable", cc), blockingPeeks("BlockingPeeks", cc),
 	    blockingPeekTimeouts("BlockingPeekTimeouts", cc), emptyPeeks("EmptyPeeks", cc),
 	    nonEmptyPeeks("NonEmptyPeeks", cc), logId(interf.id()), protocolVersion(protocolVersion),
 	    newPersistentDataVersion(invalidVersion), tLogData(tLogData), unrecoveredBefore(1), recoveredAt(1),
@@ -692,6 +695,9 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		// for why the TLog thinks it can't throw away data.
 		specialCounter(cc, "MinPoppedTagLocality", [this]() { return this->minPoppedTag.locality; });
 		specialCounter(cc, "MinPoppedTagId", [this]() { return this->minPoppedTag.id; });
+		specialCounter(cc, "MinSysPopTagVersion", [this]() { return this->minSysPopTagVersion; });
+		specialCounter(cc, "MinSysPopTagLocality", [this]() { return this->minSysPopTag.locality; });
+		specialCounter(cc, "MinSysPopTagId", [this]() { return this->minSysPopTag.id; });
 		specialCounter(cc, "SharedBytesInput", [tLogData]() { return tLogData->bytesInput; });
 		specialCounter(cc, "SharedBytesDurable", [tLogData]() { return tLogData->bytesDurable; });
 		specialCounter(cc, "SharedOverheadBytesInput", [tLogData]() { return tLogData->overheadBytesInput; });
@@ -971,6 +977,7 @@ ACTOR Future<Void> popDiskQueue(TLogData* self, Reference<LogData> logData) {
 		minVersion = locationIter->key;
 	}
 	logData->minPoppedTagVersion = std::numeric_limits<Version>::max();
+	logData->minSysPopTagVersion = std::numeric_limits<Version>::max();
 
 	for (int tagLocality = 0; tagLocality < logData->tag_data.size(); tagLocality++) {
 		for (int tagId = 0; tagId < logData->tag_data[tagLocality].size(); tagId++) {
@@ -980,10 +987,18 @@ ACTOR Future<Void> popDiskQueue(TLogData* self, Reference<LogData> logData) {
 					minLocation = std::min(minLocation, tagData->poppedLocation);
 					minVersion = std::min(minVersion, tagData->popped);
 				}
-				if ((!tagData->nothingPersistent || tagData->versionMessages.size()) &&
-				    tagData->popped < logData->minPoppedTagVersion) {
-					logData->minPoppedTagVersion = tagData->popped;
-					logData->minPoppedTag = tagData->tag;
+				if ((!tagData->nothingPersistent || tagData->versionMessages.size())) {
+					if (tagData->tag.locality >= 0) {
+						if (tagData->popped < logData->minPoppedTagVersion) {
+							logData->minPoppedTagVersion = tagData->popped;
+							logData->minPoppedTag = tagData->tag;
+						}
+					} else {
+						if (tagData->popped < logData->minSysPopTagVersion) {
+							logData->minSysPopTagVersion = tagData->popped;
+							logData->minSysPopTag = tagData->tag;
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Backports four already-merged `main` bug fixes to `release-7.4`, ahead of 7.4.7.

1. https://github.com/apple/foundationdb/pull/12318, Fix circular recursion in Snapshot.Options() (Go binding)
2. https://github.com/apple/foundationdb/pull/12643, Fix a few file read cancellation bugs (partial: only the calculateFileChecksum() UAF hunk applies to release-7.4, see commit message and conflict notes)
3. https://github.com/apple/foundationdb/pull/12750, Fix a DD shutdown crash
4. https://github.com/apple/foundationdb/pull/12755, Track min popped version separately for system localities in TLog

Did not fully backport number 2 above, either because part of it was already there, or part of it had its logic changed. For the latter, I'll do more research and open a new PR if needed.

100K: 20260813-181902-praza-port-7.4-audit-batch1-1e1c9c9a89774015, 100000/100000 pass
