### PR TITLE
packaging: remove python-2.7 package from macOS pkg build

### DIFF
--- a/packaging/osx/buildpkg.sh
+++ b/packaging/osx/buildpkg.sh
@@ -33,14 +33,12 @@ dos2unix()
 mkdir -p -m 0755 $CLIENTSDIR/usr/local/bin
 mkdir -p -m 0755 $CLIENTSDIR/usr/local/lib
 mkdir -p -m 0755 $CLIENTSDIR/usr/local/include/foundationdb
-mkdir -p -m 0755 $CLIENTSDIR/Library/Python/2.7/site-packages/fdb
 mkdir -p -m 0775 $CLIENTSDIR/usr/local/etc/foundationdb
 mkdir -p -m 0755 $CLIENTSDIR/usr/local/foundationdb/backup_agent
 
 install -m 0755 "$BUILDDIR"/bin/fdbcli $CLIENTSDIR/usr/local/bin
 install -m 0644 "$SRCDIR"/bindings/c/foundationdb/fdb_c.h "$BUILDDIR"/bindings/c/foundationdb/fdb_c_options.g.h "$BUILDDIR"/bindings/c/foundationdb/fdb_c_apiversion.g.h "$SRCDIR"/bindings/c/foundationdb/fdb_c_types.h "$SRCDIR"/bindings/c/foundationdb/fdb_c_internal.h "$SRCDIR"/fdbclient/vexillographer/fdb.options $CLIENTSDIR/usr/local/include/foundationdb
 install -m 0755 "$BUILDDIR"/lib/libfdb_c.dylib $CLIENTSDIR/usr/local/lib
-install -m 0644 "$BUILDDIR"/bindings/python/fdb/*.py $CLIENTSDIR/Library/Python/2.7/site-packages/fdb
 install -m 0755 "$BUILDDIR"/bin/fdbbackup $CLIENTSDIR/usr/local/foundationdb/backup_agent/backup_agent
 install -m 0755 "$SRCDIR"/packaging/osx/uninstall-FoundationDB.sh $CLIENTSDIR/usr/local/foundationdb
 dos2unix "$SRCDIR"/README.md $CLIENTSDIR/usr/local/foundationdb/README

--- a/packaging/osx/scripts-clients/postinstall
+++ b/packaging/osx/scripts-clients/postinstall
@@ -1,5 +1,2 @@
 #!/bin/bash
-
-/usr/bin/python -m compileall /Library/Python/2.7/site-packages/fdb
-
 exit 0

--- a/packaging/osx/uninstall-FoundationDB.sh
+++ b/packaging/osx/uninstall-FoundationDB.sh
@@ -6,7 +6,6 @@ rm -f /usr/local/lib/libfdb_c.dylib
 rm -rf /usr/local/include/foundationdb
 rm -rf /usr/local/foundationdb/backup_agent
 rm -f /usr/local/foundationdb/uninstall-FoundationDB.sh
-rm -rf /Library/Python/2.7/site-packages/fdb
 launchctl unload /Library/LaunchDaemons/com.foundationdb.fdbmonitor.plist >/dev/null 2>&1 || :
 rm -f /Library/LaunchDaemons/com.foundationdb.fdbmonitor.plist
 rm -rf /var/db/receipts/FoundationDB-{clients,server}.*


### PR DESCRIPTION
It is obsolete. In practice, python developers will use uv, poetry, or pip in a venv, with python-3.9+ to install the fdb python package, which uses the system libfdb_c (.so or .dylib) which the macOS pkg still includes.

Validated by building and installing the pkg locally:

```
buildfdb]$ ../foundationdb/packaging/osx/buildpkg.sh $PWD ../foundationdb 
pkgbuild: Inferring bundle components from contents of .../T/fdb-clients-pkg.hBXFGTahoU
pkgbuild: Adding top-level postinstall script
write: Permission denied
write: Permission denied
write: Permission denied
write: Permission denied
pkgbuild: Wrote package to FoundationDB-clients.pkg
pkgbuild: Inferring bundle components from contents of /.../T/fdb-server-pkg.n5HJmCBohv
pkgbuild: Adding top-level preinstall script
pkgbuild: Adding top-level postinstall script
write: Permission denied
write: Permission denied
write: Permission denied
write: Permission denied
pkgbuild: Wrote package to FoundationDB-server.pkg
productbuild: Wrote product to .../buildfdb/packages/FoundationDB-arm64-8.0.0.pkg

buildfdb]$ pkgutil --expand-full packages/FoundationDB-arm64-8.0.0.pkg pkg-expanded
buildfdb]$ ls -R pkg-expanded 
Distribution              FoundationDB-clients.pkg/ FoundationDB-server.pkg/  Resources/

pkg-expanded/FoundationDB-clients.pkg:
Bom          PackageInfo  Payload/     Scripts/

pkg-expanded/FoundationDB-clients.pkg/Payload:
usr/

pkg-expanded/FoundationDB-clients.pkg/Payload/usr:
local/

pkg-expanded/FoundationDB-clients.pkg/Payload/usr/local:
bin/          etc/          foundationdb/ include/      lib/

pkg-expanded/FoundationDB-clients.pkg/Payload/usr/local/bin:
dr_agent    fdbbackup   fdbcli      fdbdr       fdbrestore

# etc, all looks good

buildfdb]$ open packages/FoundationDB-arm64-8.0.0.pkg
# ran successfully
```