### PR TITLE
Remove redundant `explicit(false)` from copy and move constructors

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -102,6 +102,9 @@ jobs:
               fdbclient/S3BlobStore.cpp|fdbserver/kvstore/RocksDBLogForwarder.h)
                 continue
                 ;;
+              fdbserver/kvstore/ArtMutationBuffer.h)
+                continue  # included inside VersionedBTree's class definition
+                ;;
               fdbrpc/AsyncFileKAIO.h)
                 continue
                 ;;

--- a/fdbcli/fdbcli.cpp
+++ b/fdbcli/fdbcli.cpp
@@ -246,7 +246,7 @@ private:
 		std::map<std::string, typename T::Option> legalOptions;
 
 		OptionGroup() = default;
-		explicit(false) OptionGroup(OptionGroup<T>& base)
+		OptionGroup(OptionGroup<T>& base)
 		  : options(base.options.begin(), base.options.end()), legalOptions(base.legalOptions) {}
 
 		// Enable or disable an option. Returns true if option value changed
@@ -328,7 +328,7 @@ public:
 			transactionOptions.legalOptions[itr->second.name] = itr->first;
 	}
 
-	explicit(false) FdbOptions(FdbOptions& base) = default;
+	FdbOptions(FdbOptions& base) = default;
 };
 
 static std::string formatStringRef(StringRef item, bool fullEscaping = false) {

--- a/fdbclient/SnapshotCache.h
+++ b/fdbclient/SnapshotCache.h
@@ -315,7 +315,7 @@ public:
 		entries.insert(Entry(allKeys.end, afterAllKeys, VectorRef<KeyValueRef>()), NoMetric(), true);
 	}
 	// Visual Studio refuses to generate these, apparently despite the standard
-	explicit(false) SnapshotCache(SnapshotCache&& r) noexcept : arena(r.arena), entries(std::move(r.entries)) {}
+	SnapshotCache(SnapshotCache&& r) noexcept : arena(r.arena), entries(std::move(r.entries)) {}
 	SnapshotCache& operator=(SnapshotCache&& r) noexcept {
 		entries = std::move(r.entries);
 		arena = r.arena;

--- a/fdbclient/WriteMap.h
+++ b/fdbclient/WriteMap.h
@@ -162,7 +162,7 @@ public:
 		                                IsUnreadable::False));
 	}
 
-	explicit(false) WriteMap(WriteMap&& r) noexcept
+	WriteMap(WriteMap&& r) noexcept
 	  : arena(r.arena), writeMapEmpty(r.writeMapEmpty), writes(std::move(r.writes)), ver(r.ver),
 	    scratch_iterator(std::move(r.scratch_iterator)) {}
 

--- a/fdbclient/include/fdbclient/BackupAgent.h
+++ b/fdbclient/include/fdbclient/BackupAgent.h
@@ -143,7 +143,7 @@ class FileBackupAgent : public BackupAgentBase {
 public:
 	FileBackupAgent();
 
-	explicit(false) FileBackupAgent(FileBackupAgent&& r) noexcept
+	FileBackupAgent(FileBackupAgent&& r) noexcept
 	  : subspace(r.subspace), config(r.config), lastRestorable(r.lastRestorable), taskBucket(std::move(r.taskBucket)),
 	    futureBucket(std::move(r.futureBucket)) {}
 
@@ -393,7 +393,7 @@ public:
 	DatabaseBackupAgent();
 	explicit DatabaseBackupAgent(Database src);
 
-	explicit(false) DatabaseBackupAgent(DatabaseBackupAgent&& r) noexcept
+	DatabaseBackupAgent(DatabaseBackupAgent&& r) noexcept
 	  : subspace(r.subspace), states(r.states), config(r.config), errors(r.errors), ranges(r.ranges),
 	    tagNames(r.tagNames), sourceStates(r.sourceStates), sourceTagNames(r.sourceTagNames),
 	    taskBucket(std::move(r.taskBucket)), futureBucket(std::move(r.futureBucket)) {}

--- a/fdbclient/include/fdbclient/IBlobStore.h
+++ b/fdbclient/include/fdbclient/IBlobStore.h
@@ -191,7 +191,7 @@ public:
 		}
 
 		// CROSS_PROCESS_FIX: Copy constructor with cross-process detection
