### PR TITLE
Audit: bound validate_restore's slowest task instead of its average batch

### DIFF
--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -1165,7 +1165,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( FETCH_KEYS_PARALLELISM,                                  2 );
 	init( FETCH_KEYS_LOWER_PRIORITY,                               0 );
 	init( SERVE_FETCH_CHECKPOINT_PARALLELISM,                      4 );
-	init( SERVE_AUDIT_STORAGE_PARALLELISM,                         1 );
+	init( SERVE_AUDIT_STORAGE_PARALLELISM,                         4 ); if ( isSimulated ) SERVE_AUDIT_STORAGE_PARALLELISM = deterministicRandom()->randomInt(1, SERVE_AUDIT_STORAGE_PARALLELISM+1);
 	init( PERSIST_FINISH_AUDIT_COUNT,                             10 ); if ( isSimulated ) PERSIST_FINISH_AUDIT_COUNT = deterministicRandom()->randomInt(1, PERSIST_FINISH_AUDIT_COUNT+1);
 	init( AUDIT_RETRY_COUNT_MAX,                               10000 ); if ( isSimulated ) AUDIT_RETRY_COUNT_MAX = 10;
 	init( CONCURRENT_AUDIT_TASK_COUNT_MAX,                        20 ); if ( isSimulated ) CONCURRENT_AUDIT_TASK_COUNT_MAX = deterministicRandom()->randomInt(1, CONCURRENT_AUDIT_TASK_COUNT_MAX+1);
@@ -1175,6 +1175,36 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( AUDIT_DATAMOVE_POST_CHECK_RETRY_COUNT_MAX,              50 );
 	init( AUDIT_STORAGE_RATE_PER_SERVER_MAX,                    50e6 ); // per second
 	init( AUDIT_RESTORE_BATCH_KEY_LIMIT,                      100000 ); // 100K keys per batch (was hardcoded 10K)
+	// An audit divides its range into TASKS; each task is handled by one storage server, which walks it in
+	// BATCHES of reads. The knobs below bound those two units independently:
+	//   AUDIT_TASK_MAX_BYTES     -- how much keyspace one task covers
+	//   AUDIT_RESTORE_BATCH_*    -- how much one read inside a task fetches (validate_restore only)
+
+	// Max bytes one comparison batch fetches from each side. This is an upper bound, not the size used:
+	// the actual budget moves between AUDIT_RESTORE_BATCH_BYTE_LIMIT_MIN and this value, halving whenever a
+	// read fails and growing back on success (see nextAuditBatchBytes).
+	//
+	// It adapts because the real constraint is a deadline, not a size: a batch reads at a pinned version
+	// that expires after MAX_READ_TRANSACTION_LIFE_VERSIONS, so what a server can fetch in one go depends
+	// on current load, and overshooting fails with transaction_too_old and is re-read from the start.
+	//
+	// Raise for fewer, larger round trips. Lower if audits provoke transaction_too_old, or to cut memory:
+	// a server holds ~4 x this x SERVE_AUDIT_STORAGE_PARALLELISM in flight.
+	init( AUDIT_RESTORE_BATCH_BYTE_LIMIT,                        4e6 ); if( randomize && buggify() ) AUDIT_RESTORE_BATCH_BYTE_LIMIT = 80000;
+	// Smallest the adaptive batch above may shrink to, so a run of failed reads cannot leave the audit
+	// crawling through tiny batches.
+	init( AUDIT_RESTORE_BATCH_BYTE_LIMIT_MIN,                  256e3 ); if( randomize && buggify() ) AUDIT_RESTORE_BATCH_BYTE_LIMIT_MIN = 1000;
+	// Max bytes of keyspace one audit task covers, for every audit type (ValidateHA, ValidateReplica,
+	// ValidateRestore). Tasks default to one keyServers shard, and a shard bigger than this is subdivided
+	// so that no single task dominates.
+	//
+	// This bounds the audit phase's wall-clock: a task is scanned start to finish by one storage server,
+	// so the phase cannot end before its largest task does, and making individual tasks faster cannot help.
+	//
+	// Lower for a shorter tail at the cost of more tasks. 0 disables subdivision. A target, not a hard
+	// bound -- splitStorageMetrics jitters piece sizes and the client merges a trailing piece under
+	// STORAGE_METRICS_UNFAIR_SPLIT_LIMIT back into its predecessor, so a task can reach ~1.4x this.
+	init( AUDIT_TASK_MAX_BYTES,                                128e6 ); if( randomize && buggify() ) AUDIT_TASK_MAX_BYTES = deterministicRandom()->coinflip() ? 0 : 1e6;
 	init( AUDIT_PROGRESS_PERSIST_BYTES_INTERVAL,           100000000 ); // 100MB - only persist progress after this many bytes
 	init( ENABLE_AUDIT_VERBOSE_TRACE,                          false );
 	// Disabled in simulation: audit_storage locationmetadata already runs at controlled times in sim,

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -1105,6 +1105,12 @@ public:
 	int AUDIT_STORAGE_RATE_PER_SERVER_MAX;
 	bool ENABLE_AUDIT_VERBOSE_TRACE;
 	int AUDIT_RESTORE_BATCH_KEY_LIMIT;
+	// int, not int64_t: these feed GetRangeLimits::bytes, which is an int. Declaring them wider only
+	// moves the narrowing to the use site, where an out-of-range value can land on -1, which
+	// GetRangeLimits reads as BYTE_LIMIT_UNLIMITED and so silently removes the bound entirely.
+	int AUDIT_RESTORE_BATCH_BYTE_LIMIT;
+	int AUDIT_RESTORE_BATCH_BYTE_LIMIT_MIN; // floor the adaptive batch budget backs off to
+	int64_t AUDIT_TASK_MAX_BYTES; // cap on one audit task's range; 0 disables subdivision
 	int64_t AUDIT_PROGRESS_PERSIST_BYTES_INTERVAL;
 	double AUDIT_LOCATION_METADATA_INTERVAL;
 	bool LOGGING_STORAGE_COMMIT_WHEN_IO_TIMEOUT;

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -19,6 +19,8 @@
  */
 
 #include <algorithm>
+#include <limits>
+#include <unordered_set>
 
 #include "fdbclient/Audit.h"
 #include "fdbclient/AuditUtils.h"
@@ -444,6 +446,12 @@ public:
 	std::string bulkLoadFolder;
 
 	Optional<DDBulkLoadJobManager> bulkLoadJobManager;
+
+	// Bulkload tasks that have reached the terminal Error phase and have already been reported.
+	// scheduleBulkLoadTasks() rescans the task metadata every DD_BULKLOAD_SCHEDULE_MIN_INTERVAL_SEC and an
+	// Error-phase task is never erased, so without this the same failure is re-logged for the life of the
+	// cluster. Reset per DD generation, which is intended: a new DD should report the current state once.
+	std::unordered_set<UID> reportedErrorBulkLoadTasks;
 
 	bool bulkDumpEnabled = false;
 	ParallelismLimitor bulkDumpParallelismLimitor;
@@ -1413,9 +1421,15 @@ Future<Void> scheduleBulkLoadTasks(Reference<DataDistributor> self) {
 					// We do one metadata erase at a time to aviod unnecessary transaction conflicts
 					co_await eraseBulkLoadTask(self, bulkLoadTaskState.getRange(), bulkLoadTaskState.getTaskId());
 				} else if (bulkLoadTaskState.phase == BulkLoadPhase::Error) {
-					TraceEvent(SevWarnAlways, "DDBulkLoadTaskUnretriableError", self->ddId)
-					    .detail("Range", bulkLoadTaskState.getRange())
-					    .detail("TaskID", bulkLoadTaskState.getTaskId());
+					// Error is terminal and the metadata is deliberately left in place for the operator, so
+					// report each failed task once rather than on every rescan: the scan interval is seconds
+					// and nothing ever clears the entry, so re-logging continues for the cluster's life.
+					if (self->reportedErrorBulkLoadTasks.insert(bulkLoadTaskState.getTaskId()).second) {
+						TraceEvent(SevWarnAlways, "DDBulkLoadTaskUnretriableError", self->ddId)
+						    .detail("Range", bulkLoadTaskState.getRange())
+						    .detail("TaskID", bulkLoadTaskState.getTaskId())
+						    .detail("TotalErrorTasksReported", self->reportedErrorBulkLoadTasks.size());
+					}
 				} else {
 					ASSERT(bulkLoadTaskState.phase == BulkLoadPhase::Complete);
 				}
