### PR TITLE
Lower backup role failure severity for IO error

### DIFF
--- a/fdbserver/core/WorkerSupport.cpp
+++ b/fdbserver/core/WorkerSupport.cpp
@@ -198,7 +198,7 @@ void endRole(const Role& role, UID id, std::string reason, bool ok, Error e) {
 	if (!ok) {
 		std::string type = role.roleName + "Failed";
 
-		TraceEvent err(SevError, type.c_str(), id);
+		TraceEvent err(role == Role::BACKUP ? SevWarnAlways : SevError, type.c_str(), id);
 		if (e.code() != invalid_error_code) {
 			err.errorUnsuppressed(e);
 		}


### PR DESCRIPTION
Problem:
One off IO error when doing backup in the backup-worker when using backup-v2/partitioned logs is causing the process to report for the next 24 hours an SevError that could lead to pagable alert depending on once configuration.

Solution:
Make this issue a non SevError for the backup-worker due to the nature of the medium used for backup ie. blobstore or networked filesystem it can happen and will be retried by the process.

Testing:
Passed 10K testing in joshua

