### PR TITLE
Use auto for Flow makeReference declarations

### DIFF
--- a/flow/CoroTests.cpp
+++ b/flow/CoroTests.cpp
@@ -75,7 +75,7 @@ TEST_CASE("/flow/genericactors/ActorHeaderDeclarations") {
 	ASSERT(any);
 	co_await returnIfTrue(Future<bool>(true));
 
-	Reference<AsyncVar<bool>> condition = makeReference<AsyncVar<bool>>(false);
+	auto condition = makeReference<AsyncVar<bool>>(false);
 	co_await delayAfterCleared(condition, 0.0);
 	co_await lowPriorityDelayAfterCleared(condition, 0.0);
 }

--- a/flow/genericactors.cpp
+++ b/flow/genericactors.cpp
@@ -253,8 +253,8 @@ TEST_CASE("/flow/genericactors/AsyncListener") {
 }
 
 TEST_CASE("/flow/genericactors/DelayedAsyncVarPreservesReentrantInputChange") {
-	Reference<AsyncVar<bool>> input = makeReference<AsyncVar<bool>>(true);
-	Reference<AsyncVar<bool>> output = makeReference<AsyncVar<bool>>(true);
+	auto input = makeReference<AsyncVar<bool>>(true);
+	auto output = makeReference<AsyncVar<bool>>(true);
 	Future<Void> feedback = trigger(SetAsyncVarTrue{ input }, output->onChange());
 	Future<Void> publisher = delayedAsyncVar(input, output, 0);
 
@@ -613,7 +613,7 @@ TEST_CASE("/flow/genericactors/Delayed") {
 }
 
 TEST_CASE("/flow/genericactors/Trigger") {
-	Reference<AsyncVar<bool>> called = makeReference<AsyncVar<bool>>(false);
+	auto called = makeReference<AsyncVar<bool>>(false);
 	Promise<Void> signal;
 	Future<Void> triggered = trigger(SetAsyncVarTrue{ called }, signal.getFuture());
 


### PR DESCRIPTION
## Summary

- Replace four redundant `Reference<AsyncVar<bool>>` declarations with `auto` in Flow coroutine tests.
- Preserve the same inferred `Reference<AsyncVar<bool>>` types from `makeReference<AsyncVar<bool>>()`.

## Testing

- `flow_test -f /flow/genericactors`: 16 passed.
- AST-grep rule and snapshot tests: 11 passed.