@@ -4524,6 +4538,71 @@ Future<std::unordered_map<UID, KeyValueStoreType>> getStorageType(std::vector<St
 	co_return res;
 }
 
+// Subdivide one shard-sized audit task range so a single fat shard cannot become an unbounded
+// straggler; see AUDIT_TASK_MAX_BYTES. Takes the txnProcessor and ddId rather than the DataDistributor
+// so a mock can drive it: the failure mode that matters -- a metrics read error must degrade to the
+// unsplit shard, never fail the audit -- is otherwise only reachable on a real cluster.
+static Future<std::vector<KeyRange>> boundAuditTaskRange(Reference<IDDTxnProcessor> txnProcessor,
+                                                         UID ddId,
+                                                         KeyRange shardRange) {
+	if (SERVER_KNOBS->AUDIT_TASK_MAX_BYTES <= 0 || shardRange.empty()) {
+		co_return std::vector<KeyRange>{ shardRange };
+	}
+
+	Optional<Error> splitError;
+	try {
+		StorageMetrics splitMetrics;
+		splitMetrics.bytes = SERVER_KNOBS->AUDIT_TASK_MAX_BYTES;
+		// Split on size only. Setting the other dimensions to infinity is REQUIRED, not merely tidy:
+		// getSplitKey() does ASSERT(limits > 0), so leaving them at 0 would assert-fail in the storage
+		// server. Infinity makes getSplitKey's `limits < infinity / 2` test false, which is how a
+		// dimension is opted out of. Auditing is read-only, so size is the only dimension of interest.
+		splitMetrics.bytesWrittenPerKSecond = splitMetrics.infinity;
+		splitMetrics.iosPerKSecond = splitMetrics.infinity;
+		splitMetrics.bytesReadPerKSecond = splitMetrics.infinity;
+
+		// minSplitBytes must not exceed half the target. The storage server stops splitting once
+		// `remaining.bytes < 2 * minSplitBytes`, so passing the target itself leaves every shard below
+		// TWICE the target whole.
+		//
+		// Anything below target/2 behaves the same, since getSplitKey() only splits while
+		// remaining > target/2 and that binds first; half the target just avoids generating split points
+		// the client will discard.
+		const int minSplitBytes =
+		    std::max<int>(1,
+		                  static_cast<int>(std::min<int64_t>(std::numeric_limits<int>::max(),
+		                                                     SERVER_KNOBS->AUDIT_TASK_MAX_BYTES / 2)));
+		Standalone<VectorRef<KeyRef>> splitPoints =
+		    co_await txnProcessor->splitStorageMetrics(shardRange, splitMetrics, StorageMetrics(), minSplitBytes);
+		// splitStorageMetrics() returns shardRange.begin and shardRange.end as its first and last points,
+		// in order, so consecutive pairs tile the range. Same idiom as DDShardTracker's executeShardSplit().
+		std::vector<KeyRange> taskRanges;
+		for (int i = 0; i + 1 < splitPoints.size(); ++i) {
+			taskRanges.push_back(KeyRangeRef(splitPoints[i], splitPoints[i + 1]));
+		}
+		ASSERT(!taskRanges.empty());
+		if (taskRanges.size() > 1) {
+			TraceEvent(SevInfo, "DDAuditTaskRangeSubdivided", ddId)
+			    .suppressFor(30.0)
+			    .detail("ShardRange", shardRange)
+			    .detail("NumTaskRanges", taskRanges.size())
+			    .detail("MaxBytesPerTask", SERVER_KNOBS->AUDIT_TASK_MAX_BYTES);
+		}
+		co_return taskRanges;
+	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled) {
+			throw e;
+		}
+		splitError = e;
+	}
+	// A metrics read must never fail an audit: fall back to the unsplit shard, which is exactly the
+	// behaviour before this cap existed. Worst case we keep the straggler we were trying to avoid.
+	TraceEvent(SevWarn, "DDAuditTaskRangeSplitFailed", ddId)
+	    .errorUnsuppressed(splitError.get())
+	    .detail("ShardRange", shardRange);
+	co_return std::vector<KeyRange>{ shardRange };
+}
+
 // Partition the input range into multiple subranges according to the range ownership, and
 // schedule ha/replica/restore audit tasks of each subrange on the server which owns the subrange
 // Automatically retry until complete or timed out
@@ -4543,6 +4622,9 @@ Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 	Key currentRangeToScheduleBegin = rangeToSchedule.begin;
 	KeyRange currentRangeToSchedule;
 	int64_t issueDoAuditCount = 0;
+	// Counts skipped task ranges, not distinct shards: the engine-type skip has always been per audit
+	// state range, and a shard subdivided by AUDIT_TASK_MAX_BYTES contributes one count per piece. Kept
+	// under its existing name so the SkippedShardsCountInThisSchedule trace field stays greppable.
 	int64_t numSkippedShards = 0;
 
 	try {
@@ -4560,12 +4642,32 @@ Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 				    .detail("RangeLocationsBackKey", rangeLocations.back().range.end);
 			}
 
-			// Divide the audit job in to tasks according to KeyServers system mapping
+			// Divide the audit job in to tasks according to KeyServers system mapping, then subdivide
+			// any shard larger than AUDIT_TASK_MAX_BYTES. A task is scanned sequentially by one storage
+			// server and the audit phase ends only when its slowest task does, so an uncapped fat shard
+			// bounds the whole phase from below.
 			int assignedRangeTasks = 0;
