### PR TITLE
Make no-throw coroutine cancellation reentrant-safe

### DIFF
--- a/flow/CoroTests.cpp
+++ b/flow/CoroTests.cpp
@@ -2079,6 +2079,18 @@ Future<Void> noThrowOnCancelTest(NoThrowOnCancelRecorder& recorder, Future<Void>
 	recorder.record(NoThrowOnCancelEvent::AfterWait);
 }
 
+Future<Void> noThrowOnCancelReentrantCancelTest(Future<Void>* result,
+                                                Future<Void> signal,
+                                                int* cleanupCount,
+                                                NoThrowOnCancel = {}) {
+	ScopeExit cleanup([result, cleanupCount]() {
+		++*cleanupCount;
+		result->cancel();
+	});
+
+	co_await signal;
+}
+
 Future<int> noThrowOnCancelValueTest(NoThrowOnCancelRecorder& recorder, Future<Void> signal, NoThrowOnCancel = {}) {
 	recorder.record(NoThrowOnCancelEvent::Start);
 
@@ -2766,6 +2778,23 @@ TEST_CASE("/flow/coro/noThrowOnCancel/awaitedFutureErrorRunsCatch") {
 	ASSERT(f.isReady() && !f.isError());
 	ASSERT(signal.getFutureReferenceCount() == 0);
 	assertNoThrowOnCancelCaughtError(recorder);
+	return Void();
+}
+
+TEST_CASE("/flow/coro/noThrowOnCancel/reentrantCancelDuringCleanup") {
+	Promise<Void> signal;
+	Future<Void> result;
+	int cleanupCount = 0;
+	result = noThrowOnCancelReentrantCancelTest(&result, signal.getFuture(), &cleanupCount);
+	ASSERT(signal.getFutureReferenceCount() > 0);
+
+	result.cancel();
+	ASSERT(result.isReady() && result.isError() && result.getError().code() == error_code_actor_cancelled);
+	ASSERT_EQ(cleanupCount, 1);
+	ASSERT_EQ(signal.getFutureReferenceCount(), 0);
+
+	result.cancel();
+	ASSERT_EQ(cleanupCount, 1);
 	return Void();
 }
 

--- a/flow/include/flow/CoroutinesImpl.h
+++ b/flow/include/flow/CoroutinesImpl.h
@@ -231,9 +231,12 @@ struct NoThrowOnCancelCoroActor final : Actor<std::conditional_t<std::is_void_v<
 	}
 
 	void cancel() override {
-		if (!SAV<ValType>::canBeSet()) {
+		if (!SAV<ValType>::canBeSet() || actorWaitStateIsCancelled(Actor<ValType>::actor_wait_state)) {
 			return;
 		}
+
+		// Detaching a waiter or destroying the frame can synchronously reenter cancellation.
+		Actor<ValType>::actor_wait_state = ACTOR_WAIT_STATE_CANCELLED;
 
 		if (cancelHandler) {
 			// The handler object is stored in the coroutine frame, so unregister


### PR DESCRIPTION
## Summary

Make shared `NoThrowOnCancel` coroutine cancellation safe against synchronous
reentry from cleanup. Previously, detaching a waiter or destroying the coroutine
frame could cancel the same unresolved future again and attempt to destroy its
frame twice. Mark cancellation before either cleanup step and ignore recursive
cancellation.

Add a focused regression that cancels again from scope cleanup and checks the
cancellation result, exactly-once cleanup, released waiter references, and
repeated-cancel behavior.

This extracts the shared runtime fix from #13836. It does not change
ActorCollection.

## Testing

- `git diff --check` passed.
- The same cancellation fix and regression were previously tested in #13836
  (`flow_test -f /flow/coro/noThrowOnCancel/ --seed 12345`: 7 passed).
- A fresh test run on this standalone branch is pending.