-		explicit(false) ReusableConnection(const ReusableConnection& other)
+		ReusableConnection(const ReusableConnection& other)
 		  : conn(other.conn), expirationTime(other.expirationTime), creatingProcess(other.creatingProcess) {
 			if (g_network && g_network->isSimulated() && creatingProcess.isValid() &&
 			    creatingProcess != g_network->getLocalAddress()) {

--- a/fdbclient/include/fdbclient/IdempotencyId.h
+++ b/fdbclient/include/fdbclient/IdempotencyId.h
@@ -85,9 +85,9 @@ struct IdempotencyIdRef {
 
 	bool operator==(const IdempotencyIdRef& other) const { return asStringRefUnsafe() == other.asStringRefUnsafe(); }
 
-	explicit(false) IdempotencyIdRef(IdempotencyIdRef&& other) = default;
+	IdempotencyIdRef(IdempotencyIdRef&& other) = default;
 	IdempotencyIdRef& operator=(IdempotencyIdRef&& other) = default;
-	explicit(false) IdempotencyIdRef(const IdempotencyIdRef& other) = default;
+	IdempotencyIdRef(const IdempotencyIdRef& other) = default;
 	IdempotencyIdRef& operator=(const IdempotencyIdRef& other) = default;
 
 	template <class Archive>

--- a/fdbclient/include/fdbclient/KeyRangeMap.h
+++ b/fdbclient/include/fdbclient/KeyRangeMap.h
@@ -107,7 +107,7 @@ public:
 		RangeMap<Key, Val, KeyRangeRef, Metric, MetricFunc>::operator=(std::move(r));
 	}
 
-	explicit(false) CoalescedKeyRangeMap(CoalescedKeyRangeMap&& source) = default;
+	CoalescedKeyRangeMap(CoalescedKeyRangeMap&& source) = default;
 
 	void insert(const KeyRangeRef& keys, const Val& value);
 	void insert(const KeyRef& key, const Val& value);

--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -108,8 +108,8 @@ public:
 
 	Database() {} // an uninitialized database can be destructed or reassigned safely; that's it
 	void operator=(Database const& rhs) { db = rhs.db; }
-	explicit(false) Database(Database const& rhs) : db(rhs.db) {}
-	explicit(false) Database(Database&& r) noexcept : db(std::move(r.db)) {}
+	Database(Database const& rhs) : db(rhs.db) {}
+	Database(Database&& r) noexcept : db(std::move(r.db)) {}
 	void operator=(Database&& r) noexcept { db = std::move(r.db); }
 
 	// For internal use by the native client:

--- a/fdbclient/include/fdbclient/Notified.h
+++ b/fdbclient/include/fdbclient/Notified.h
@@ -76,7 +76,7 @@ struct Notified {
 
 	void operator=(const ValueType& v) { set(v); }
 
-	explicit(false) Notified(Notified&& r) noexcept : waiting(std::move(r.waiting)), val(std::move(r.val)) {}
+	Notified(Notified&& r) noexcept : waiting(std::move(r.waiting)), val(std::move(r.val)) {}
 	void operator=(Notified&& r) noexcept {
 		waiting = std::move(r.waiting);
 		val = std::move(r.val);

--- a/fdbclient/include/fdbclient/ReadYourWrites.h
+++ b/fdbclient/include/fdbclient/ReadYourWrites.h
@@ -147,7 +147,7 @@ public:
 	// These are to permit use as state variables in actors:
 	ReadYourWritesTransaction();
 	void operator=(ReadYourWritesTransaction&& r) noexcept;
-	explicit(false) ReadYourWritesTransaction(ReadYourWritesTransaction&& r) noexcept;
+	ReadYourWritesTransaction(ReadYourWritesTransaction&& r) noexcept;
 
 	void cancel();
 	void reset();

--- a/fdbclient/include/fdbclient/SimpleIni.h
+++ b/fdbclient/include/fdbclient/SimpleIni.h
@@ -301,7 +301,7 @@ public:
 		  : pItem(a_pszItem), pComment(NULL), nOrder(a_nOrder) {}
 		Entry(const SI_CHAR* a_pszItem, const SI_CHAR* a_pszComment, int a_nOrder)
 		  : pItem(a_pszItem), pComment(a_pszComment), nOrder(a_nOrder) {}
-		explicit(false) Entry(const Entry& rhs) { operator=(rhs); }
+		Entry(const Entry& rhs) { operator=(rhs); }
 		Entry& operator=(const Entry& rhs) {
 			pItem = rhs.pItem;
 			pComment = rhs.pComment;
@@ -355,7 +355,7 @@ public:
 		virtual void Write(const char* a_pBuf) = 0;
 
 	private:
-		explicit(false) OutputWriter(const OutputWriter&); // disable
+		OutputWriter(const OutputWriter&); // disable
 		OutputWriter& operator=(const OutputWriter&); // disable
 	};
 
@@ -368,7 +368,7 @@ public:
 		void Write(const char* a_pBuf) { fputs(a_pBuf, m_file); }
 
 	private:
-		explicit(false) FileWriter(const FileWriter&); // disable
+		FileWriter(const FileWriter&); // disable
 		FileWriter& operator=(const FileWriter&); // disable
 	};
 
@@ -381,7 +381,7 @@ public:
 		void Write(const char* a_pBuf) { m_string.append(a_pBuf); }
 
 	private:
-		explicit(false) StringWriter(const StringWriter&); // disable
+		StringWriter(const StringWriter&); // disable
 		StringWriter& operator=(const StringWriter&); // disable
 	};
 
@@ -395,7 +395,7 @@ public:
 		void Write(const char* a_pBuf) { m_ostream << a_pBuf; }
 
 	private:
-		explicit(false) StreamWriter(const StreamWriter&); // disable
+		StreamWriter(const StreamWriter&); // disable
 		StreamWriter& operator=(const StreamWriter&); // disable
 	};
 #endif // SI_SUPPORT_IOSTREAMS
@@ -407,7 +407,7 @@ public:
 	public:
 		using SI_CONVERTER::SizeToStore;
 		explicit Converter(bool a_bStoreIsUtf8) : SI_CONVERTER(a_bStoreIsUtf8) { m_scratch.resize(1024); }
-		explicit(false) Converter(const Converter& rhs) { operator=(rhs); }
+		Converter(const Converter& rhs) { operator=(rhs); }
 		Converter& operator=(const Converter& rhs) {
 			m_scratch = rhs.m_scratch;
 			return *this;
@@ -1012,7 +1012,7 @@ public:
 
 private:
 	// copying is not permitted
-	explicit(false) CSimpleIniTempl(const CSimpleIniTempl&); // disabled
+	CSimpleIniTempl(const CSimpleIniTempl&); // disabled
 	CSimpleIniTempl& operator=(const CSimpleIniTempl&); // disabled
 
 	/** Parse the data looking for a file comment and store it if found.
@@ -2435,7 +2435,7 @@ public:
 	explicit SI_ConvertA(bool a_bStoreIsUtf8) : m_bStoreIsUtf8(a_bStoreIsUtf8) {}
 
 	/* copy and assignment */
-	explicit(false) SI_ConvertA(const SI_ConvertA& rhs) { operator=(rhs); }
+	SI_ConvertA(const SI_ConvertA& rhs) { operator=(rhs); }
 	SI_ConvertA& operator=(const SI_ConvertA& rhs) {
 		m_bStoreIsUtf8 = rhs.m_bStoreIsUtf8;
 		return *this;
@@ -2554,7 +2554,7 @@ public:
 	explicit SI_ConvertW(bool a_bStoreIsUtf8) : m_bStoreIsUtf8(a_bStoreIsUtf8) {}
 
 	/* copy and assignment */
-	explicit(false) SI_ConvertW(const SI_ConvertW& rhs) { operator=(rhs); }
+	SI_ConvertW(const SI_ConvertW& rhs) { operator=(rhs); }
 	SI_ConvertW& operator=(const SI_ConvertW& rhs) {
 		m_bStoreIsUtf8 = rhs.m_bStoreIsUtf8;
 		return *this;
@@ -2735,7 +2735,7 @@ public:
 	explicit SI_ConvertW(bool a_bStoreIsUtf8) : m_pConverter(NULL) { m_pEncoding = a_bStoreIsUtf8 ? "UTF-8" : NULL; }
 
 	/* copy and assignment */
-	explicit(false) SI_ConvertW(const SI_ConvertW& rhs) { operator=(rhs); }
+	SI_ConvertW(const SI_ConvertW& rhs) { operator=(rhs); }
 	SI_ConvertW& operator=(const SI_ConvertW& rhs) {
 		m_pEncoding = rhs.m_pEncoding;
 		m_pConverter = NULL;
@@ -2942,7 +2942,7 @@ public:
 	explicit SI_ConvertW(bool a_bStoreIsUtf8) { m_uCodePage = a_bStoreIsUtf8 ? CP_UTF8 : CP_ACP; }
 
 	/* copy and assignment */
-	explicit(false) SI_ConvertW(const SI_ConvertW& rhs) { operator=(rhs); }
+	SI_ConvertW(const SI_ConvertW& rhs) { operator=(rhs); }
 	SI_ConvertW& operator=(const SI_ConvertW& rhs) {
 		m_uCodePage = rhs.m_uCodePage;
 		return *this;

--- a/fdbclient/include/fdbclient/ThreadSafeTransaction.h
+++ b/fdbclient/include/fdbclient/ThreadSafeTransaction.h
@@ -163,7 +163,7 @@ public:
 	// These are to permit use as state variables in actors:
 	ThreadSafeTransaction() : tr(nullptr), initialized(std::make_shared<std::atomic_bool>(false)) {}
 	void operator=(ThreadSafeTransaction&& r) noexcept;
-	explicit(false) ThreadSafeTransaction(ThreadSafeTransaction&& r) noexcept;
+	ThreadSafeTransaction(ThreadSafeTransaction&& r) noexcept;
 
 	void reset() override;
 

--- a/fdbclient/include/fdbclient/Tracing.h
+++ b/fdbclient/include/fdbclient/Tracing.h
@@ -50,7 +50,7 @@ struct SpanContext {
 	SpanContext() : traceID(UID()), spanID(0), m_Flags(TraceFlags::unsampled) {}
 	SpanContext(UID traceID, uint64_t spanID, TraceFlags flags) : traceID(traceID), spanID(spanID), m_Flags(flags) {}
 	SpanContext(UID traceID, uint64_t spanID) : traceID(traceID), spanID(spanID), m_Flags(TraceFlags::unsampled) {}
-	explicit(false) SpanContext(const SpanContext& span) = default;
+	SpanContext(const SpanContext& span) = default;
 	bool isSampled() const { return (m_Flags & TraceFlags::sampled) == TraceFlags::sampled; }
 	std::string toString() const { return format("%016llx%016llx%016llx", traceID.first(), traceID.second(), spanID); };
 	bool isValid() const { return traceID.first() != 0 && traceID.second() != 0 && spanID != 0; }
@@ -160,7 +160,7 @@ public:
 	explicit Span(const Location& location) : Span(location, SpanContext()) {}
 
 	Span(const Span&) = delete;
-	explicit(false) Span(Span&& o) {
+	Span(Span&& o) {
 		arena = std::move(o.arena);
 		context = o.context;
 		location = o.location;

--- a/fdbclient/include/fdbclient/TransactionLineage.h
+++ b/fdbclient/include/fdbclient/TransactionLineage.h
@@ -108,8 +108,7 @@ public:
 		}
 		getCurrentLineage()->modify(member) = before;
 	}
-	explicit(false) ScopedLineage(ScopedLineage<T, V>&& o)
-	  : before(std::move(o.before)), member(o.member), valid(o.valid) {
+	ScopedLineage(ScopedLineage<T, V>&& o) : before(std::move(o.before)), member(o.member), valid(o.valid) {
 		o.release();
 	}
 	ScopedLineage& operator=(ScopedLineage<T, V>&& o) {

--- a/fdbclient/include/fdbclient/VersionedMap.h
+++ b/fdbclient/include/fdbclient/VersionedMap.h
@@ -121,7 +121,7 @@ struct PTree : public ReferenceCounted<PTree<T>>, FastAllocated<PTree<T>>, NonCo
 	}
 
 private:
-	explicit(false) PTree(PTree const&);
+	PTree(PTree const&);
 };
 
 template <class T>
@@ -139,8 +139,8 @@ public:
 	PTreeFinger() = default;
 
 	// Explicit copy constructors ensure we copy the live values in entries_.
-	explicit(false) PTreeFinger(PTreeFinger const& f) { *this = f; }
-	explicit(false) PTreeFinger(PTreeFinger&& f) { *this = f; }
+	PTreeFinger(PTreeFinger const& f) { *this = f; }
+	PTreeFinger(PTreeFinger&& f) { *this = f; }
 
 	PTreeFinger& operator=(PTreeFinger const& f) {
 		size_ = f.size_;
@@ -769,7 +769,7 @@ public:
 	VersionedMap() : oldestVersion(0), latestVersion(0), priorityRandom(deterministicRandom()) {
 		roots.emplace_back(0, Tree());
 	}
-	explicit(false) VersionedMap(VersionedMap&& v) noexcept
+	VersionedMap(VersionedMap&& v) noexcept
 	  : oldestVersion(v.oldestVersion), latestVersion(v.latestVersion), priorityRandom(std::move(v.priorityRandom)),
 	    roots(std::move(v.roots)) {}
 	void operator=(VersionedMap&& v) noexcept {

--- a/fdbclient/include/fdbclient/json_spirit/json_spirit_value.h
+++ b/fdbclient/include/fdbclient/json_spirit/json_spirit_value.h
@@ -62,7 +62,7 @@ public:
 	explicit(false) Value_impl(
 	    const boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>& variant); // constructor for compatible variant types
 
-	explicit(false) Value_impl(const Value_impl& other);
+	Value_impl(const Value_impl& other);
 
 	bool operator==(const Value_impl& lhs) const;
 

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -1409,7 +1409,7 @@ struct Tracker {
 	int copied;
 	bool moved;
 	explicit Tracker(int copied = 0) : copied(copied), moved(false) {}
-	explicit(false) Tracker(Tracker&& other) : Tracker(other.copied) {
+	Tracker(Tracker&& other) : Tracker(other.copied) {
 		ASSERT(!other.moved);
 		other.moved = true;
 	}
@@ -1420,7 +1420,7 @@ struct Tracker {
 		this->copied = other.copied;
 		return *this;
 	}
-	explicit(false) Tracker(const Tracker& other) : Tracker(other.copied + 1) { ASSERT(!other.moved); }
+	Tracker(const Tracker& other) : Tracker(other.copied + 1) { ASSERT(!other.moved); }
 	Tracker& operator=(const Tracker& other) {
 		ASSERT(!other.moved);
 		this->moved = false;

--- a/fdbrpc/include/fdbrpc/RangeMap.h
+++ b/fdbrpc/include/fdbrpc/RangeMap.h
@@ -211,7 +211,7 @@ public:
 
 	void operator=(RangeMap&& r) noexcept { map = std::move(r.map); }
 
-	explicit(false) RangeMap(RangeMap&& source) = default;
+	RangeMap(RangeMap&& source) = default;
 	// void clear( const Val& value ) { ranges.clear(); ranges.insert(std::make_pair(Key(),value)); }
 	void clear() { map.clear(); }
 

--- a/fdbrpc/include/fdbrpc/Replication.h
+++ b/fdbrpc/include/fdbrpc/Replication.h
@@ -28,11 +28,11 @@
 
 struct LocalitySet : public ReferenceCounted<LocalitySet> {
 public:
-	explicit(false) LocalitySet(LocalitySet const& source)
+	LocalitySet(LocalitySet const& source)
 	  : _keymap(source._keymap), _entryArray(source._entryArray), _mutableEntryArray(source._mutableEntryArray),
 	    _keyValueArray(source._keyValueArray), _keyIndexArray(source._keyIndexArray), _cacheArray(source._cacheArray),
 	    _localitygroup(source._localitygroup), _cachehits(source._cachehits), _cachemisses(source._cachemisses) {}
-	explicit(false) LocalitySet(LocalitySet& localityGroup)
+	LocalitySet(LocalitySet& localityGroup)
 	  : _keymap(new StringToIntMap()), _localitygroup(&localityGroup), _cachehits(0), _cachemisses(0) {}
 	virtual ~LocalitySet() = default;
 
@@ -474,7 +474,7 @@ protected:
 		Reference<LocalitySet> _resultset;
 		LocalityCacheRecord(AttribRecord const& attribute, Reference<LocalitySet> resultset)
 		  : _attribute(attribute), _resultset(resultset) {}
-		explicit(false) LocalityCacheRecord(LocalityCacheRecord const&) = default;
+		LocalityCacheRecord(LocalityCacheRecord const&) = default;
 		virtual ~LocalityCacheRecord() = default;
 		LocalityCacheRecord& operator=(LocalityCacheRecord const&) = default;
 		int getMemoryUsed() const { return sizeof(_attribute) + sizeof(_resultset) + _resultset->getMemoryUsed(); }
@@ -521,7 +521,7 @@ protected:
 
 struct LocalityGroup : public LocalitySet {
 	LocalityGroup() : LocalitySet(*this), _valuemap(new StringToIntMap()) {}
-	explicit(false) LocalityGroup(LocalityGroup const&) = default;
+	LocalityGroup(LocalityGroup const&) = default;
 	~LocalityGroup() override = default;
 
 	LocalityEntry const& add(LocalityData const& data) {
@@ -601,7 +601,7 @@ protected:
 template <class V>
 struct LocalityMap : public LocalityGroup {
 	LocalityMap() = default;
-	explicit(false) LocalityMap(LocalityMap const&) = default;
+	LocalityMap(LocalityMap const&) = default;
 	~LocalityMap() override = default;
 
 	bool selectReplicas(Reference<IReplicationPolicy> const& policy,

--- a/fdbrpc/include/fdbrpc/ReplicationTypes.h
+++ b/fdbrpc/include/fdbrpc/ReplicationTypes.h
@@ -69,7 +69,7 @@ struct KeyValueMap final : public ReferenceCounted<KeyValueMap> {
 
 	KeyValueMap() = default;
 	explicit KeyValueMap(const LocalityData& data);
-	explicit(false) KeyValueMap(const KeyValueMap& entry) : _keyvaluearray(entry._keyvaluearray) {}
+	KeyValueMap(const KeyValueMap& entry) : _keyvaluearray(entry._keyvaluearray) {}
 	KeyValueMap& operator=(KeyValueMap const& source) {
 		_keyvaluearray = source._keyvaluearray;
 		return *this;
@@ -111,8 +111,7 @@ struct LocalityRecord final : public ReferenceCounted<LocalityRecord> {
 	LocalityEntry _entryIndex;
 	LocalityRecord(Reference<KeyValueMap> const& dataMap, int arrayIndex)
 	  : _dataMap(dataMap), _entryIndex(arrayIndex) {}
-	explicit(false) LocalityRecord(LocalityRecord const& entry)
-	  : _dataMap(entry._dataMap), _entryIndex(entry._entryIndex) {}
+	LocalityRecord(LocalityRecord const& entry) : _dataMap(entry._dataMap), _entryIndex(entry._entryIndex) {}
 	LocalityRecord& operator=(LocalityRecord const& source) {
 		_dataMap = source._dataMap;
 		_entryIndex = source._entryIndex;
@@ -145,8 +144,7 @@ struct StringToIntMap final : public ReferenceCounted<StringToIntMap> {
 	std::map<std::string, int> _hashmap;
 	std::vector<std::string> _lookuparray;
 	StringToIntMap() = default;
-	explicit(false) StringToIntMap(StringToIntMap const& source)
-	  : _hashmap(source._hashmap), _lookuparray(source._lookuparray) {}
+	StringToIntMap(StringToIntMap const& source) : _hashmap(source._hashmap), _lookuparray(source._lookuparray) {}
 	StringToIntMap& operator=(StringToIntMap const& source) {
 		_hashmap = source._hashmap;
 		_lookuparray = source._lookuparray;

--- a/fdbrpc/include/fdbrpc/Stats.h
+++ b/fdbrpc/include/fdbrpc/Stats.h
@@ -220,7 +220,7 @@ public:
 	    double loggingInterval,
 	    std::function<void(TraceEvent&)> const& decorator = [](auto&) {});
 
-	explicit(false) LatencyBands(LatencyBands&&) = default;
+	LatencyBands(LatencyBands&&) = default;
 	LatencyBands& operator=(LatencyBands&&) = default;
 
 	void addThreshold(double value);

--- a/fdbrpc/include/fdbrpc/fdbrpc.h
+++ b/fdbrpc/include/fdbrpc/fdbrpc.h
@@ -158,8 +158,8 @@ public:
 	explicit ReplyPromise(const PeerCompatibilityPolicy& policy) : ReplyPromise() {
 		sav->setPeerCompatibilityPolicy(policy);
 	}
-	explicit(false) ReplyPromise(const ReplyPromise& rhs) : sav(rhs.sav) { sav->addPromiseRef(); }
-	explicit(false) ReplyPromise(ReplyPromise&& rhs) noexcept : sav(rhs.sav) { rhs.sav = 0; }
+	ReplyPromise(const ReplyPromise& rhs) : sav(rhs.sav) { sav->addPromiseRef(); }
+	ReplyPromise(ReplyPromise&& rhs) noexcept : sav(rhs.sav) { rhs.sav = 0; }
 	~ReplyPromise() {
 		if (sav)
 			sav->delPromiseRef();
@@ -503,13 +503,13 @@ public:
 		return FutureStream<T>(queue);
 	}
 	ReplyPromiseStream() : queue(new NetNotifiedQueueWithAcknowledgements<T>(0, 1)), errors(new SAV<Void>(0, 1)) {}
-	explicit(false) ReplyPromiseStream(const ReplyPromiseStream& rhs) : queue(rhs.queue), errors(rhs.errors) {
+	ReplyPromiseStream(const ReplyPromiseStream& rhs) : queue(rhs.queue), errors(rhs.errors) {
 		queue->addPromiseRef();
 		if (errors) {
 			errors->addPromiseRef();
 		}
 	}
-	explicit(false) ReplyPromiseStream(ReplyPromiseStream&& rhs) noexcept : queue(rhs.queue), errors(rhs.errors) {
+	ReplyPromiseStream(ReplyPromiseStream&& rhs) noexcept : queue(rhs.queue), errors(rhs.errors) {
 		rhs.queue = nullptr;
 		rhs.errors = nullptr;
 	}
@@ -907,8 +907,8 @@ public:
 	explicit RequestStream(PeerCompatibilityPolicy policy) : RequestStream() {
 		queue->setPeerCompatibilityPolicy(policy);
 	}
-	explicit(false) RequestStream(const RequestStream& rhs) : queue(rhs.queue) { queue->addPromiseRef(); }
-	explicit(false) RequestStream(RequestStream&& rhs) noexcept : queue(rhs.queue) { rhs.queue = 0; }
+	RequestStream(const RequestStream& rhs) : queue(rhs.queue) { queue->addPromiseRef(); }
+	RequestStream(RequestStream&& rhs) noexcept : queue(rhs.queue) { rhs.queue = 0; }
 	void operator=(const RequestStream& rhs) {
 		rhs.queue->addPromiseRef();
 		if (queue)

--- a/fdbserver/clustercontroller/ClusterController.h
+++ b/fdbserver/clustercontroller/ClusterController.h
@@ -78,7 +78,7 @@ struct WorkerInfo : NonCopyable {
 	  : watcher(watcher), reply(reply), gen(gen), reboots(0), verified(false), initialClass(initialClass),
 	    priorityInfo(priorityInfo), details(interf, processClass, degraded, recoveredDiskFiles), issues(issues) {}
 
-	explicit(false) WorkerInfo(WorkerInfo&& r) noexcept
+	WorkerInfo(WorkerInfo&& r) noexcept
 	  : watcher(std::move(r.watcher)), reply(std::move(r.reply)), gen(r.gen), reboots(r.reboots), verified(r.verified),
 	    initialClass(r.initialClass), priorityInfo(r.priorityInfo), details(std::move(r.details)),
 	    distributorInterf(std::move(r.distributorInterf)), ratekeeperInterf(std::move(r.ratekeeperInterf)),

--- a/fdbserver/clustercontroller/ClusterHealthMonitor.h
+++ b/fdbserver/clustercontroller/ClusterHealthMonitor.h
@@ -105,7 +105,7 @@ class Monitor {
 	Monitor(std::vector<std::unique_ptr<IFactor>>&& factors, Reference<IWorkerEventProvider const> workerEventProvider);
 
 public:
-	explicit(false) Monitor(Monitor&&) noexcept = default;
+	Monitor(Monitor&&) noexcept = default;
 	Monitor& operator=(Monitor&&) noexcept = default;
 
 	static Monitor create(Reference<IWorkerEventProvider const> workerEventProvider);

--- a/fdbserver/core/include/fdbserver/core/MasterInterface.h
+++ b/fdbserver/core/include/fdbserver/core/MasterInterface.h
@@ -288,7 +288,7 @@ struct CommitProxyVersionReplies {
 	MAP_UInt64_GetCommitVersionReply replies;
 	NotifiedVersion latestRequestNum;
 
-	explicit(false) CommitProxyVersionReplies(CommitProxyVersionReplies&& r) noexcept
+	CommitProxyVersionReplies(CommitProxyVersionReplies&& r) noexcept
 	  : replies(std::move(r.replies)), latestRequestNum(std::move(r.latestRequestNum)) {}
 
 	void operator=(CommitProxyVersionReplies&& r) noexcept {

--- a/fdbserver/fdbserver.cpp
+++ b/fdbserver/fdbserver.cpp
@@ -316,7 +316,7 @@ public:
 	boost::interprocess::permissions permission;
 
 private:
-	explicit(false) WorldReadablePermissions(const WorldReadablePermissions& rhs) {}
+	WorldReadablePermissions(const WorldReadablePermissions& rhs) {}
 #ifdef _WIN32
 	SECURITY_ATTRIBUTES sa;
 #endif

--- a/fdbserver/kvstore/ArtMutationBuffer.h
+++ b/fdbserver/kvstore/ArtMutationBuffer.h
@@ -37,7 +37,7 @@ public:
 
 		explicit const_iterator(art_iterator i) { artIterator = i; }
 
-		explicit(false) const_iterator(const const_iterator& i) { artIterator = i.artIterator; }
+		const_iterator(const const_iterator& i) { artIterator = i.artIterator; }
 
 		const KeyRef& key() const { return artIterator.key(); }
 
@@ -65,7 +65,7 @@ public:
 
 		explicit iterator(art_iterator i) { artIterator = i; }
 
-		explicit(false) iterator(const iterator& i) { artIterator = i.artIterator; }
+		iterator(const iterator& i) { artIterator = i.artIterator; }
 
 		const KeyRef& key() const { return artIterator.key(); }
 

--- a/fdbserver/kvstore/DeltaTree.h
+++ b/fdbserver/kvstore/DeltaTree.h
@@ -1149,7 +1149,7 @@ public:
 		  : tree(tree), cache(cache), nodeIndex(nodeIndex) {}
 
 		// Copy constructor does not copy item because normally a copied cursor will be immediately moved.
-		explicit(false) Cursor(const Cursor& c) : tree(c.tree), cache(c.cache), nodeIndex(c.nodeIndex) {}
+		Cursor(const Cursor& c) : tree(c.tree), cache(c.cache), nodeIndex(c.nodeIndex) {}
 
 		~Cursor() {
 			if (cache.isValid()) {

--- a/fdbserver/kvstore/IKeyValueContainer.h
+++ b/fdbserver/kvstore/IKeyValueContainer.h
@@ -36,7 +36,7 @@ struct KeyValueMapPair {
 		key = rhs.key;
 		value = rhs.value;
 	}
-	explicit(false) KeyValueMapPair(KeyValueMapPair const& rhs) : arena(rhs.arena), key(rhs.key), value(rhs.value) {}
+	KeyValueMapPair(KeyValueMapPair const& rhs) : arena(rhs.arena), key(rhs.key), value(rhs.value) {}
 
 	KeyValueMapPair(KeyRef key, ValueRef value)
 	  : arena(key.expectedSize() + value.expectedSize()), key(arena, key), value(arena, value) {}
@@ -115,7 +115,7 @@ public:
 	static constexpr int getElementBytes() { return IndexedSet<KeyValueMapPair, uint64_t>::getElementBytes(); }
 
 private:
-	explicit(false) IKeyValueContainer(IKeyValueContainer const&); // unimplemented
+	IKeyValueContainer(IKeyValueContainer const&); // unimplemented
 	void operator=(IKeyValueContainer const&); // unimplemented
 	IndexedSet<KeyValueMapPair, uint64_t> data;
 };

--- a/fdbserver/kvstore/IKeyValueContainer.h
+++ b/fdbserver/kvstore/IKeyValueContainer.h
@@ -21,6 +21,7 @@
 #define IKEYVALUECONTAINER_H
 #pragma once
 
+#include "fdbclient/FDBTypes.h"
 #include "flow/IndexedSet.h"
 
 // Stored in the IndexedSets that hold the database.
@@ -36,7 +37,7 @@ struct KeyValueMapPair {
 		key = rhs.key;
 		value = rhs.value;
 	}
-	KeyValueMapPair(KeyValueMapPair const& rhs) : arena(rhs.arena), key(rhs.key), value(rhs.value) {}
+	KeyValueMapPair(KeyValueMapPair const&) = default;
 
 	KeyValueMapPair(KeyRef key, ValueRef value)
 	  : arena(key.expectedSize() + value.expectedSize()), key(arena, key), value(arena, value) {}

--- a/fdbserver/kvstore/RadixTree.h
+++ b/fdbserver/kvstore/RadixTree.h
@@ -235,7 +235,7 @@ public:
 		node* m_pointee;
 
 		iterator() : m_pointee(nullptr) {}
-		explicit(false) iterator(const iterator& r) : m_pointee(r.m_pointee) {}
+		iterator(const iterator& r) : m_pointee(r.m_pointee) {}
 		explicit(false) iterator(node* p) : m_pointee(p) {}
 		iterator& operator=(const iterator& r) {
 			m_pointee = r.m_pointee;

--- a/fdbserver/kvstore/art.h
+++ b/fdbserver/kvstore/art.h
@@ -324,7 +324,7 @@ private:
 public:
 	explicit art_iterator(art_tree::art_leaf* l) { leaf = l; }
 
-	explicit(false) art_iterator(const art_iterator& i) { leaf = i.leaf; }
+	art_iterator(const art_iterator& i) { leaf = i.leaf; }
 
 	art_iterator() { leaf = nullptr; }
 

--- a/fdbserver/logrouter/LogRouter.cpp
+++ b/fdbserver/logrouter/LogRouter.cpp
@@ -47,7 +47,7 @@ struct LogRouterData {
 		TagData(Tag tag, Version popped, Version durableKnownCommittedVersion)
 		  : popped(popped), durableKnownCommittedVersion(durableKnownCommittedVersion), tag(tag) {}
 
-		explicit(false) TagData(TagData&& r) noexcept
+		TagData(TagData&& r) noexcept
 		  : version_messages(std::move(r.version_messages)), popped(r.popped),
 		    durableKnownCommittedVersion(r.durableKnownCommittedVersion), tag(r.tag) {}
 		void operator=(TagData&& r) noexcept {

--- a/fdbserver/ratekeeper/RkTagThrottleCollection.h
+++ b/fdbserver/ratekeeper/RkTagThrottleCollection.h
@@ -55,7 +55,7 @@ class RkTagThrottleCollection : NonCopyable {
 
 public:
 	RkTagThrottleCollection() = default;
-	explicit(false) RkTagThrottleCollection(RkTagThrottleCollection&& other);
+	RkTagThrottleCollection(RkTagThrottleCollection&& other);
 	RkTagThrottleCollection& operator=(RkTagThrottleCollection&& other);
 
 	Optional<double> autoThrottleTag(UID id,

--- a/fdbserver/resolver/ConflictSet.cpp
+++ b/fdbserver/resolver/ConflictSet.cpp
@@ -421,7 +421,7 @@ public:
 		}
 	}
 	~SkipList() { destroy(); }
-	explicit(false) SkipList(SkipList&& other) noexcept : header(other.header) { other.header = nullptr; }
+	SkipList(SkipList&& other) noexcept : header(other.header) { other.header = nullptr; }
 	void operator=(SkipList&& other) noexcept {
 		destroy();
 		header = other.header;

--- a/fdbserver/tester/include/fdbserver/tester/workloads.h
+++ b/fdbserver/tester/include/fdbserver/tester/workloads.h
@@ -45,7 +45,7 @@ struct WorkloadContext {
 	std::vector<KeyRange> rangesToCheck; // for urgent consistency checker
 
 	WorkloadContext();
-	explicit(false) WorkloadContext(const WorkloadContext&);
+	WorkloadContext(const WorkloadContext&);
 	~WorkloadContext();
 	WorkloadContext& operator=(const WorkloadContext&) = delete;
 };

--- a/fdbserver/tlog/TLogServer.cpp
+++ b/fdbserver/tlog/TLogServer.cpp
@@ -463,7 +463,7 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		    versionForPoppedLocation(0), poppedLocation(poppedLocation), unpoppedRecovered(unpoppedRecovered),
 		    tag(tag) {}
 
-		explicit(false) TagData(TagData&& r) noexcept
+		TagData(TagData&& r) noexcept
 		  : versionMessages(std::move(r.versionMessages)), nothingPersistent(r.nothingPersistent),
 		    poppedRecently(r.poppedRecently), popped(r.popped), persistentPopped(r.persistentPopped),
 		    versionForPoppedLocation(r.versionForPoppedLocation), poppedLocation(r.poppedLocation),

--- a/flow/CoroTests.cpp
+++ b/flow/CoroTests.cpp
@@ -1281,7 +1281,7 @@ struct Tracker {
 	int copied;
 	bool moved;
 	explicit Tracker(int copied = 0) : copied(copied), moved(false) {}
-	explicit(false) Tracker(Tracker&& other) : Tracker(other.copied) {
+	Tracker(Tracker&& other) : Tracker(other.copied) {
 		ASSERT(!other.moved);
 		other.moved = true;
 	}
@@ -1292,7 +1292,7 @@ struct Tracker {
 		this->copied = other.copied;
 		return *this;
 	}
-	explicit(false) Tracker(const Tracker& other) : Tracker(other.copied + 1) { ASSERT(!other.moved); }
+	Tracker(const Tracker& other) : Tracker(other.copied + 1) { ASSERT(!other.moved); }
 	Tracker& operator=(const Tracker& other) {
 		ASSERT(!other.moved);
 		this->moved = false;
@@ -1312,8 +1312,8 @@ struct LifetimeTracked {
 	inline static int liveCount = 0;
 
 	LifetimeTracked() { ++liveCount; }
-	explicit(false) LifetimeTracked(const LifetimeTracked&) { ++liveCount; }
-	explicit(false) LifetimeTracked(LifetimeTracked&&) noexcept { ++liveCount; }
+	LifetimeTracked(const LifetimeTracked&) { ++liveCount; }
+	LifetimeTracked(LifetimeTracked&&) noexcept { ++liveCount; }
 	LifetimeTracked& operator=(const LifetimeTracked&) = default;
 	LifetimeTracked& operator=(LifetimeTracked&&) noexcept = default;
 	~LifetimeTracked() { --liveCount; }

--- a/flow/Deque.cpp
+++ b/flow/Deque.cpp
@@ -84,7 +84,7 @@ struct RandomlyThrows {
 	RandomlyThrows() = default;
 	explicit RandomlyThrows(int data) : data(data) {}
 	~RandomlyThrows() = default;
-	explicit(false) RandomlyThrows(const RandomlyThrows& other) : data(other.data) { randomlyThrow(); }
+	RandomlyThrows(const RandomlyThrows& other) : data(other.data) { randomlyThrow(); }
 	RandomlyThrows& operator=(const RandomlyThrows& other) {
 		data = other.data;
 		randomlyThrow();

--- a/flow/IThreadPool.cpp
+++ b/flow/IThreadPool.cpp
@@ -78,9 +78,7 @@ class ThreadPool final : public IThreadPool, public ReferenceCounted<ThreadPool>
 		explicit ActionWrapper(PThreadAction action) : action(action) {}
 		// HACK: Boost won't use move constructors, so we just assume the last copy made is the one that will be called
 		// or cancelled
-		explicit(false) ActionWrapper(ActionWrapper const& r) : action(r.action) {
-			const_cast<ActionWrapper&>(r).action = nullptr;
-		}
+		ActionWrapper(ActionWrapper const& r) : action(r.action) { const_cast<ActionWrapper&>(r).action = nullptr; }
 		void operator()() {
 			Thread::dispatch(action);
 			action = nullptr;

--- a/flow/IndexedSet.cpp
+++ b/flow/IndexedSet.cpp
@@ -431,7 +431,7 @@ TEST_CASE("/flow/IndexedSet/data constructor and destructor calls match") {
 		int value;
 		explicit Counter(int value) : value(value) { count++; }
 		~Counter() { count--; }
-		explicit(false) Counter(const Counter& r) : value(r.value) { count++; }
+		Counter(const Counter& r) : value(r.value) { count++; }
 		void operator=(const Counter& r) { value = r.value; }
 		int compare(const Counter& r) const { return ::compare(value, r.value); }
 		bool operator<(const Counter& r) const { return value < r.value; }

--- a/flow/Net2.cpp
+++ b/flow/Net2.cpp
@@ -383,8 +383,8 @@ public:
 	  : errContext(errContext), errID(errID), peerAddr(peerAddr) {}
 	BindPromise(AuditedEvent auditedEvent, UID errID, NetworkAddress peerAddr)
 	  : errContext(auditedEvent), errID(errID), peerAddr(peerAddr) {}
-	explicit(false) BindPromise(BindPromise const& r) = default;
-	explicit(false) BindPromise(BindPromise&& r) noexcept
+	BindPromise(BindPromise const& r) = default;
+	BindPromise(BindPromise&& r) noexcept
 	  : p(std::move(r.p)), errContext(r.errContext), errID(r.errID), peerAddr(r.peerAddr) {}
 
 	Future<Void> getFuture() const { return p.getFuture(); }
@@ -617,9 +617,8 @@ class ReadPromise {
 
 public:
 	ReadPromise(const char* errContext, UID errID) : errContext(errContext), errID(errID) {}
-	explicit(false) ReadPromise(ReadPromise const& other) = default;
-	explicit(false) ReadPromise(ReadPromise&& other)
-	  : p(std::move(other.p)), errContext(other.errContext), errID(other.errID) {}
+	ReadPromise(ReadPromise const& other) = default;
+	ReadPromise(ReadPromise&& other) : p(std::move(other.p)), errContext(other.errContext), errID(other.errID) {}
 
 	std::shared_ptr<udp::endpoint>& getEndpoint() { return endpoint; }
 

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -76,8 +76,8 @@ struct TrackIt {
 	}
 
 	TrackIt() { printf("TrackItCreate\t%s\t%p\t%s\n", __trackit__type(), this, platform::get_backtrace().c_str()); }
-	explicit(false) TrackIt(const TrackIt& o) : TrackIt() {}
-	explicit(false) TrackIt(const TrackIt&& o) : TrackIt() {}
+	TrackIt(const TrackIt& o) : TrackIt() {}
+	TrackIt(const TrackIt&& o) : TrackIt() {}
 	TrackIt& operator=(const TrackIt& o) {
 		printf("TrackItAssigned\t%s\t%p<%p\t%s\n", __trackit__type(), this, &o, platform::get_backtrace().c_str());
 		return *this;
@@ -90,7 +90,7 @@ class NonCopyable {
 protected:
 	NonCopyable() = default;
 	~NonCopyable() = default; /// Protected non-virtual destructor
-	explicit(false) NonCopyable(NonCopyable&&) = default;
+	NonCopyable(NonCopyable&&) = default;
 	NonCopyable& operator=(NonCopyable&&) = default;
 	NonCopyable(const NonCopyable&) = delete;
 	NonCopyable& operator=(const NonCopyable&) = delete;
@@ -111,8 +111,8 @@ public:
 	Arena();
 	explicit Arena(size_t reservedSize);
 	//~Arena();
-	explicit(false) Arena(const Arena&);
-	explicit(false) Arena(Arena&& r) noexcept;
+	Arena(const Arena&);
+	Arena(Arena&& r) noexcept;
 	Arena& operator=(const Arena&);
 	Arena& operator=(Arena&&) noexcept;
 
@@ -315,9 +315,9 @@ public:
 	}
 
 	Standalone(const T& t, const Arena& arena) : Arena(arena), T(t) {}
-	explicit(false) Standalone(const Standalone<T>&) = default;
+	Standalone(const Standalone<T>&) = default;
 	Standalone<T>& operator=(const Standalone<T>&) = default;
-	explicit(false) Standalone(Standalone<T>&&) = default;
+	Standalone(Standalone<T>&&) = default;
 	Standalone<T>& operator=(Standalone<T>&&) = default;
 	~Standalone() = default;
 
@@ -904,7 +904,7 @@ struct VectorRefPreserializer<T, VecSerStrategy::String> {
 	string_serialized_traits<T> _string_traits;
 
 	VectorRefPreserializer() : _cached_size(0) {}
-	explicit(false) VectorRefPreserializer(const VectorRefPreserializer<T, VecSerStrategy::String>& other) noexcept
+	VectorRefPreserializer(const VectorRefPreserializer<T, VecSerStrategy::String>& other) noexcept
 	  : _cached_size(other._cached_size) {}
 	VectorRefPreserializer& operator=(const VectorRefPreserializer<T, VecSerStrategy::String>& other) noexcept {
 		_cached_size = other._cached_size;
@@ -1311,7 +1311,7 @@ public:
 public: // Construction
 	static_assert(std::is_trivially_destructible_v<T>);
 	SmallVectorRef() = default;
-	explicit(false) SmallVectorRef(const SmallVectorRef<T, InlineMembers>& other)
+	SmallVectorRef(const SmallVectorRef<T, InlineMembers>& other)
 	  : m_size(other.m_size), arr(other.arr), data(other.data) {}
 	SmallVectorRef& operator=(const SmallVectorRef<T, InlineMembers>&) = default;
 

--- a/flow/include/flow/Coroutines.h
+++ b/flow/include/flow/Coroutines.h
@@ -255,12 +255,12 @@ private:
 public:
 	explicit Generator(handle_type h) : handle(h) {}
 	Generator() = default;
-	explicit(false) Generator(Generator const& other) : handle(other.handle) {
+	Generator(Generator const& other) : handle(other.handle) {
 		if (handle) {
 			handle.promise().addRef();
 		}
 	}
-	explicit(false) Generator(Generator&& other) : handle(std::move(other.handle)) { other.handle = handle_type{}; }
+	Generator(Generator&& other) : handle(std::move(other.handle)) { other.handle = handle_type{}; }
 	~Generator() {
 		if (handle) {
 			handle.promise().delRef();

--- a/flow/include/flow/Deque.h
+++ b/flow/include/flow/Deque.h
@@ -41,7 +41,7 @@ public:
 	Deque() : arr(0), begin(0), end(0), mask(-1) {}
 
 	// TODO: iterator construction, other constructors
-	explicit(false) Deque(Deque const& r) : arr(nullptr), begin(0), end(r.size()), mask(r.mask) {
+	Deque(Deque const& r) : arr(nullptr), begin(0), end(r.size()), mask(r.mask) {
 		if (r.capacity() > 0) {
 			arr = (T*)aligned_alloc(std::max(__alignof(T), sizeof(void*)), capacity() * sizeof(T));
 			if (arr == nullptr) {
@@ -85,7 +85,7 @@ public:
 		}
 	}
 
-	explicit(false) Deque(Deque&& r) noexcept : arr(r.arr), begin(r.begin), end(r.end), mask(r.mask) {
+	Deque(Deque&& r) noexcept : arr(r.arr), begin(r.begin), end(r.end), mask(r.mask) {
 		r.arr = nullptr;
 		r.begin = r.end = 0;
 		r.mask = -1;

--- a/flow/include/flow/FastRef.h
+++ b/flow/include/flow/FastRef.h
@@ -56,7 +56,7 @@ public:
 	int32_t debugGetReferenceCount() const { return referenceCount.load(); }
 
 private:
-	explicit(false) ThreadSafeReferenceCounted(const ThreadSafeReferenceCounted&) /* = delete*/;
+	ThreadSafeReferenceCounted(const ThreadSafeReferenceCounted&) /* = delete*/;
 	void operator=(const ThreadSafeReferenceCounted&) /* = delete*/;
 	mutable std::atomic<int32_t> referenceCount;
 };
@@ -76,7 +76,7 @@ public:
 	bool isSoleOwner() const { return referenceCount == 1; }
 
 private:
-	explicit(false) ThreadUnsafeReferenceCounted(const ThreadUnsafeReferenceCounted&) /* = delete*/;
+	ThreadUnsafeReferenceCounted(const ThreadUnsafeReferenceCounted&) /* = delete*/;
 	void operator=(const ThreadUnsafeReferenceCounted&) /* = delete*/;
 	mutable int32_t referenceCount;
 };
@@ -107,11 +107,11 @@ public:
 		return Reference(ptr);
 	}
 
-	explicit(false) Reference(const Reference& r) : ptr(r.getPtr()) {
+	Reference(const Reference& r) : ptr(r.getPtr()) {
 		if (ptr)
 			addref(ptr);
 	}
-	explicit(false) Reference(Reference&& r) noexcept : ptr(r.getPtr()) { r.ptr = nullptr; }
+	Reference(Reference&& r) noexcept : ptr(r.getPtr()) { r.ptr = nullptr; }
 
 	template <class Q>
 	explicit(false) Reference(const Reference<Q>& r) : ptr(r.getPtr()) {

--- a/flow/include/flow/FlowThread.h
+++ b/flow/include/flow/FlowThread.h
@@ -196,8 +196,8 @@ template <class T>
 class ThreadFutureStream {
 public:
 	ThreadFutureStream() : queue(nullptr) {}
-	explicit(false) ThreadFutureStream(const ThreadFutureStream& rhs) : queue(rhs.queue) { queue->addFutureRef(); }
-	explicit(false) ThreadFutureStream(ThreadFutureStream&& rhs) noexcept : queue(rhs.queue) { rhs.queue = 0; }
+	ThreadFutureStream(const ThreadFutureStream& rhs) : queue(rhs.queue) { queue->addFutureRef(); }
+	ThreadFutureStream(ThreadFutureStream&& rhs) noexcept : queue(rhs.queue) { rhs.queue = 0; }
 	explicit ThreadFutureStream(ThreadNotifiedQueue<T>* queue) : queue(queue) {}
 	~ThreadFutureStream() {
 		if (queue)
@@ -256,9 +256,7 @@ class ThreadReturnPromiseStream {
 public:
 	ThreadReturnPromiseStream() : queue(new ThreadNotifiedQueue<T>(0, 1)) {}
 	ThreadReturnPromiseStream(const ThreadReturnPromiseStream& rhs) = delete;
-	explicit(false) ThreadReturnPromiseStream(ThreadReturnPromiseStream&& rhs) noexcept : queue(rhs.queue) {
-		rhs.queue = 0;
-	}
+	ThreadReturnPromiseStream(ThreadReturnPromiseStream&& rhs) noexcept : queue(rhs.queue) { rhs.queue = 0; }
 	~ThreadReturnPromiseStream() {
 		if (queue)
 			queue->delPromiseRef();

--- a/flow/include/flow/IThreadPool.h
+++ b/flow/include/flow/IThreadPool.h
@@ -85,7 +85,7 @@ class ThreadReturnPromise : NonCopyable {
 public:
 	ThreadReturnPromise() = default;
 	ThreadReturnPromise(const ThreadReturnPromise& p) = delete;
-	explicit(false) ThreadReturnPromise(ThreadReturnPromise&& other) : promise(std::move(other.promise)) {}
+	ThreadReturnPromise(ThreadReturnPromise&& other) : promise(std::move(other.promise)) {}
 
 	~ThreadReturnPromise() {
 		if (promise.isValid())

--- a/flow/include/flow/IndexedSet.h
+++ b/flow/include/flow/IndexedSet.h
@@ -151,7 +151,7 @@ public:
 
 	IndexedSet() : root(nullptr) {};
 	~IndexedSet() { delete root; }
-	explicit(false) IndexedSet(IndexedSet&& r) noexcept : root(r.root) { r.root = nullptr; }
+	IndexedSet(IndexedSet&& r) noexcept : root(r.root) { r.root = nullptr; }
 	IndexedSet& operator=(IndexedSet&& r) noexcept {
 		delete root;
 		root = r.root;
@@ -311,7 +311,7 @@ public:
 
 private:
 	// Copy operations unimplemented.  SOMEDAY: Implement and make public.
-	explicit(false) IndexedSet(const IndexedSet&);
+	IndexedSet(const IndexedSet&);
 	IndexedSet& operator=(const IndexedSet&);
 
 	Node* root;
@@ -376,9 +376,9 @@ public:
 		key = rhs.key;
 		value = rhs.value;
 	}
-	explicit(false) MapPair(MapPair const& rhs) : key(rhs.key), value(rhs.value) {}
+	MapPair(MapPair const& rhs) : key(rhs.key), value(rhs.value) {}
 
-	explicit(false) MapPair(MapPair&& r) noexcept : key(std::move(r.key)), value(std::move(r.value)) {}
+	MapPair(MapPair&& r) noexcept : key(std::move(r.key)), value(std::move(r.value)) {}
 	void operator=(MapPair&& r) noexcept {
 		key = std::move(r.key);
 		value = std::move(r.value);
@@ -531,7 +531,7 @@ public:
 
 	static int getElementBytes() { return IndexedSet<Pair, Metric>::getElementBytes(); }
 
-	explicit(false) Map(Map&& r) noexcept : set(std::move(r.set)) {}
+	Map(Map&& r) noexcept : set(std::move(r.set)) {}
 	void operator=(Map&& r) noexcept { set = std::move(r.set); }
 
 	Future<Void> clearAsync();

--- a/flow/include/flow/OwningResource.h
+++ b/flow/include/flow/OwningResource.h
@@ -21,6 +21,8 @@
 #ifndef FLOW_OWNING_REOSURCE_H
 #define FLOW_OWNING_REOSURCE_H
 
+#include "flow/Arena.h"
+#include "flow/Error.h"
 #include "flow/FastRef.h"
 
 // Consider the following situation:

--- a/flow/include/flow/OwningResource.h
+++ b/flow/include/flow/OwningResource.h
@@ -122,7 +122,7 @@ template <typename T>
 class ResourceWeakRef : public details::ResourceRef<T> {
 public:
 	explicit ResourceWeakRef(const ResourceOwningRef<T>& ref) : details::ResourceRef<T>(ref.resourceRef) {}
-	explicit(false) ResourceWeakRef(const ResourceWeakRef& ref) : details::ResourceRef<T>(ref.resourceRef) {}
+	ResourceWeakRef(const ResourceWeakRef& ref) : details::ResourceRef<T>(ref.resourceRef) {}
 };
 
 // A unique reference that takes the ownership of the self object. The self object is widely used as the "global"
@@ -138,7 +138,7 @@ class ActorWeakSelfRef : public ResourceWeakRef<T> {
 public:
 	explicit ActorWeakSelfRef(const ResourceOwningRef<T>& ref) : ResourceWeakRef<T>(ref) {}
 	explicit ActorWeakSelfRef(const ResourceWeakRef<T>& ref) : ResourceWeakRef<T>(ref) {}
-	explicit(false) ActorWeakSelfRef(const ActorWeakSelfRef<T>& ref)
+	ActorWeakSelfRef(const ActorWeakSelfRef<T>& ref)
 	  : ResourceWeakRef<T>(static_cast<const ResourceWeakRef<T>&>(ref)) {}
 
 	// Retrieves the resource as a pointer, throws operation_cancelled if the resource is not available

--- a/flow/include/flow/PKey.h
+++ b/flow/include/flow/PKey.h
@@ -52,7 +52,7 @@ public:
 	// d2i_PUBKEY
 	PublicKey(DerEncoded, StringRef der);
 
-	explicit(false) PublicKey(const PublicKey& other) noexcept = default;
+	PublicKey(const PublicKey& other) noexcept = default;
 
 	PublicKey& operator=(const PublicKey& other) noexcept = default;
 
@@ -87,7 +87,7 @@ public:
 	// d2i_AutoPrivateKey
 	PrivateKey(DerEncoded, StringRef der);
 
-	explicit(false) PrivateKey(const PrivateKey& other) noexcept = default;
+	PrivateKey(const PrivateKey& other) noexcept = default;
 
 	PrivateKey& operator=(const PrivateKey& other) noexcept = default;
 

--- a/flow/include/flow/TDMetric.h
+++ b/flow/include/flow/TDMetric.h
@@ -94,7 +94,7 @@ struct KeyWithWriter {
 
 	KeyWithWriter(Standalone<StringRef> const& key, BinaryWriter& writer, int writerOffset = 0)
 	  : key(key), writer(std::move(writer)), writerOffset(writerOffset) {}
-	explicit(false) KeyWithWriter(KeyWithWriter&& r)
+	KeyWithWriter(KeyWithWriter&& r)
 	  : key(std::move(r.key)), writer(std::move(r.writer)), writerOffset(r.writerOffset) {}
 	void operator=(KeyWithWriter&& r) {
 		key = std::move(r.key);
@@ -271,7 +271,7 @@ struct MetricData {
 	  : start(0), rollTime(std::numeric_limits<uint64_t>::max()), appendStart(appendStart),
 	    writer(AssumeVersion(g_network->protocolVersion())) {}
 
-	explicit(false) MetricData(MetricData&& r) noexcept
+	MetricData(MetricData&& r) noexcept
 	  : start(r.start), rollTime(r.rollTime), appendStart(r.appendStart), writer(std::move(r.writer)) {}
 
 	void operator=(MetricData&& r) noexcept {
@@ -785,7 +785,7 @@ template <class T, class Descriptor = NullDescriptor, class FieldLevelType = Fie
 struct EventField : public Descriptor {
 	std::vector<FieldLevelType> levels;
 
-	explicit(false) EventField(EventField&& r) noexcept : Descriptor(r), levels(std::move(r.levels)) {}
+	EventField(EventField&& r) noexcept : Descriptor(r), levels(std::move(r.levels)) {}
 
 	void operator=(EventField&& r) noexcept { levels = std::move(r.levels); }
 

--- a/flow/include/flow/ThreadHelper.h
+++ b/flow/include/flow/ThreadHelper.h
@@ -592,11 +592,11 @@ public:
 	explicit ThreadFuture(ThreadSingleAssignmentVar<T>* sav) : sav(sav) {
 		// sav->addref();
 	}
-	explicit(false) ThreadFuture(const ThreadFuture<T>& rhs) : sav(rhs.sav) {
+	ThreadFuture(const ThreadFuture<T>& rhs) : sav(rhs.sav) {
 		if (sav)
 			sav->addref();
 	}
-	explicit(false) ThreadFuture(ThreadFuture<T>&& rhs) noexcept : sav(rhs.sav) { rhs.sav = 0; }
+	ThreadFuture(ThreadFuture<T>&& rhs) noexcept : sav(rhs.sav) { rhs.sav = 0; }
 	explicit(false) ThreadFuture(const T& presentValue) : sav(new ThreadSingleAssignmentVar<T>()) {
 		sav->send(presentValue);
 	}
@@ -940,11 +940,11 @@ public:
 		ASSERT(sav->isReady());
 		// sav->addref();
 	}
-	explicit(false) ThreadResult(const ThreadResult<T>& rhs) : sav(rhs.sav) {
+	ThreadResult(const ThreadResult<T>& rhs) : sav(rhs.sav) {
 		if (sav)
 			sav->addref();
 	}
-	explicit(false) ThreadResult(ThreadResult<T>&& rhs) noexcept : sav(rhs.sav) { rhs.sav = 0; }
+	ThreadResult(ThreadResult<T>&& rhs) noexcept : sav(rhs.sav) { rhs.sav = 0; }
 	explicit(false) ThreadResult(const T& presentValue) : sav(new ThreadSingleAssignmentVar<T>()) {
 		sav->send(presentValue);
 	}

--- a/flow/include/flow/Trace.h
+++ b/flow/include/flow/Trace.h
@@ -337,8 +337,8 @@ protected:
 				value = Type::FORCED;
 		}
 
-		explicit(false) State(const State& other) noexcept = default;
-		explicit(false) State(State&& other) noexcept : value(other.value) { other.value = Type::DISABLED; }
+		State(const State& other) noexcept = default;
+		State(State&& other) noexcept : value(other.value) { other.value = Type::DISABLED; }
 		State& operator=(const State& other) noexcept = default;
 		State& operator=(State&& other) noexcept {
 			if (this != &other) {

--- a/flow/include/flow/Util.h
+++ b/flow/include/flow/Util.h
@@ -28,7 +28,8 @@
 #include <cstdio>
 #include <ctime>
 #include <functional>
-#include <iosfwd>
+#include <istream>
+#include <sstream>
 #include <string>
 
 // Read key/value pairs from stream. The stream is constituted by lines of text.

--- a/flow/include/flow/Util.h
+++ b/flow/include/flow/Util.h
@@ -90,7 +90,7 @@ struct Hold {
 		}
 	}
 
-	explicit(false) Hold(Hold&& other) {
+	Hold(Hold&& other) {
 		pCount = other.pCount;
 		other.pCount = nullptr;
 		n = other.n;

--- a/flow/include/flow/WipedString.h
+++ b/flow/include/flow/WipedString.h
@@ -110,8 +110,8 @@ public:
 		}
 	}
 
-	explicit(false) WipedString(const WipedString& other) noexcept = default;
-	explicit(false) WipedString(WipedString&& other) noexcept = default;
+	WipedString(const WipedString& other) noexcept = default;
+	WipedString(WipedString&& other) noexcept = default;
 	WipedString& operator=(const WipedString& other) noexcept = default;
 	WipedString& operator=(WipedString&& other) noexcept = default;
 

--- a/flow/include/flow/flow.h
+++ b/flow/include/flow/flow.h
@@ -656,9 +656,8 @@ class LineageReference : public Reference<ActorLineage> {
 public:
 	LineageReference() : Reference<ActorLineage>(nullptr), actorName_(""), allocated_(false) {}
 	explicit LineageReference(ActorLineage* ptr) : Reference<ActorLineage>(ptr), actorName_(""), allocated_(false) {}
-	explicit(false) LineageReference(const LineageReference& r)
-	  : Reference<ActorLineage>(r), actorName_(""), allocated_(false) {}
-	explicit(false) LineageReference(LineageReference&& r)
+	LineageReference(const LineageReference& r) : Reference<ActorLineage>(r), actorName_(""), allocated_(false) {}
+	LineageReference(LineageReference&& r)
 	  : Reference<ActorLineage>(r.getPtr()), actorName_(r.actorName_), allocated_(r.allocated_) {
 		r.setPtrUnsafe(nullptr);
 		r.actorName_ = "";

--- a/flow/include/flow/genericactors.h
+++ b/flow/include/flow/genericactors.h
@@ -657,7 +657,7 @@ public:
 	ReferencedObject() : value() {}
 	explicit ReferencedObject(V const& v) : value(v) {}
 	explicit ReferencedObject(V&& v) : value(std::move(v)) {}
-	explicit(false) ReferencedObject(ReferencedObject&& r) : value(std::move(r.value)) {}
+	ReferencedObject(ReferencedObject&& r) : value(std::move(r.value)) {}
 
 	void operator=(ReferencedObject&& r) { value = std::move(r.value); }
 
@@ -724,7 +724,7 @@ private:
 class AsyncTrigger : NonCopyable {
 public:
 	AsyncTrigger() = default;
-	explicit(false) AsyncTrigger(AsyncTrigger&& at) : v(std::move(at.v)) {}
+	AsyncTrigger(AsyncTrigger&& at) : v(std::move(at.v)) {}
 	void operator=(AsyncTrigger&& at) { v = std::move(at.v); }
 	Future<Void> onTrigger() const { return v.onChange(); }
 	void trigger() { v.trigger(); }
@@ -746,7 +746,7 @@ Future<Void> forward(Reference<AsyncVar<T> const> from, AsyncTrigger* to) {
 class Debouncer : NonCopyable {
 public:
 	explicit Debouncer(double delay) { worker = debounceWorker(this, delay); }
-	explicit(false) Debouncer(Debouncer&& at) = default;
+	Debouncer(Debouncer&& at) = default;
 	Debouncer& operator=(Debouncer&& at) = default;
 	Future<Void> onTrigger() { return output.onChange(); }
 	void trigger() { input.setUnconditional(Void()); }
@@ -1924,8 +1924,7 @@ struct ActiveCounter {
 		  : parent(parent), delta(delta), releaseCallback(releaseCallback) {
 			parent->counter += delta;
 		}
-		explicit(false) Releaser(Releaser&& r) noexcept
-		  : parent(r.parent), delta(r.delta), releaseCallback(r.releaseCallback) {
+		Releaser(Releaser&& r) noexcept : parent(r.parent), delta(r.delta), releaseCallback(r.releaseCallback) {
 			r.parent = nullptr;
 		}
 		void operator=(Releaser&& r) {
@@ -2028,7 +2027,7 @@ struct FlowLock : NonCopyable, public ReferenceCounted<FlowLock> {
 		int64_t remaining;
 		Releaser() : lock(0), remaining(0) {}
 		explicit(false) Releaser(FlowLock& lock, int64_t amount = 1) : lock(&lock), remaining(amount) {}
-		explicit(false) Releaser(Releaser&& r) noexcept : lock(r.lock), remaining(r.remaining) { r.remaining = 0; }
+		Releaser(Releaser&& r) noexcept : lock(r.lock), remaining(r.remaining) { r.remaining = 0; }
 		void operator=(Releaser&& r) {
 			if (remaining)
 				lock->release(remaining);
@@ -2185,7 +2184,7 @@ struct NotifiedInt {
 
 	void operator=(int64_t v) { set(v); }
 
-	explicit(false) NotifiedInt(NotifiedInt&& r) noexcept : waiting(std::move(r.waiting)), val(r.val) {}
+	NotifiedInt(NotifiedInt&& r) noexcept : waiting(std::move(r.waiting)), val(r.val) {}
 	void operator=(NotifiedInt&& r) noexcept {
 		waiting = std::move(r.waiting);
 		val = r.val;
@@ -2211,9 +2210,7 @@ struct BoundedFlowLock : NonCopyable, public ReferenceCounted<BoundedFlowLock> {
 		int64_t permitNumber;
 		Releaser() : lock(nullptr), permitNumber(0) {}
 		Releaser(BoundedFlowLock* lock, int64_t permitNumber) : lock(lock), permitNumber(permitNumber) {}
-		explicit(false) Releaser(Releaser&& r) noexcept : lock(r.lock), permitNumber(r.permitNumber) {
-			r.permitNumber = 0;
-		}
+		Releaser(Releaser&& r) noexcept : lock(r.lock), permitNumber(r.permitNumber) { r.permitNumber = 0; }
 		void operator=(Releaser&& r) {
 			if (permitNumber)
 				lock->release(permitNumber);
@@ -2401,8 +2398,8 @@ public:
 class AndFuture {
 public:
 	AndFuture() = default;
-	explicit(false) AndFuture(AndFuture const& f) = default;
-	explicit(false) AndFuture(AndFuture&& f) noexcept = default;
+	AndFuture(AndFuture const& f) = default;
+	AndFuture(AndFuture&& f) noexcept = default;
 	AndFuture& operator=(AndFuture const& f) = default;
 	AndFuture& operator=(AndFuture&& f) noexcept = default;
 

--- a/flow/include/flow/serialize.h
+++ b/flow/include/flow/serialize.h
@@ -452,7 +452,7 @@ public:
 	explicit BinaryWriter(VersionOptions vo) : data(nullptr), size(0), allocated(0) {
 		vo.write(*this);
 	}
-	explicit(false) BinaryWriter(BinaryWriter&& rhs)
+	BinaryWriter(BinaryWriter&& rhs)
 	  : arena(std::move(rhs.arena)), data(rhs.data), size(rhs.size), allocated(rhs.allocated),
 	    m_protocolVersion(rhs.m_protocolVersion) {
 		rhs.size = 0;


### PR DESCRIPTION
Earlier enforcement of `explicit` or `explicit(false)` single-argument constructors was too broad, affecting copy and move constructors, which was unnecessary