### PR TITLE
Test unsupported mapped-range read options

### DIFF
--- a/fdbclient/ReadYourWrites.cpp
+++ b/fdbclient/ReadYourWrites.cpp
@@ -1214,7 +1214,7 @@ public:
 		// isolation support. But it is not default and is rarely used. So we disallow it until we have thorough test
 		// coverage for it.)
 		if (snapshot) {
-			CODE_PROBE(true, "getMappedRange not supported for snapshot.", probe::decoration::rare);
+			CODE_PROBE(true, "getMappedRange not supported for snapshot.");
 			throw unsupported_operation();
 		}
 		// For now, getMappedRange requires read-your-writes being NOT disabled. But the support of RYW is limited
@@ -1223,7 +1223,7 @@ public:
 		// which returns the written value transparently. In another word, it makes sure not break RYW semantics without
 		// actually implementing reading from the writes.
 		if (ryw->options.readYourWritesDisabled) {
-			CODE_PROBE(true, "getMappedRange not supported for read-your-writes disabled.", probe::decoration::rare);
+			CODE_PROBE(true, "getMappedRange not supported for read-your-writes disabled.");
 			throw unsupported_operation();
 		}
 

--- a/fdbserver/workloads/GetMappedRange.cpp
+++ b/fdbserver/workloads/GetMappedRange.cpp
@@ -587,7 +587,6 @@ struct GetMappedRangeWorkload : ApiWorkload {
 			rejected = true;
 		}
 		ASSERT(rejected);
-		co_return;
 	}
 
 	Future<Void> checkMappedSelectorBoundaries(Database cx, Key mapper, GetMappedRangeWorkload* self) {

--- a/fdbserver/workloads/GetMappedRange.cpp
+++ b/fdbserver/workloads/GetMappedRange.cpp
@@ -562,6 +562,34 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		}
 	}
 
+	Future<Void> checkUnsupportedMappedRange(Database cx,
+	                                         Key begin,
+	                                         Key end,
+	                                         Key mapper,
+	                                         Snapshot snapshot,
+	                                         bool readYourWritesDisabled) {
+		bool rejected = false;
+		try {
+			ReadYourWritesTransaction tr(cx);
+			if (readYourWritesDisabled) {
+				tr.setOption(FDBTransactionOptions::READ_YOUR_WRITES_DISABLE);
+			}
+			co_await tr.getMappedRange(KeySelector(firstGreaterOrEqual(begin), begin.arena()),
+			                           KeySelector(firstGreaterOrEqual(end), end.arena()),
+			                           mapper,
+			                           GetRangeLimits(/*rowLimit=*/100, /*byteLimit=*/100000),
+			                           snapshot,
+			                           Reverse::False);
+		} catch (Error& e) {
+			if (e.code() != error_code_unsupported_operation) {
+				throw;
+			}
+			rejected = true;
+		}
+		ASSERT(rejected);
+		co_return;
+	}
+
 	Future<Void> checkMappedSelectorBoundaries(Database cx, Key mapper, GetMappedRangeWorkload* self) {
 		Key begin = indexEntryKey(10);
 		Key end = indexEntryKey(20);
@@ -590,6 +618,9 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		                                              KeySelector(firstGreaterOrEqual(begin), begin.arena()),
 		                                              mapper,
 		                                              GetRangeLimits(/*rowLimit=*/100, /*byteLimit=*/100000));
+
+		co_await checkUnsupportedMappedRange(cx, begin, end, mapper, Snapshot::True, /*readYourWritesDisabled=*/false);
+		co_await checkUnsupportedMappedRange(cx, begin, end, mapper, Snapshot::False, /*readYourWritesDisabled=*/true);
 
 		bool specialKeyRejected = false;
 		try {


### PR DESCRIPTION
## Summary

- Extend the existing `GetMappedRange` simulation workload to reject mapped reads with snapshot isolation.
- Assert that mapped reads also reject transactions with `READ_YOUR_WRITES_DISABLE`.
- Cover both existing `unsupported_operation` paths without changing production behavior.

## Testing

- `clang-format --dry-run --Werror fdbserver/workloads/GetMappedRange.cpp`
- `fdbserver -r simulation -f tests/fast/GetMappedRange.toml`