-			int rangeLocationIndex = 0;
-			for (; rangeLocationIndex < rangeLocations.size(); ++rangeLocationIndex) {
+			// Split lazily, one shard at a time, so the first task dispatches immediately: splitting
+			// every shard up front would put thousands of sequential metrics reads ahead of any audit
+			// work. Entries are (task range, index of the shard it came from) -- the shard index is
+			// needed because the servers to audit come from that rangeLocations entry.
+			std::vector<std::pair<KeyRange, int>> taskRangesToSchedule;
+			int nextShardToSplit = 0;
+			for (int taskIndex = 0;; ++taskIndex) {
+				while (taskIndex >= taskRangesToSchedule.size() && nextShardToSplit < rangeLocations.size()) {
+					std::vector<KeyRange> boundedRanges = co_await boundAuditTaskRange(
+					    self->txnProcessor, self->ddId, rangeLocations[nextShardToSplit].range);
+					for (KeyRange const& boundedRange : boundedRanges) {
+						taskRangesToSchedule.emplace_back(boundedRange, nextShardToSplit);
+					}
+					++nextShardToSplit;
+				}
+				if (taskIndex >= taskRangesToSchedule.size()) {
+					break; // every shard split and every resulting task scheduled
+				}
 				// For each task, check the progress, and create task request for the unfinished range
-				KeyRange taskRange = rangeLocations[rangeLocationIndex].range;
+				KeyRange taskRange = taskRangesToSchedule[taskIndex].first;
+				const int rangeLocationIndex = taskRangesToSchedule[taskIndex].second;
 				if (SERVER_KNOBS->ENABLE_AUDIT_VERBOSE_TRACE) {
 					TraceEvent(SevInfo, "DDScheduleAuditOnCurrentRangeTask", self->ddId)
 					    .detail("AuditID", audit->coreState.id)
@@ -4790,7 +4892,15 @@ Future<Void> scheduleAuditOnRange(Reference<DataDistributor> self,
 					TraceEvent(SevInfo, "DDScheduleAuditOnCurrentRangeTaskAssigned", self->ddId);
 				}
 				++assignedRangeTasks;
-				co_await delay(0.1);
+				// Throttle once per keyServers shard, NOT once per subdivided piece: per piece this
+				// multiplies by the split factor, adding a term linear in the piece count to the very
+				// wall-clock the cap exists to shorten. Pieces are appended a whole shard at a time, so
+				// the last present entry is always its shard's last piece.
+				const bool lastPieceOfShard = taskIndex + 1 >= taskRangesToSchedule.size() ||
+				                              taskRangesToSchedule[taskIndex + 1].second != rangeLocationIndex;
+				if (lastPieceOfShard) {
+					co_await delay(0.1);
+				}
 			}
 			// Proceed to the next range if getSourceServerInterfacesForRange is partially read
 			currentRangeToScheduleBegin = rangeLocations.back().range.end;
@@ -5342,6 +5452,123 @@ inline int getRandomShardCount() {
 }
 
 } // namespace data_distribution_test
+
+namespace {
+
+// Drives boundAuditTaskRange() without a cluster: returns the configured split points, or fails the
+// metrics read when asked to.
+class AuditSplitTestTxnProcessor final : public DDTxnProcessor {
+public:
+	explicit AuditSplitTestTxnProcessor(std::vector<std::string> points, Optional<Error> failWith = {})
+	  : points(std::move(points)), failWith(failWith) {}
+
+	int getSplitCalls() const { return splitCalls; }
+	int64_t getLastMinSplitBytes() const { return lastMinSplitBytes; }
+
+	Future<Standalone<VectorRef<KeyRef>>> splitStorageMetrics(KeyRange const& keys,
+	                                                          StorageMetrics const&,
+	                                                          StorageMetrics const&,
+	                                                          Optional<int> const& minSplitBytes) const override {
+		++splitCalls;
+		lastMinSplitBytes = minSplitBytes.present() ? minSplitBytes.get() : -1;
+		if (failWith.present()) {
+			return failWith.get();
+		}
+		Standalone<VectorRef<KeyRef>> splitKeys;
+		for (std::string const& p : points) {
+			splitKeys.push_back_deep(splitKeys.arena(), StringRef(p));
+		}
+		return splitKeys;
+	}
+
+private:
+	std::vector<std::string> points;
+	Optional<Error> failWith;
+	mutable int splitCalls = 0;
+	mutable int64_t lastMinSplitBytes = 0;
+};
+
+// Restores AUDIT_TASK_MAX_BYTES on any exit path. Unit tests share a process, so a knob left at a
+// test value by a failed ASSERT silently reconfigures every test that runs afterwards, turning one
+// failure into a cascade that no longer points at its cause.
+class AuditTaskMaxBytesGuard {
+public:
+	AuditTaskMaxBytesGuard() : saved(SERVER_KNOBS->AUDIT_TASK_MAX_BYTES) {}
+	~AuditTaskMaxBytesGuard() { set(saved); }
+	AuditTaskMaxBytesGuard(AuditTaskMaxBytesGuard const&) = delete;
+	AuditTaskMaxBytesGuard& operator=(AuditTaskMaxBytesGuard const&) = delete;
+
+	void set(int64_t value) { const_cast<ServerKnobs*>(SERVER_KNOBS)->AUDIT_TASK_MAX_BYTES = value; }
+
+private:
+	int64_t saved;
+};
+
+} // namespace
+
+TEST_CASE("/DataDistribution/Audit/BoundAuditTaskRange") {
+	KeyRange shard = KeyRangeRef("a"_sr, "z"_sr);
+	AuditTaskMaxBytesGuard maxBytes;
+
+	// A fat shard is subdivided at the reported split points.
+	{
+		maxBytes.set(1000);
+		auto processor = makeReference<AuditSplitTestTxnProcessor>(std::vector<std::string>{ "a", "m", "z" });
+		std::vector<KeyRange> ranges = co_await boundAuditTaskRange(processor, UID(), shard);
+		ASSERT_EQ(ranges.size(), 2);
+		ASSERT(ranges[0] == KeyRangeRef("a"_sr, "m"_sr));
+		ASSERT(ranges[1] == KeyRangeRef("m"_sr, "z"_sr));
+		ASSERT_EQ(processor->getSplitCalls(), 1);
+
+		// REGRESSION: minSplitBytes above target/2 makes the storage server leave shards below
+		// 2 * minSplitBytes whole. Silent when wrong -- the only symptom is a slow tail that looks like
+		// ordinary variance.
+		ASSERT(processor->getLastMinSplitBytes() > 0);
+		ASSERT(processor->getLastMinSplitBytes() * 2 <= SERVER_KNOBS->AUDIT_TASK_MAX_BYTES);
+	}
+
+	// A shard smaller than the cap reports no interior points and stays whole.
+	{
+		maxBytes.set(1000);
+		auto processor = makeReference<AuditSplitTestTxnProcessor>(std::vector<std::string>{ "a", "z" });
+		std::vector<KeyRange> ranges = co_await boundAuditTaskRange(processor, UID(), shard);
+		ASSERT_EQ(ranges.size(), 1);
+		ASSERT(ranges[0] == shard);
+	}
+
+	// Knob disabled: no metrics read at all, and the shard is used as-is.
+	{
+		maxBytes.set(0);
+		auto processor = makeReference<AuditSplitTestTxnProcessor>(std::vector<std::string>{ "a", "m", "z" });
+		std::vector<KeyRange> ranges = co_await boundAuditTaskRange(processor, UID(), shard);
+		ASSERT_EQ(ranges.size(), 1);
+		ASSERT(ranges[0] == shard);
+		ASSERT_EQ(processor->getSplitCalls(), 0);
+	}
+
+	// A failed metrics read must degrade to the unsplit shard rather than fail the audit: an audit that
+	// dies because a size estimate was unavailable is strictly worse than one straggler task.
+	{
+		maxBytes.set(1000);
+		auto processor =
+		    makeReference<AuditSplitTestTxnProcessor>(std::vector<std::string>{}, Optional<Error>(timed_out()));
+		std::vector<KeyRange> ranges = co_await boundAuditTaskRange(processor, UID(), shard);
+		ASSERT_EQ(ranges.size(), 1);
+		ASSERT(ranges[0] == shard);
+	}
+
+	// A cap small enough that target/2 would round to zero must still send a usable minSplitBytes: a
+	// zero or negative value would fall back to MIN_SHARD_BYTES on the server, silently ignoring the cap.
+	{
+		maxBytes.set(1);
+		auto processor = makeReference<AuditSplitTestTxnProcessor>(std::vector<std::string>{ "a", "m", "z" });
+		std::vector<KeyRange> ranges = co_await boundAuditTaskRange(processor, UID(), shard);
+		ASSERT_EQ(ranges.size(), 2);
+		ASSERT(processor->getLastMinSplitBytes() >= 1);
+	}
+
+	co_return;
+}
 
 TEST_CASE("/DataDistribution/Initialization/DcIds") {
 	RegionInfo configuredPrimary;

--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -71,6 +71,7 @@
 #include "flow/PriorityMultiLock.h"
 #include "flow/IRandom.h"
 #include "flow/IndexedSet.h"
+#include "flow/ScopeExit.h"
 #include "flow/SystemMonitor.h"
 #include "flow/Trace.h"
 #include "fdbclient/Tracing.h"
@@ -1392,6 +1393,18 @@ public:
 
 	FlowLock serveAuditStorageParallelismLock;
 
+	// Serializes ValidateStorageServerShard audits against each other. They drive
+	// shardAssignmentHistory / trackShardAssignmentMinVersion, single-instance state on this server
+	// (startTrackShardAssignment() ASSERTs tracking is off), so two concurrent ssshard audits corrupt
+	// each other's view of which ranges moved. Exclusion must not depend on
+	// SERVE_AUDIT_STORAGE_PARALLELISM. Held only by ssshard audits; other types stay parallel.
+	FlowLock ssShardAuditExclusionLock;
+
+	// Shared by every concurrent audit task on this server. It must NOT be per-task: the knob is named
+	// AUDIT_STORAGE_RATE_PER_SERVER_MAX, and a per-task limiter would multiply the allowance by
+	// SERVE_AUDIT_STORAGE_PARALLELISM, against a server that is also serving reads.
+	Reference<IRateControl> auditStorageRateLimiter;
+
 	FlowLock serveBulkDumpParallelismLock;
 
 	int64_t instanceID;
@@ -1483,7 +1496,8 @@ public:
 	    serveFetchCheckpointParallelismLock(SERVER_KNOBS->SERVE_FETCH_CHECKPOINT_PARALLELISM),
 	    ssLock(makeReference<PriorityMultiLock>(SERVER_KNOBS->STORAGE_SERVER_READ_CONCURRENCY,
 	                                            SERVER_KNOBS->STORAGESERVER_READ_PRIORITIES)),
-	    serveAuditStorageParallelismLock(SERVER_KNOBS->SERVE_AUDIT_STORAGE_PARALLELISM),
+	    serveAuditStorageParallelismLock(SERVER_KNOBS->SERVE_AUDIT_STORAGE_PARALLELISM), ssShardAuditExclusionLock(1),
+	    auditStorageRateLimiter(makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1)),
 	    serveBulkDumpParallelismLock(SERVER_KNOBS->SS_SERVE_BULKDUMP_PARALLELISM),
 	    instanceID(deterministicRandom()->randomUniqueID().first()), shuttingDown(false), behind(false),
 	    versionBehind(false), debug_inApplyUpdate(false), debug_lastValidateTime(0), lastBytesInputEBrake(0),
@@ -3716,21 +3730,34 @@ AuditGetShardInfoRes getThisServerShardInfo(StorageServer* data, KeyRange range)
 // Check consistency between StorageServer->shardInfo and ServerKeys system key space
 Future<Void> auditStorageServerShardQ(StorageServer* data, AuditStorageRequest req) {
 	ASSERT(req.getType() == AuditType::ValidateStorageServerShard);
+	// trackShardAssignment is only correct when at most one auditStorageServerShardQ runs at a time, so
+	// take the exclusion lock before the shared permit -- waiting on a peer ssshard audit must not sit on
+	// a permit the other audit types are competing for. The check below is the tripwire for this
+	// invariant and deliberately fails simulation, so reintroducing concurrency shows up loudly.
+	co_await data->ssShardAuditExclusionLock.take(TaskPriority::DefaultYield);
+	FlowLock::Releaser ssShardHolder(data->ssShardAuditExclusionLock);
 	co_await data->serveAuditStorageParallelismLock.take(TaskPriority::DefaultYield);
-	// The trackShardAssignment is correct when at most 1 auditStorageServerShardQ runs
-	// at a time. Currently, this is guaranteed by setting serveAuditStorageParallelismLock == 1
-	// If serveAuditStorageParallelismLock > 1, we need to check trackShardAssignmentMinVersion
-	// to make sure no onging auditStorageServerShardQ is running
+	// Constructed BEFORE the tripwire below: the early co_return there would otherwise leak a permit,
+	// and this lock is shared by every audit type, so enough leaks exhaust it permanently and every
+	// later audit on this server blocks in take() forever.
+	FlowLock::Releaser holder(data->serveAuditStorageParallelismLock);
 	if (data->trackShardAssignmentMinVersion != invalidVersion) {
-		// Another auditStorageServerShardQ is running
+		// Another auditStorageServerShardQ is running, or a previous one was cancelled before reaching
+		// its stopTrackShardAssignment() -- that call is plain code at the end of the function, not a
+		// destructor, so cancellation skips it and leaves tracking on.
 		req.reply.sendError(audit_storage_cancelled());
 		TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways,
 		           "ExistStorageServerShardAuditExit") // unexpected
 		    .detail("NewAuditId", req.id)
-		    .detail("NewAuditType", req.getType());
+		    .detail("NewAuditType", req.getType())
+		    .detail("TrackShardAssignmentMinVersion", data->trackShardAssignmentMinVersion);
 		co_return;
 	}
-	FlowLock::Releaser holder(data->serveAuditStorageParallelismLock);
+	// The stopTrackShardAssignment() calls below are plain statements, so a cancelled audit destroys the
+	// coroutine frame without running any of them and strands trackShardAssignmentMinVersion set, which
+	// trips the check above for every later ssshard audit on this server. Idempotent, so it coexists with
+	// the early stops that close the tracking window before the audit finishes.
+	ScopeExit stopTrackingOnExit([data]() { data->stopTrackShardAssignment(); });
 	TraceEvent(SevInfo, "SSAuditStorageSsShardBegin", data->thisServerID)
 	    .detail("AuditId", req.id)
 	    .detail("AuditRange", req.range);
@@ -3764,7 +3791,8 @@ Future<Void> auditStorageServerShardQ(StorageServer* data, AuditStorageRequest r
 	int retryCount = 0;
 	int64_t cumulatedValidatedLocalShardsNum = 0;
 	int64_t cumulatedValidatedServerKeysNum = 0;
-	Reference<IRateControl> rateLimiter = makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
+	// Server-wide, not per-task: see StorageServer::auditStorageRateLimiter.
+	Reference<IRateControl> rateLimiter = data->auditStorageRateLimiter;
 	int64_t remoteReadBytes = 0;
 	double startTime = now();
 	double lastRateLimiterWaitTime = 0;
@@ -4179,6 +4207,44 @@ Future<Void> auditStorageServerShardQ(StorageServer* data, AuditStorageRequest r
 
 // Helper: Read both source and restored data for a given range
 //
+// Per-batch validate_restore traces, which at scale run to millions of events per audit, so they are
+// gated behind the existing ENABLE_AUDIT_VERBOSE_TRACE knob. The per-range events
+// (SSAuditRestoreBegin/Complete, and any error) stay unconditional.
+//
+// TODO(Audit): move to fdbclient/Audit.h as auditVerboseEventSev(), beside the audit types, matching
+// bulkLoadVerboseEventSev() in BulkLoading.h and s3VerboseEventSev() in S3Client.h. DataDistribution.cpp
+// gates this same knob with six `if (SERVER_KNOBS->ENABLE_AUDIT_VERBOSE_TRACE)` blocks, so the subsystem
+// has two idioms for one knob. Deferred because consolidating flips those six sites from emitting nothing
+// to emitting SevDebug, which is a trace-volume change and wants measuring on its own.
+static inline Severity auditRestoreVerboseEventSev() {
+	return SERVER_KNOBS->ENABLE_AUDIT_VERBOSE_TRACE ? SevInfo : SevDebug;
+}
+
+// Adapt the byte budget of one validate_restore comparison batch (AIMD). See
+// AUDIT_RESTORE_BATCH_BYTE_LIMIT for why a fixed size does not work.
+//
+// The increase is a quarter of the ceiling, coarse on purpose: a failure is cheap and self-correcting
+// (one re-read), whereas sitting below the workable size costs throughput on every remaining batch.
+//
+// Never returns zero or below, because GetRangeLimits overloads the sign of `bytes`: -1 means
+// BYTE_LIMIT_UNLIMITED and removes the bound, below -1 fails isValid(), and 0 costs a round trip per
+// key. Not hang protection -- minRows=1 means even a zero budget still returns a key.
+static int nextAuditBatchBytes(int currentBytes, bool succeeded, int floorBytes, int ceilingBytes) {
+	// Tolerate a misconfigured floor above the ceiling rather than producing an empty window.
+	floorBytes = std::max(1, floorBytes);
+	ceilingBytes = std::max(floorBytes, ceilingBytes);
+	currentBytes = std::clamp(currentBytes, floorBytes, ceilingBytes);
+	if (succeeded) {
+		const int increment = std::max(1, ceilingBytes / 4);
+		// Guard the add: currentBytes + increment can overflow int for a large ceiling.
+		if (currentBytes > ceilingBytes - increment) {
+			return ceilingBytes;
+		}
+		return currentBytes + increment;
+	}
+	return std::max(floorBytes, currentBytes / 2);
+}
+
 // Restored data is stored at validateRestoreLogKeys (\xff\x02/rlog/) in system key space.
 // NOTE: We read the ENTIRE restored keyspace (not just rangeToRead with prefix),
 // because restored keys are stored with their original names under the prefix.
@@ -4194,7 +4260,7 @@ static Future<std::pair<GetKeyValuesReply, GetKeyValuesReply>> fetchSourceAndRes
 	Key restoredEnd = rangeToRead.end.withPrefix(validateRestoreLogKeys.begin);
 	KeyRange restoredRange = KeyRangeRef(restoredBegin, restoredEnd);
 
-	TraceEvent("SSAuditRestoreFetch", data->thisServerID)
+	TraceEvent(auditRestoreVerboseEventSev(), "SSAuditRestoreFetch", data->thisServerID)
 	    .detail("RangeToRead", rangeToRead)
 	    .detail("RestoredRange", restoredRange)
 	    .detail("Version", version)
@@ -4210,8 +4276,18 @@ static Future<std::pair<GetKeyValuesReply, GetKeyValuesReply>> fetchSourceAndRes
 		Transaction tr(data->cx);
 		tr.setVersion(version);
 		tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+		// ACCESS_SYSTEM_KEYS is needed for the restored range (it lives under \xff\x02/rlog/) and is set up
+		// front so both reads can be issued together.
+		tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+		// Issue both reads concurrently. They are independent ranges on the same transaction at the same
+		// explicit read version, so there is no ordering dependency between them; awaiting them in sequence
+		// paid two serial round trips per batch.
 		GetRangeLimits sourceLimits(limit, limitBytes);
-		RangeResult sourceData = co_await tr.getRange(rangeToRead, sourceLimits, Snapshot::False, Reverse::False);
+		GetRangeLimits restoredLimits(limit, limitBytes);
+		Future<RangeResult> sourceFuture = tr.getRange(rangeToRead, sourceLimits, Snapshot::False, Reverse::False);
+		Future<RangeResult> restoredFuture =
+		    tr.getRange(restoredRange, restoredLimits, Snapshot::False, Reverse::False);
+		RangeResult sourceData = co_await sourceFuture;
 
 		// Convert source to GetKeyValuesReply format
 		GetKeyValuesReply sourceReply;
@@ -4220,10 +4296,7 @@ static Future<std::pair<GetKeyValuesReply, GetKeyValuesReply>> fetchSourceAndRes
 		sourceReply.version = version;
 		sourceResult = sourceReply;
 
-		// Read restored data with the same limits as source to ensure comparable results
-		tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-		GetRangeLimits restoredLimits(limit, limitBytes);
-		RangeResult restoredData = co_await tr.getRange(restoredRange, restoredLimits, Snapshot::False, Reverse::False);
+		RangeResult restoredData = co_await restoredFuture;
 
 		// Convert restored to GetKeyValuesReply format
 		GetKeyValuesReply restoredReply;
@@ -4254,7 +4327,7 @@ static Future<std::pair<GetKeyValuesReply, GetKeyValuesReply>> fetchSourceAndRes
 	}
 
 	// Log what we fetched
-	TraceEvent("SSAuditRestoreFetchResult", data->thisServerID)
+	TraceEvent(auditRestoreVerboseEventSev(), "SSAuditRestoreFetchResult", data->thisServerID)
 	    .detail("SourceKeys", sourceResult.get().data.size())
 	    .detail("RestoredKeys", restoredResult.get().data.size())
 	    .detail("SourceBytes", sourceResult.get().data.expectedSize())
@@ -4280,7 +4353,7 @@ std::vector<std::string> compareSourceAndRestoredData(UID thisServerID,
 	int sourceIdx = 0;
 	int restoredIdx = 0;
 
-	TraceEvent("SSAuditRestoreCompare", thisServerID)
+	TraceEvent(auditRestoreVerboseEventSev(), "SSAuditRestoreCompare", thisServerID)
 	    .detail("AuditID", auditID)
 	    .detail("SourceKeys", sourceReply.data.size())
 	    .detail("RestoredKeys", restoredReply.data.size())
@@ -4289,17 +4362,17 @@ std::vector<std::string> compareSourceAndRestoredData(UID thisServerID,
 
 	// Log first few keys from both sets for debugging
 	if (!sourceReply.data.empty()) {
-		TraceEvent("SSAuditRestoreCompareSourceKeys", thisServerID)
+		TraceEvent(auditRestoreVerboseEventSev(), "SSAuditRestoreCompareSourceKeys", thisServerID)
 		    .detail("FirstSourceKey", sourceReply.data[0].key)
 		    .detail("LastSourceKey", sourceReply.data[sourceReply.data.size() - 1].key);
 	}
 	if (!restoredReply.data.empty()) {
-		TraceEvent("SSAuditRestoreCompareRestoredKeys", thisServerID)
+		TraceEvent(auditRestoreVerboseEventSev(), "SSAuditRestoreCompareRestoredKeys", thisServerID)
 		    .detail("FirstRestoredKey", restoredReply.data[0].key)
 		    .detail("LastRestoredKey", restoredReply.data[restoredReply.data.size() - 1].key);
 	}
 
-	TraceEvent("SSAuditRestoreCompareStart", thisServerID)
+	TraceEvent(auditRestoreVerboseEventSev(), "SSAuditRestoreCompareStart", thisServerID)
 	    .detail("SourceSize", sourceReply.data.size())
 	    .detail("RestoredSize", restoredReply.data.size())
 	    .detail("SourceMore", sourceReply.more)
@@ -4403,7 +4476,7 @@ std::vector<std::string> compareSourceAndRestoredData(UID thisServerID,
 		errors.push_back(error);
 	}
 
-	TraceEvent("SSAuditRestoreCompareEnd", thisServerID)
+	TraceEvent(auditRestoreVerboseEventSev(), "SSAuditRestoreCompareEnd", thisServerID)
 	    .detail("SourceIdx", sourceIdx)
 	    .detail("RestoredIdx", restoredIdx)
 	    .detail("SourceSize", sourceReply.data.size())
@@ -4441,7 +4514,20 @@ Future<Void> auditRestoreQ(StorageServer* data, AuditStorageRequest req) {
 	Key rangeToReadBegin = req.range.begin;
 	KeyRange claimRange;
 	int limit = SERVER_KNOBS->AUDIT_RESTORE_BATCH_KEY_LIMIT; // Use knob instead of hardcoded 10K
-	int limitBytes = CLIENT_KNOBS->REPLY_BYTE_LIMIT;
+	// Ceiling of an adaptive budget, not a fixed batch size. Deliberately not
+	// CLIENT_KNOBS->REPLY_BYTE_LIMIT, which is what silently defeated the key limit above; see that knob
+	// and nextAuditBatchBytes().
+	const int limitBytesCeiling = SERVER_KNOBS->AUDIT_RESTORE_BATCH_BYTE_LIMIT;
+	const int limitBytesFloor = std::min<int>(limitBytesCeiling, SERVER_KNOBS->AUDIT_RESTORE_BATCH_BYTE_LIMIT_MIN);
+	// Seeded through nextAuditBatchBytes() so a nonsensical knob pair cannot put the FIRST batch outside
+	// the window. Returns the ceiling unchanged for any sane configuration.
+	int limitBytes = nextAuditBatchBytes(limitBytesCeiling, true, limitBytesFloor, limitBytesCeiling);
+	int consecutiveRetries = 0;
+	int64_t totalRetryableErrors = 0;
+	// Jittered geometric backoff on the house knobs (DEFAULT_BACKOFF -> DEFAULT_MAX_BACKOFF at
+	// BACKOFF_GROWTH_RATE), reset on success so an audit that hits an occasional retry does not ratchet
+	// to the maximum and stay there.
+	Backoff retryBackoff;
 	int64_t readBytes = 0;
 	Error nonRetryableError;
 	int64_t numValidatedKeys = 0;
@@ -4449,12 +4535,23 @@ Future<Void> auditRestoreQ(StorageServer* data, AuditStorageRequest req) {
 	int64_t lastPersistBytes = 0; // Track when we last persisted progress
 	bool complete = false;
 	double startTime = now();
-	Reference<IRateControl> rateLimiter = makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
+	// Time spent blocked on the audit rate limiter, which is now shared per server rather than per task.
+	double rateLimiterTotalWaitTime = 0;
+	// Server-wide, not per-task: see StorageServer::auditStorageRateLimiter.
+	Reference<IRateControl> rateLimiter = data->auditStorageRateLimiter;
 
 	{
 		Optional<Error> err;
 		try {
 			while (true) {
+				// Snapshot every piece of per-attempt state: a retryable failure re-reads this same batch
+				// from the same start key. `complete` matters most -- a stale true would end the audit
+				// early and report Complete over a range never fully read; only the persist block's
+				// !complete guard makes that unreachable today.
+				const int64_t batchStartValidatedKeys = numValidatedKeys;
+				const int64_t batchStartValidatedBytes = validatedBytes;
+				const int64_t batchStartPersistBytes = lastPersistBytes;
+				const bool batchStartComplete = complete;
 				try {
 					readBytes = 0;
 					rangeToRead = KeyRangeRef(rangeToReadBegin, req.range.end);
@@ -4561,8 +4658,12 @@ Future<Void> auditRestoreQ(StorageServer* data, AuditStorageRequest req) {
 						lastPersistBytes = validatedBytes;
 					}
 
-					// Apply rate limiting
+					// Apply rate limiting. The limiter is shared by every concurrent audit task on this
+					// server, so unlike the old per-task limiter it can actually bind; account for the
+					// wait so a throttled audit is distinguishable from a slow one.
+					const double rateLimiterBeforeWaitTime = now();
 					co_await rateLimiter->getAllowance(readBytes);
+					rateLimiterTotalWaitTime += now() - rateLimiterBeforeWaitTime;
 
 					// If errors found or complete, break
 					if (!errors.empty() || complete) {
@@ -4571,6 +4672,10 @@ Future<Void> auditRestoreQ(StorageServer* data, AuditStorageRequest req) {
 
 					// Move to next range
 					rangeToReadBegin = keyAfter(lastKey);
+					// The batch succeeded, so let the byte budget grow back toward its ceiling.
+					consecutiveRetries = 0;
+					retryBackoff = Backoff();
+					limitBytes = nextAuditBatchBytes(limitBytes, true, limitBytesFloor, limitBytesCeiling);
 					if (rangeToReadBegin >= req.range.end) {
 						complete = true;
 						break;
@@ -4587,13 +4692,32 @@ Future<Void> auditRestoreQ(StorageServer* data, AuditStorageRequest req) {
 					if (nonRetryableError.code() == error_code_future_version ||
 					    nonRetryableError.code() == error_code_transaction_too_old ||
 					    nonRetryableError.code() == error_code_server_overloaded) {
+						// This batch is retried from the same start key, so undo its partial accounting.
+						numValidatedKeys = batchStartValidatedKeys;
+						validatedBytes = batchStartValidatedBytes;
+						lastPersistBytes = batchStartPersistBytes;
+						complete = batchStartComplete;
+						const int retriedBytes = limitBytes;
+						limitBytes = nextAuditBatchBytes(limitBytes, false, limitBytesFloor, limitBytesCeiling);
+						// A flat 1s per retry was pure latency when the remedy is a smaller batch, and
+						// these can number in the thousands per server.
+						++consecutiveRetries;
+						++totalRetryableErrors;
+						// Suppressed, with the running total reported in SSAuditRestoreComplete. Retrying
+						// is the normal path -- the budget halving above exists because these are expected.
+						// Event name kept for greps.
 						TraceEvent(SevWarn, "SSAuditRestoreRetryableError", data->thisServerID)
+						    .suppressFor(10.0)
 						    .detail("AuditID", req.id)
 						    .detail("Error", nonRetryableError.what())
 						    .detail("Version", version)
-						    .detail("Range", rangeToRead);
+						    .detail("Range", rangeToRead)
+						    .detail("BatchBytes", retriedBytes)
+						    .detail("NextBatchBytes", limitBytes)
+						    .detail("ConsecutiveRetries", consecutiveRetries)
+						    .detail("TotalRetryableErrors", totalRetryableErrors);
 						nonRetryableError = Error();
-						co_await delay(1.0);
+						co_await retryBackoff.onError();
 						continue;
 					}
 					throw nonRetryableError;
@@ -4612,7 +4736,10 @@ Future<Void> auditRestoreQ(StorageServer* data, AuditStorageRequest req) {
 				    .detail("ValidationErrors", errors.size())
 				    .detail("NumValidatedKeys", numValidatedKeys)
 				    .detail("ValidatedBytes", validatedBytes)
-				    .detail("Duration", now() - startTime);
+				    .detail("Duration", now() - startTime)
+				    .detail("RateLimiterTotalWaitTime", rateLimiterTotalWaitTime)
+				    .detail("FinalBatchBytes", limitBytes)
+				    .detail("TotalRetryableErrors", totalRetryableErrors);
 			} else {
 				res.setPhase(AuditPhase::Complete);
 				res.range = req.range;
@@ -4622,7 +4749,10 @@ Future<Void> auditRestoreQ(StorageServer* data, AuditStorageRequest req) {
 				    .detail("Complete", complete)
 				    .detail("NumValidatedKeys", numValidatedKeys)
 				    .detail("ValidatedBytes", validatedBytes)
-				    .detail("Duration", now() - startTime);
+				    .detail("Duration", now() - startTime)
+				    .detail("RateLimiterTotalWaitTime", rateLimiterTotalWaitTime)
+				    .detail("FinalBatchBytes", limitBytes)
+				    .detail("TotalRetryableErrors", totalRetryableErrors);
 			}
 
 			// Persist final audit state
@@ -4689,7 +4819,8 @@ Future<Void> auditStorageShardReplicaQ(StorageServer* data, AuditStorageRequest 
 	double lastRateLimiterWaitTime = 0;
 	double rateLimiterBeforeWaitTime = 0;
 	double rateLimiterTotalWaitTime = 0;
-	Reference<IRateControl> rateLimiter = makeReference<SpeedLimit>(SERVER_KNOBS->AUDIT_STORAGE_RATE_PER_SERVER_MAX, 1);
+	// Server-wide, not per-task: see StorageServer::auditStorageRateLimiter.
+	Reference<IRateControl> rateLimiter = data->auditStorageRateLimiter;
 	try {
 		while (true) {
 			{
@@ -5295,7 +5426,16 @@ Future<Void> bulkDumpQ(StorageServer* data, BulkDumpRequest req) {
 			if (e.code() == error_code_actor_cancelled) {
 				throw e;
 			}
-			TraceEvent(SevWarn, "SSBulkDumpError", data->thisServerID)
+			// Retrying is the normal path here: this loop allows up to 50 attempts a second apart while
+			// shards move underneath the dump, and one task routinely burns dozens of them. Only the
+			// terminal outcome is warning-worthy. Reporting every attempt at SevWarn reads as thousands of
+			// failures rather than the handful of tasks that actually gave up.
+			const bool giveUp = e.code() == error_code_bulkdump_task_outdated ||
+			                    e.code() == error_code_wrong_shard_server || e.code() == error_code_platform_error ||
+			                    e.code() == error_code_io_error || retryCount >= 50;
+			TraceEvent(giveUp ? SevWarn : bulkLoadVerboseEventSev(),
+			           giveUp ? "SSBulkDumpError" : "SSBulkDumpRetry",
+			           data->thisServerID)
 			    .errorUnsuppressed(e)
 			    .detail("TaskID", req.bulkDumpState.getTaskId())
 			    .detail("TaskRange", req.bulkDumpState.getRange())
@@ -5306,8 +5446,7 @@ Future<Void> bulkDumpQ(StorageServer* data, BulkDumpRequest req) {
 				req.reply.sendError(bulkdump_task_outdated()); // give up
 				break; // silently exit
 			}
-			if (e.code() == error_code_wrong_shard_server || e.code() == error_code_platform_error ||
-			    e.code() == error_code_io_error || retryCount >= 50) {
+			if (giveUp) {
 				req.reply.sendError(bulkdump_task_failed()); // give up
 				break; // silently exit
 			}
@@ -6797,6 +6936,55 @@ static BulkLoadFileSetKeyMap selectOwnedBulkLoadFileSets(const BulkLoadFileSetKe
 	return owned;
 }
 
+TEST_CASE("/fdbserver/storageserver/nextAuditBatchBytes") {
+	const int floorBytes = 256000;
+	const int ceilingBytes = 4000000;
+
+	// Failure halves, and keeps halving, but never below the floor. The floor is not hang protection
+	// (GetRangeLimits sets minRows=1, so even a zero budget still returns a key): it exists because a
+	// budget of -1 reads as BYTE_LIMIT_UNLIMITED, below -1 fails as range_limits_invalid, and 0 costs a
+	// round trip per key. See nextAuditBatchBytes().
+	ASSERT_EQ(nextAuditBatchBytes(ceilingBytes, false, floorBytes, ceilingBytes), 2000000);
+	ASSERT_EQ(nextAuditBatchBytes(2000000, false, floorBytes, ceilingBytes), 1000000);
+	int budget = ceilingBytes;
+	for (int i = 0; i < 100; ++i) {
+		budget = nextAuditBatchBytes(budget, false, floorBytes, ceilingBytes);
+		ASSERT(budget >= floorBytes && budget <= ceilingBytes);
+	}
+	ASSERT_EQ(budget, floorBytes);
+
+	// Success increases additively (a quarter of the ceiling) and saturates at the ceiling rather than
+	// overshooting it.
+	ASSERT_EQ(nextAuditBatchBytes(floorBytes, true, floorBytes, ceilingBytes), floorBytes + ceilingBytes / 4);
+	ASSERT_EQ(nextAuditBatchBytes(ceilingBytes, true, floorBytes, ceilingBytes), ceilingBytes);
+	budget = floorBytes;
+	for (int i = 0; i < 100; ++i) {
+		budget = nextAuditBatchBytes(budget, true, floorBytes, ceilingBytes);
+		ASSERT(budget >= floorBytes && budget <= ceilingBytes);
+	}
+	ASSERT_EQ(budget, ceilingBytes);
+
+	// A huge ceiling must not overflow int when the increment is added.
+	ASSERT_EQ(
+	    nextAuditBatchBytes(std::numeric_limits<int>::max() - 1, true, floorBytes, std::numeric_limits<int>::max()),
+	    std::numeric_limits<int>::max());
+
+	// Degenerate configurations: floor above ceiling, and a zero/negative current budget.
+	ASSERT_EQ(nextAuditBatchBytes(1000, false, 5000, 1000), 5000); // floor wins, clamped up
+	ASSERT(nextAuditBatchBytes(0, false, floorBytes, ceilingBytes) >= floorBytes);
+	ASSERT(nextAuditBatchBytes(-1, true, floorBytes, ceilingBytes) >= floorBytes);
+	ASSERT(nextAuditBatchBytes(0, false, 0, 0) >= 1); // never returns a budget of zero
+
+	// Randomized: the budget stays inside the window no matter the sequence of outcomes.
+	budget = deterministicRandom()->randomInt(floorBytes, ceilingBytes);
+	for (int i = 0; i < 1000; ++i) {
+		budget = nextAuditBatchBytes(budget, deterministicRandom()->coinflip(), floorBytes, ceilingBytes);
+		ASSERT(budget >= floorBytes && budget <= ceilingBytes);
+	}
+
+	return Void();
+}
+
 TEST_CASE("/fdbserver/storageserver/selectOwnedBulkLoadFileSets") {
 	auto entry = [](StringRef begin, StringRef end) {
 		return std::make_pair(KeyRange(KeyRangeRef(begin, end)), BulkLoadFileSet());
@@ -7163,7 +7351,14 @@ Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 				KeyRange firstUncontainedFileRange;
 				auto ownedBulkLoadFileSets = std::make_shared<BulkLoadFileSetKeyMap>(selectOwnedBulkLoadFileSets(
 				    *localBulkLoadFileSets, keys, &allFilesContained, &firstUncontainedFileRange));
+				// Coverage probes: the filtering above only matters when a task spans more than one
+				// destination shard piece. Deliberately unannotated -- probe::assert::simOnly asserts a path
+				// is reachable ONLY under simulation, and both of these are normal production behaviour.
+				if (ownedBulkLoadFileSets->size() < localBulkLoadFileSets->size()) {
+					CODE_PROBE(true, "bulkload fetchKeys skipped a sibling fetch's file");
+				}
 				if (!allFilesContained) {
+					CODE_PROBE(true, "bulkload file straddles the fetched shard piece");
 					TraceEvent(SevInfo, "SSBulkLoadFileRangeMismatch", data->thisServerID)
 					    .detail("ShardRange", keys)
 					    .detail("FileRange", firstUncontainedFileRange)


### PR DESCRIPTION
The `validate_restore` audit phase finishes only when its slowest task does, and nothing bounded that task. Measured at 100M scale, the slowest task took **2535.86s of a 2536.0s phase — 100% of the wall clock**, so per-task throughput improvements could not move the phase at all. An earlier attempt raised the per-batch byte budget, gained a real 1.94x in per-task throughput, and made the phase **25% slower**, because that run's shards happened to be 1.87x fatter. It was optimising an average when the metric is a maximum.

This PR is a bit of a bucket. I tried splitting it out into 3/4 pieces but was hard to tell a story about each of the pieces.

## 1. Cap the size of one audit task

`scheduleAuditOnRange` divided work by live `keyServers` boundaries — one task per shard, dispatched to a single storage server that scans it sequentially — with no size cap anywhere in the audit dispatch path, so a fat shard was an unbounded straggler. Shards above `AUDIT_TASK_MAX_BYTES` (default 128MB) are now subdivided via `splitStorageMetrics`, lazily one shard at a time so the first task dispatches immediately. A failed metrics read falls back to the unsplit shard — the previous behaviour — so this cannot fail an audit that would otherwise pass.

`minSplitBytes` is `target/2`. The storage server stops splitting once `remaining.bytes < 2 * minSplitBytes`, so that product is the real "leave it alone" threshold and half the target is what puts it on the target. Passing the target itself pushes the threshold to *twice* the target and opens a dead band: 287 of 867 tasks sat unsplit in the 128–256MB band, too big for the cap but too small for the server to bother, and the tail stayed at 1215.92s.

Going *below* `target/2` makes little difference, because `getSplitKey` only splits while `remaining > target/2` and that binds first. Note also that the client discards a trailing piece under `STORAGE_METRICS_UNFAIR_SPLIT_LIMIT` (2/3) of the target, so the largest task can reach roughly **1.4x** the knob rather than exactly 1x.

The `delay(0.1)` that paces dispatch stays per `keyServers` shard rather than becoming per piece. Per piece it multiplies by the split factor and caps dispatch at 10 tasks/sec, adding a term linear in the piece count to the very wall-clock this cap exists to shorten.

## 2. Treat the batch byte budget as a ceiling and adapt within it

`AUDIT_RESTORE_BATCH_BYTE_LIMIT` previously used `CLIENT_KNOBS->REPLY_BYTE_LIMIT` (80KB), a generic per-RPC-reply cap with nothing to do with audit batching. 80KB is reached long before `AUDIT_RESTORE_BATCH_KEY_LIMIT`'s 100,000 keys at any realistic record size, so that knob was unreachable and raising it changed nothing: a 1B validation spent 2h26m in ~3.6M two-round-trip iterations at ~5.5MB/s per server, against an `AUDIT_STORAGE_RATE_PER_SERVER_MAX` allowance ~9x higher.

A fixed 4MB is no better — it took `transaction_too_old` from 679 to 2515 — because the real constraint is a **deadline, not a size**. A batch reads at a pinned version that expires after `MAX_READ_TRANSACTION_LIFE_VERSIONS`, so what a server can fetch in one go depends on current load; overshooting fails and the retry re-reads from the same key, buying double work rather than throughput. The budget now halves on a retryable error and grows back additively above `AUDIT_RESTORE_BATCH_BYTE_LIMIT_MIN`.

Also on this path:

- The two sides of a batch were read **serially** on one transaction, for two independent ranges at the same explicit read version. They are now issued together.
- Retries slept a flat 1.0s regardless of cause. They now use the existing `Backoff` helper (`DEFAULT_BACKOFF` → `DEFAULT_MAX_BACKOFF` at `BACKOFF_GROWTH_RATE`, jittered), reset on success so an occasional retry does not ratchet to the maximum.
- `numValidatedKeys`/`validatedBytes` advanced before the progress-persist that can throw, so a batch failing *there* double-counted the counters the throughput analysis reads. All per-attempt state is now snapshotted and rolled back — including `complete`, which is derived from `sourceReply.more` and would otherwise be able to end an audit early over a range never fully read.

## 3. Let a server work several audit tasks at once

`SERVE_AUDIT_STORAGE_PARALLELISM` defaulted to 1, so subdivided pieces landing on the same server would serialize and the cap would buy nothing; the default is now 4, randomized 1..4 in simulation so both paths keep coverage.

That exposed two things the knob being 1 had masked:

- The rate limiter was built **per call site**, so concurrent tasks multiplied an allowance whose knob is named `AUDIT_STORAGE_RATE_PER_SERVER_MAX`. One limiter is now shared per server, with time blocked on it reported in `SSAuditRestoreComplete` — `auditRestoreQ` had no limiter accounting at all, so a throttled audit was indistinguishable from a slow one.
- `auditStorageServerShardQ` requires **exclusive** use of the server: it owns `shardAssignmentHistory`, which is single-instance state, and `startTrackShardAssignment()` asserts tracking is off. It now takes a dedicated lock instead of relying on the permit count. Without that, the per-server retry at the end of `scheduleAuditStorageShardOnServer` can re-dispatch while the previous attempt is still running on that server; at one permit the second request queued, at four it runs concurrently and trips the guard. Observed as `SevError ExistStorageServerShardAuditExit` on `Sideband`, `InventoryTestSomeWrites` and `MoveKeysCycle` — 3 hits across 20,000 runs, every one audit id 1 and `usable_regions:=2`.

## 4. Two pre-existing ways an ssshard audit wedges a storage server

Both reachable without any of the above, and both found while diagnosing the failure in §3.

- **Cancellation stranded the tracking flag.** `stopTrackShardAssignment()` was reached only by plain statements at the end of the function and on its error paths. Cancellation runs none of them — it destroys the coroutine frame — leaving `trackShardAssignmentMinVersion` set with no audit owning it, after which every later ssshard audit on that server bails out on the guard **for the life of the process**. Now runs from a `ScopeExit` guard.
- **The guard leaked a parallelism permit.** Its early `co_return` sat between `take()` and the `FlowLock::Releaser`, and that lock is shared by every audit type, so enough leaks exhaust it and every subsequent audit on that server blocks in `take()` forever, with only a warning to say so.

Cancellation is routine here — the retry above re-dispatches after any failure, and Attrition, `RandomMoveKeys` and remote-DC latency all supply those failures — so these are worth considering for backport independently of the performance work.

## 5. Two report-storm fixes

- **BulkLoad** — `scheduleBulkLoadTasks()` rescans task metadata every `DD_BULKLOAD_SCHEDULE_MIN_INTERVAL_SEC`, and a task in the terminal `Error` phase is deliberately left in place (unlike `Acknowledged`, it is never erased), so the `SevWarnAlways` report fired again on every scan for the life of the cluster: 11,313 events from 2 tasks in one 1B run, still climbing hours after the job finished. Each task is now reported once, carrying the running total.
- **BulkDump** — the SS bulkdump loop retries up to 50 times, a second apart, while shards move underneath it; retrying is the normal path. Every attempt logged `SevWarn SSBulkDumpError` — 18,023 events in one run against 29,026 files generated. Intermediate retries move to `SSBulkDumpRetry` at `bulkLoadVerboseEventSev()`; the terminal cases keep the original name and severity, so existing greps and dashboards keep working and now match only tasks that actually failed.

Both matter beyond tidiness: this is how the real failure ends up buried thousands of log lines from the top.

## Results

| | before | after |
|---|---|---|
| audit phase | 42m16s | **25m00s** (also 26% below the 33m47s pre-existing baseline) |
| `transaction_too_old` | 2515 | **150** (below the baseline's 679) |
| aggregate audit throughput | 79 MB/s | **130 MB/s** |
| `RateLimiterTotalWaitTime` | — | 0, so the shared limiter never bound |

Zero `SSAuditRestoreError`, zero `StorageServerFailed`.

**These numbers need retaking.** They were measured before the `minSplitBytes` correction in §1 and before the dispatch-throttle decision, both of which change the task count. Treat them as evidence that the approach works, not as the current figures.

## Testing

`nextAuditBatchBytes()` is pure and unit tested for the budget staying within `[floor, ceiling]` and never reaching zero or below. That is *not* hang protection — `GetRangeLimits` sets `minRows = 1`, so even a zero budget returns a key — but because `GetRangeLimits` overloads the sign of `bytes`: `-1` means `BYTE_LIMIT_UNLIMITED` and silently removes the bound, below `-1` fails `isValid()`, and `0` costs a round trip per key.

`boundAuditTaskRange()` is covered by a mock `IDDTxnProcessor`, including that a failed metrics read degrades to the unsplit shard rather than failing the audit, and asserting `minSplitBytes <= target/2` because exceeding it is silent — subdivision just does not happen and the only symptom is a slower tail that looks like variance.

Split points become task ranges with the same consecutive-pairs idiom `DDShardTracker::executeShardSplit()` uses. `splitStorageMetrics()` guarantees `begin` and `end` as its first and last points and `NativeAPI` rejects out-of-order replies, so no defensive re-derivation is needed here.

Per-batch traces are gated behind the existing `ENABLE_AUDIT_VERBOSE_TRACE` knob; at 1B scale they were ~18M unconditional `SevInfo` events. There is a `TODO(Audit)` to move that gate into `fdbclient/Audit.h` and adopt it in `DataDistribution.cpp`, which currently gates the same knob with six `if` blocks — deferred because it flips those sites from emitting nothing to `SevDebug`, a trace-volume change worth measuring on its own.

Joshua, 100k runs, clean:

```
20260818-041541-stack-13886-04944201f8ee8683  ended=100000 pass=100000 remaining=0
  max_runs=100000 runtime=0:31:15 timeout=5400 username=stack-13886
```

`ExistStorageServerShardAuditExit` did not recur, against 3 hits in 20,000 runs before §3 and §4.

---

<sub>Rebased and squashed to a single commit since first posted. Substantive changes from review: `minSplitBytes` `target/8` → `target/2`; the dispatch throttle kept per-shard rather than per-piece; the ssshard fixes in §4 added; `AUDIT_RESTORE_BATCH_BYTE_LIMIT`/`_MIN` narrowed `int64_t` → `int` since they feed `GetRangeLimits::bytes`; and three reimplementations dropped in favour of existing machinery — a bespoke split-point partitioner (NativeAPI already guarantees the contract), a hand-rolled backoff (`Backoff`), and a local scope guard (`flow/ScopeExit.h`).</sub>
