### PR TITLE
Exercise streaming range selector boundary cases

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -3674,18 +3674,18 @@ Future<Void> Transaction::getRangeStream(PromiseStream<RangeResult>& results,
 
 	KeySelector b = begin;
 	if (b.orEqual) {
-		CODE_PROBE(true, "Native stream begin orEqual==true", probe::decoration::rare);
+		CODE_PROBE(true, "Native stream begin orEqual==true");
 		b.removeOrEqual(b.arena());
 	}
 
 	KeySelector e = end;
 	if (e.orEqual) {
-		CODE_PROBE(true, "Native stream end orEqual==true", probe::decoration::rare);
+		CODE_PROBE(true, "Native stream end orEqual==true");
 		e.removeOrEqual(e.arena());
 	}
 
 	if (b.offset >= e.offset && b.getKey() >= e.getKey()) {
-		CODE_PROBE(true, "Native stream range inverted", probe::decoration::rare);
+		CODE_PROBE(true, "Native stream range inverted");
 		results.sendError(end_of_stream());
 		return Void();
 	}

--- a/fdbserver/workloads/StreamingRangeRead.cpp
+++ b/fdbserver/workloads/StreamingRangeRead.cpp
@@ -29,6 +29,8 @@
 #include "flow/Trace.h"
 #include "flow/serialize.h"
 
+#include <algorithm>
+
 Future<Void> streamUsingGetRange(PromiseStream<RangeResult> results, Transaction* tr, KeyRange keys) {
 	KeySelectorRef begin = firstGreaterOrEqual(keys.begin);
 	KeySelectorRef end = firstGreaterOrEqual(keys.end);
@@ -102,7 +104,8 @@ struct StreamingRangeReadWorkload : KVWorkload {
 	                                KeySelector begin,
 	                                KeySelector end,
 	                                uint64_t expectedBegin,
-	                                uint64_t expectedEnd) {
+	                                uint64_t expectedEnd,
+	                                bool expectImmediateEnd = false) {
 		Transaction tr(cx);
 		while (true) {
 			PromiseStream<RangeResult> results;
@@ -110,6 +113,14 @@ struct StreamingRangeReadWorkload : KVWorkload {
 			Error err;
 			try {
 				stream = tr.getRangeStream(results, begin, end, GetRangeLimits(), Snapshot::True);
+				if (expectImmediateEnd) {
+					ASSERT(stream.isReady());
+					ASSERT(!stream.isError());
+					FutureStream<RangeResult> result = results.getFuture();
+					ASSERT(result.isReady());
+					ASSERT(result.isError());
+					ASSERT_EQ(result.getError().code(), error_code_end_of_stream);
+				}
 				RangeResult expected = co_await tr.getRange(begin, end, 100, Snapshot::True);
 				ASSERT_EQ(expected.size(), expectedEnd - expectedBegin);
 				for (uint64_t i = expectedBegin; i < expectedEnd; ++i) {
@@ -148,18 +159,21 @@ struct StreamingRangeReadWorkload : KVWorkload {
 	}
 
 	Future<Void> checkSelectorBoundaries(Database cx) {
-		Key begin = keyForIndex(10, false);
-		Key end = keyForIndex(20, false);
+		const uint64_t endIndex = nodeCount == 0 ? 0 : std::min<uint64_t>(20, nodeCount - 1);
+		const uint64_t beginIndex = endIndex == 0 ? 0 : std::min<uint64_t>(10, endIndex - 1);
+		Key begin = keyForIndex(beginIndex, false);
+		Key end = keyForIndex(endIndex, false);
 		co_await checkSelectorRange(cx,
 		                            KeySelector(firstGreaterThan(begin), begin.arena()),
 		                            KeySelector(firstGreaterThan(end), end.arena()),
-		                            11,
-		                            21);
+		                            std::min(beginIndex + 1, nodeCount),
+		                            std::min(endIndex + 1, nodeCount));
 		co_await checkSelectorRange(cx,
 		                            KeySelector(firstGreaterThan(end), end.arena()),
 		                            KeySelector(firstGreaterOrEqual(begin), begin.arena()),
 		                            0,
-		                            0);
+		                            0,
+		                            true);
 		co_return;
 	}
 

--- a/fdbserver/workloads/StreamingRangeRead.cpp
+++ b/fdbserver/workloads/StreamingRangeRead.cpp
@@ -92,10 +92,76 @@ struct StreamingRangeReadWorkload : KVWorkload {
 
 	Future<bool> check(Database const& cx) override {
 		client = Void();
-		return true;
+		co_await checkSelectorBoundaries(cx->clone());
+		co_return true;
 	}
 
 	void getMetrics(std::vector<PerfMetric>& m) override {}
+
+	Future<Void> checkSelectorRange(Database cx,
+	                                KeySelector begin,
+	                                KeySelector end,
+	                                uint64_t expectedBegin,
+	                                uint64_t expectedEnd) {
+		Transaction tr(cx);
+		while (true) {
+			PromiseStream<RangeResult> results;
+			Future<Void> stream;
+			Error err;
+			try {
+				stream = tr.getRangeStream(results, begin, end, GetRangeLimits(), Snapshot::True);
+				RangeResult expected = co_await tr.getRange(begin, end, 100, Snapshot::True);
+				ASSERT_EQ(expected.size(), expectedEnd - expectedBegin);
+				for (uint64_t i = expectedBegin; i < expectedEnd; ++i) {
+					ASSERT(expected[i - expectedBegin].key == keyForIndex(i, false));
+				}
+
+				uint64_t index = expectedBegin;
+				while (true) {
+					Optional<RangeResult> batch;
+					try {
+						batch = co_await results.getFuture();
+					} catch (Error& e) {
+						if (e.code() != error_code_end_of_stream) {
+							throw;
+						}
+						break;
+					}
+					for (auto const& kv : batch.get()) {
+						ASSERT(index < expectedEnd);
+						ASSERT(kv == expected[index - expectedBegin]);
+						++index;
+					}
+				}
+				co_await stream;
+				ASSERT_EQ(index, expectedEnd);
+				co_return;
+			} catch (Error& e) {
+				if (e.code() == error_code_actor_cancelled) {
+					throw;
+				}
+				err = e;
+			}
+			stream.cancel();
+			co_await tr.onError(err);
+		}
+	}
+
+	Future<Void> checkSelectorBoundaries(Database cx) {
+		Key begin = keyForIndex(10, false);
+		Key end = keyForIndex(20, false);
+		co_await checkSelectorRange(cx,
+		                            KeySelector(firstGreaterThan(begin), begin.arena()),
+		                            KeySelector(firstGreaterThan(end), end.arena()),
+		                            11,
+		                            21);
+		co_await checkSelectorRange(cx,
+		                            KeySelector(firstGreaterThan(end), end.arena()),
+		                            KeySelector(firstGreaterOrEqual(begin), begin.arena()),
+		                            0,
+		                            0);
+		co_return;
+	}
 
 	// Reads the database using both the normal get range API and the streaming API and compares the results
 	Future<Void> streamingClient(Database cx) {


### PR DESCRIPTION
## Summary

- Extend the existing `StreamingRangeRead` workload to exercise exclusive begin and end key selectors.
- Compare streamed selector results with ordinary range reads, including the exact expected keys.
- Verify that an inverted streaming range immediately terminates with `end_of_stream`.

## Test Plan

- `clang-format --dry-run --Werror fdbserver/workloads/StreamingRangeRead.cpp`
- Built `fdbserver_workloads` and `fdbserver` with Clang.
- `fdbserver -r simulation -f tests/fast/StreamingRangeRead.toml -s 41237 -b off`: passed, including all seven workload clients and the consistency check.
- Confirmed that the exclusive begin, exclusive end, and inverted-range code probes were all covered.
