### PR TITLE
Enable focused REST utility simulation tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -218,7 +218,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES fast/RangeLockCycle.toml)
   add_fdb_test(TEST_FILES fast/ReadHotDetectionCorrectness.toml IGNORE) # TODO re-enable once read hot detection is enabled.
   add_fdb_test(TEST_FILES fast/ReportConflictingKeys.toml)
-  add_fdb_test(TEST_FILES fast/RESTUnit.toml IGNORE)
+  add_fdb_test(TEST_FILES fast/RESTUnit.toml)
   add_fdb_test(TEST_FILES fast/SelectorCorrectness.toml)
   add_fdb_test(TEST_FILES fast/ShardedRocksNondeterministicTest.toml)
   add_fdb_test(TEST_FILES fast/Sideband.toml)


### PR DESCRIPTION
## Summary

- Include the existing focused REST utility simulation in the normal correctness suite.
- Run the existing malformed-protocol and missing-host parser checks without relying on randomized unit-test sampling.
- Keep the suite limited to its current six no-database REST utility tests; previously included key-management suites have already been removed.

## Validation

- Focused REST utility unit tests.
- Focused REST utility simulation.
