### PR TITLE
Replace explicit-self helpers with member coroutines

### DIFF
--- a/fdbclient/BackupFileFormat.cpp
+++ b/fdbclient/BackupFileFormat.cpp
@@ -77,12 +77,12 @@ Value makePadding(int size) {
 RangeFileWriter::RangeFileWriter(Reference<IBackupFile> file, int blockSize)
   : file(file), blockSize(blockSize), blockEnd(0), fileVersion(BACKUP_AGENT_SNAPSHOT_FILE_VERSION) {}
 
-Future<Void> RangeFileWriter::newBlock(RangeFileWriter* self, int bytesNeeded, bool final) {
+Future<Void> RangeFileWriter::newBlock(int bytesNeeded, bool final) {
 	// Write padding to finish current block if needed
-	int bytesLeft = self->blockEnd - self->file->size();
+	int bytesLeft = blockEnd - file->size();
 	if (bytesLeft > 0) {
 		Value paddingFFs = makePadding(bytesLeft);
-		co_await self->file->append(paddingFFs.begin(), bytesLeft);
+		co_await file->append(paddingFFs.begin(), bytesLeft);
 	}
 
 	if (final) {
@@ -91,20 +91,20 @@ Future<Void> RangeFileWriter::newBlock(RangeFileWriter* self, int bytesNeeded, b
 	}
 
 	// Set new blockEnd
-	self->blockEnd += self->blockSize;
+	blockEnd += blockSize;
 
 	// write Header
-	co_await self->file->append((uint8_t*)&self->fileVersion, sizeof(self->fileVersion));
+	co_await file->append((uint8_t*)&fileVersion, sizeof(fileVersion));
 
 	// If this is NOT the first block then write duplicate stuff needed from last block
-	if (self->blockEnd > self->blockSize) {
-		co_await self->file->appendStringRefWithLen(self->lastKey);
-		co_await self->file->appendStringRefWithLen(self->lastKey);
-		co_await self->file->appendStringRefWithLen(self->lastValue);
+	if (blockEnd > blockSize) {
+		co_await file->appendStringRefWithLen(lastKey);
+		co_await file->appendStringRefWithLen(lastKey);
+		co_await file->appendStringRefWithLen(lastValue);
 	}
 
 	// There must now be room in the current block for bytesNeeded or the block size is too small
-	if (self->file->size() + bytesNeeded > self->blockEnd)
+	if (file->size() + bytesNeeded > blockEnd)
 		throw backup_bad_block_size();
 
 	co_return;
@@ -113,40 +113,32 @@ Future<Void> RangeFileWriter::newBlock(RangeFileWriter* self, int bytesNeeded, b
 Future<Void> RangeFileWriter::padEnd(bool final) {
 	ASSERT(g_network->isSimulated());
 	if (file->size() > 0) {
-		return newBlock(this, 0, final);
+		return newBlock(0, final);
 	}
 	return Void();
 }
 
 Future<Void> RangeFileWriter::newBlockIfNeeded(int bytesNeeded) {
 	if (file->size() + bytesNeeded > blockEnd)
-		return newBlock(this, bytesNeeded);
+		return newBlock(bytesNeeded);
 	return Void();
 }
 
-Future<Void> RangeFileWriter::writeKV_impl(RangeFileWriter* self, Key k, Value v) {
-	int toWrite = sizeof(int32_t) + k.size() + sizeof(int32_t) + v.size();
-	co_await self->newBlockIfNeeded(toWrite);
-	co_await self->file->appendStringRefWithLen(k);
-	co_await self->file->appendStringRefWithLen(v);
-	self->lastKey = k;
-	self->lastValue = v;
-	co_return;
-}
-
 Future<Void> RangeFileWriter::writeKV(Key k, Value v) {
-	return writeKV_impl(this, k, v);
-}
-
-Future<Void> RangeFileWriter::writeKey_impl(RangeFileWriter* self, Key k) {
-	int toWrite = sizeof(uint32_t) + k.size();
-	co_await self->newBlockIfNeeded(toWrite);
-	co_await self->file->appendStringRefWithLen(k);
+	int toWrite = sizeof(int32_t) + k.size() + sizeof(int32_t) + v.size();
+	co_await newBlockIfNeeded(toWrite);
+	co_await file->appendStringRefWithLen(k);
+	co_await file->appendStringRefWithLen(v);
+	lastKey = k;
+	lastValue = v;
 	co_return;
 }
 
 Future<Void> RangeFileWriter::writeKey(Key k) {
-	return writeKey_impl(this, k);
+	int toWrite = sizeof(uint32_t) + k.size();
+	co_await newBlockIfNeeded(toWrite);
+	co_await file->appendStringRefWithLen(k);
+	co_return;
 }
 
 Future<Void> RangeFileWriter::finish() {
@@ -275,36 +267,32 @@ Future<Standalone<VectorRef<KeyValueRef>>> decodeRangeFileBlock(Reference<IAsync
 LogFileWriter::LogFileWriter(Reference<IBackupFile> file, int blockSize)
   : file(file), blockSize(blockSize), blockEnd(0) {}
 
-Future<Void> LogFileWriter::writeKV_impl(LogFileWriter* self, Key k, Value v) {
+Future<Void> LogFileWriter::writeKV(Key k, Value v) {
 	// If key and value do not fit in this block, end it and start a new one
 	int toWrite = sizeof(int32_t) + k.size() + sizeof(int32_t) + v.size();
-	if (self->file->size() + toWrite > self->blockEnd) {
+	if (file->size() + toWrite > blockEnd) {
 		// Write padding if needed
-		int bytesLeft = self->blockEnd - self->file->size();
+		int bytesLeft = blockEnd - file->size();
 		if (bytesLeft > 0) {
 			Value paddingFFs = makePadding(bytesLeft);
-			co_await self->file->append(paddingFFs.begin(), bytesLeft);
+			co_await file->append(paddingFFs.begin(), bytesLeft);
 		}
 
 		// Set new blockEnd
-		self->blockEnd += self->blockSize;
+		blockEnd += blockSize;
 
 		// write the block header
-		co_await self->file->append((uint8_t*)&BACKUP_AGENT_MLOG_VERSION, sizeof(BACKUP_AGENT_MLOG_VERSION));
+		co_await file->append((uint8_t*)&BACKUP_AGENT_MLOG_VERSION, sizeof(BACKUP_AGENT_MLOG_VERSION));
 	}
 
-	co_await self->file->appendStringRefWithLen(k);
-	co_await self->file->appendStringRefWithLen(v);
+	co_await file->appendStringRefWithLen(k);
+	co_await file->appendStringRefWithLen(v);
 
 	// At this point we should be in whatever the current block is or the block size is too small
-	if (self->file->size() > self->blockEnd)
+	if (file->size() > blockEnd)
 		throw backup_bad_block_size();
 
 	co_return;
-}
-
-Future<Void> LogFileWriter::writeKV(Key k, Value v) {
-	return writeKV_impl(this, k, v);
 }
 
 Standalone<VectorRef<KeyValueRef>> decodeMutationLogFileBlock(const Standalone<StringRef>& buf) {

--- a/fdbclient/FileBackupAgentFileFormat.h
+++ b/fdbclient/FileBackupAgentFileFormat.h
@@ -42,7 +42,7 @@ struct RangeFileWriter : public IRangeFileWriter {
 
 	// Handles the first block and internal blocks. Ends current block if needed.
 	// The final flag is used in simulation to pad the file's final block to a whole block size.
-	static Future<Void> newBlock(RangeFileWriter* self, int bytesNeeded, bool final = false);
+	Future<Void> newBlock(int bytesNeeded, bool final = false);
 
 	// Used in simulation only to create backup file sizes which are an integer multiple of the block size.
 	Future<Void> padEnd(bool final) override;
@@ -51,11 +51,9 @@ struct RangeFileWriter : public IRangeFileWriter {
 	Future<Void> newBlockIfNeeded(int bytesNeeded);
 
 	// Start a new block if needed, then write the key and value.
-	static Future<Void> writeKV_impl(RangeFileWriter* self, Key k, Value v);
 	Future<Void> writeKV(Key k, Value v) override;
 
 	// Write begin key or end key.
-	static Future<Void> writeKey_impl(RangeFileWriter* self, Key k);
 	Future<Void> writeKey(Key k) override;
 
 	Future<Void> finish() override;
@@ -74,7 +72,6 @@ struct LogFileWriter {
 	explicit LogFileWriter(Reference<IBackupFile> file = Reference<IBackupFile>(), int blockSize = 0);
 
 	// Start a new block if needed, then write the key and value.
-	static Future<Void> writeKV_impl(LogFileWriter* self, Key k, Value v);
 	Future<Void> writeKV(Key k, Value v);
 
 	Reference<IBackupFile> file;

--- a/fdbclient/MutationLogReader.cpp
+++ b/fdbclient/MutationLogReader.cpp
@@ -59,10 +59,6 @@ void PipelinedReader::startReading(Database cx) {
 }
 
 Future<Void> PipelinedReader::getNext(Database cx) {
-	return getNext_impl(this, cx);
-}
-
-Future<Void> PipelinedReader::getNext_impl(PipelinedReader* self, Database cx) {
 	Transaction tr(cx);
 
 	GetRangeLimits limits(GetRangeLimits::ROW_LIMIT_UNLIMITED,
@@ -70,12 +66,12 @@ Future<Void> PipelinedReader::getNext_impl(PipelinedReader* self, Database cx) {
 	                          ? CLIENT_KNOBS->BACKUP_SIMULATED_LIMIT_BYTES
 	                          : CLIENT_KNOBS->BACKUP_GET_RANGE_LIMIT_BYTES);
 
-	Key begin = versionToKey(self->currentBeginVersion, self->prefix);
-	Key end = versionToKey(self->endVersion, self->prefix);
+	Key begin = versionToKey(currentBeginVersion, prefix);
+	Key end = versionToKey(endVersion, prefix);
 
 	while (true) {
 		// Get the lock
-		co_await self->readerLimit.take();
+		co_await readerLimit.take();
 
 		// Read begin to end forever until successful
 		while (true) {
@@ -89,17 +85,16 @@ Future<Void> PipelinedReader::getNext_impl(PipelinedReader* self, Database cx) {
 				// No more results, send end of stream
 				if (!kvs.empty()) {
 					// Send results to the reads stream
-					self->reads.send(
-					    RangeResultBlock{ .result = kvs,
-					                      .firstVersion = keyRefToVersion(kvs.front().key, self->prefix.size()),
-					                      .lastVersion = keyRefToVersion(kvs.back().key, self->prefix.size()),
-					                      .hash = self->hash,
-					                      .prefixLen = self->prefix.size(),
-					                      .indexToRead = 0 });
+					reads.send(RangeResultBlock{ .result = kvs,
+					                             .firstVersion = keyRefToVersion(kvs.front().key, prefix.size()),
+					                             .lastVersion = keyRefToVersion(kvs.back().key, prefix.size()),
+					                             .hash = hash,
+					                             .prefixLen = prefix.size(),
+					                             .indexToRead = 0 });
 				}
 
 				if (!kvs.more) {
-					self->reads.sendError(end_of_stream());
+					reads.sendError(end_of_stream());
 					co_return;
 				}
 
@@ -122,53 +117,48 @@ Future<Void> PipelinedReader::getNext_impl(PipelinedReader* self, Database cx) {
 
 } // namespace mutation_log_reader
 
-Future<Void> MutationLogReader::initializePQ(MutationLogReader* self) {
+Future<Void> MutationLogReader::initializePQ() {
 	int h{ 0 };
 	for (h = 0; h < 256; ++h) {
 		try {
-			mutation_log_reader::RangeResultBlock front = co_await self->pipelinedReaders[h]->reads.getFuture();
-			self->priorityQueue.push(front);
+			mutation_log_reader::RangeResultBlock front = co_await pipelinedReaders[h]->reads.getFuture();
+			priorityQueue.push(front);
 		} catch (Error& e) {
 			if (e.code() != error_code_end_of_stream) {
 				throw e;
 			}
-			++self->finished;
+			++finished;
 		}
 	}
 }
 
 Future<Standalone<RangeResultRef>> MutationLogReader::getNext() {
-	return getNext_impl(this);
-}
-
-Future<Standalone<RangeResultRef>> MutationLogReader::getNext_impl(MutationLogReader* self) {
 	while (true) {
-		if (self->finished == 256) {
+		if (finished == 256) {
 			int i{ 0 };
-			for (i = 0; i < self->pipelinedReaders.size(); ++i) {
-				co_await self->pipelinedReaders[i]->done();
+			for (i = 0; i < pipelinedReaders.size(); ++i) {
+				co_await pipelinedReaders[i]->done();
 			}
 			throw end_of_stream();
 		}
-		mutation_log_reader::RangeResultBlock top = self->priorityQueue.top();
-		self->priorityQueue.pop();
+		mutation_log_reader::RangeResultBlock top = priorityQueue.top();
+		priorityQueue.pop();
 		uint8_t hash = top.hash;
 		Standalone<RangeResultRef> ret = top.consume();
 		if (top.empty()) {
-			self->pipelinedReaders[(int)hash]->release();
+			pipelinedReaders[(int)hash]->release();
 			try {
-				mutation_log_reader::RangeResultBlock next =
-				    co_await self->pipelinedReaders[(int)hash]->reads.getFuture();
-				self->priorityQueue.push(next);
+				mutation_log_reader::RangeResultBlock next = co_await pipelinedReaders[(int)hash]->reads.getFuture();
+				priorityQueue.push(next);
 			} catch (Error& e) {
 				if (e.code() == error_code_end_of_stream) {
-					++self->finished;
+					++finished;
 				} else {
 					throw e;
 				}
 			}
 		} else {
-			self->priorityQueue.push(top);
+			priorityQueue.push(top);
 		}
 		if (!ret.empty()) {
 			co_return ret;

--- a/fdbclient/include/fdbclient/MutationLogReader.h
+++ b/fdbclient/include/fdbclient/MutationLogReader.h
@@ -61,7 +61,6 @@ public:
 
 	void startReading(Database cx);
 	Future<Void> getNext(Database cx);
-	static Future<Void> getNext_impl(PipelinedReader* self, Database cx);
 
 	void release() { readerLimit.release(); }
 
@@ -109,15 +108,14 @@ public:
 	                                                   Key beginKey,
 	                                                   unsigned pd) {
 		Reference<MutationLogReader> self(new MutationLogReader(cx, bv, ev, uid, beginKey, pd));
-		co_await self->initializePQ(self.getPtr());
+		co_await self->initializePQ();
 		co_return self;
 	}
 
 	Future<Standalone<RangeResultRef>> getNext();
 
 private:
-	static Future<Void> initializePQ(MutationLogReader* self);
-	static Future<Standalone<RangeResultRef>> getNext_impl(MutationLogReader* self);
+	Future<Void> initializePQ();
 
 	std::vector<std::unique_ptr<mutation_log_reader::PipelinedReader>> pipelinedReaders;
 	std::priority_queue<mutation_log_reader::RangeResultBlock> priorityQueue;

--- a/fdbserver/coordinator/Coordination.cpp
+++ b/fdbserver/coordinator/Coordination.cpp
@@ -45,21 +45,20 @@ const std::string fileCoordinatorPrefix = "coordination-";
 class LivenessChecker {
 	double threshold;
 	AsyncVar<double> lastTime;
-	static Future<Void> checkStuck(LivenessChecker const* self) {
-		while (true) {
-			auto res = co_await race(delayUntil(self->lastTime.get() + self->threshold), self->lastTime.onChange());
-			if (res.index() == 0) {
-				co_return;
-			}
-		}
-	}
 
 public:
 	explicit LivenessChecker(double threshold) : threshold(threshold), lastTime(now()) {}
 
 	void confirmLiveness() { lastTime.set(now()); }
 
-	Future<Void> checkStuck() const { return checkStuck(this); }
+	Future<Void> checkStuck() const {
+		while (true) {
+			auto res = co_await race(delayUntil(lastTime.get() + threshold), lastTime.onChange());
+			if (res.index() == 0) {
+				co_return;
+			}
+		}
+	}
 };
 
 struct GenerationRegVal {

--- a/fdbserver/datadistributor/ExclusionTracker.h
+++ b/fdbserver/datadistributor/ExclusionTracker.h
@@ -38,7 +38,7 @@ struct ExclusionTracker {
 	Future<Void> trackerFuture;
 
 	ExclusionTracker() = default;
-	explicit ExclusionTracker(Database db) : db(db) { trackerFuture = tracker(this); }
+	explicit ExclusionTracker(Database db) : db(db) { trackerFuture = tracker(); }
 
 	bool isFailedOrExcluded(NetworkAddress addr) {
 		AddressExclusion addrExclusion(addr.ip, addr.port);
@@ -47,9 +47,9 @@ struct ExclusionTracker {
 
 	// Note the tracker is intended to be used by the Data Distributor. The tracker will check for excluded localities
 	// based on the server list, the server list only includes storage processes.
-	static Future<Void> tracker(ExclusionTracker* self) {
+	Future<Void> tracker() {
 		// Fetch the list of excluded servers
-		ReadYourWritesTransaction tr(self->db);
+		ReadYourWritesTransaction tr(db);
 		while (true) {
 			Error err;
 			bool hasErr = false;
@@ -150,17 +150,17 @@ struct ExclusionTracker {
 				}
 
 				bool foundChange = false;
-				if (self->excluded != newExcluded) {
-					self->excluded = newExcluded;
+				if (excluded != newExcluded) {
+					excluded = newExcluded;
 					foundChange = true;
 				}
-				if (self->failed != newFailed) {
-					self->failed = newFailed;
+				if (failed != newFailed) {
+					failed = newFailed;
 					foundChange = true;
 				}
 
 				if (foundChange) {
-					self->changed.trigger();
+					changed.trigger();
 				}
 
 				Future<Void> watchFuture = tr.watch(excludedServersVersionKey) || tr.watch(failedServersVersionKey) ||

--- a/fdbserver/datadistributor/TCInfo.cpp
+++ b/fdbserver/datadistributor/TCInfo.cpp
@@ -133,17 +133,6 @@ public:
 	}
 };
 
-class TCTeamInfoImpl {
-public:
-	static Future<Void> updateStorageMetrics(TCTeamInfo* self) {
-		std::vector<Future<Void>> updates;
-		updates.reserve(self->servers.size());
-		for (int i = 0; i < self->servers.size(); i++)
-			updates.push_back(TCServerInfo::updateServerMetrics(self->servers[i]));
-		co_await waitForAll(updates);
-	}
-};
-
 TCServerInfo::TCServerInfo(StorageServerInterface ssi,
                            DDTeamCollection* collection,
                            ProcessClass processClass,
@@ -604,5 +593,9 @@ int64_t TCTeamInfo::getLoadAverage() const {
 }
 
 Future<Void> TCTeamInfo::updateStorageMetrics() {
-	return TCTeamInfoImpl::updateStorageMetrics(this);
+	std::vector<Future<Void>> updates;
+	updates.reserve(servers.size());
+	for (int i = 0; i < servers.size(); i++)
+		updates.push_back(TCServerInfo::updateServerMetrics(servers[i]));
+	co_await waitForAll(updates);
 }

--- a/fdbserver/datadistributor/TCInfo.h
+++ b/fdbserver/datadistributor/TCInfo.h
@@ -182,7 +182,6 @@ public:
 
 // TeamCollection's server team info.
 class TCTeamInfo final : public ReferenceCounted<TCTeamInfo>, public IDataDistributionTeam {
-	friend class TCTeamInfoImpl;
 	std::vector<Reference<TCServerInfo>> servers;
 	std::vector<UID> serverIDs;
 	bool healthy;

--- a/fdbserver/ratekeeper/TagThrottler.cpp
+++ b/fdbserver/ratekeeper/TagThrottler.cpp
@@ -34,10 +34,11 @@ class TagThrottlerImpl {
 	bool autoThrottlingEnabled{ false };
 	Future<Void> expiredTagThrottleCleanup;
 
-	static Future<Void> monitorThrottlingChanges(TagThrottlerImpl* self) {
+public:
+	Future<Void> monitorThrottlingChanges() {
 		bool committed = false;
 		while (true) {
-			ReadYourWritesTransaction tr(self->db);
+			ReadYourWritesTransaction tr(db);
 
 			while (true) {
 				Error err;
@@ -58,30 +59,30 @@ class TagThrottlerImpl {
 
 					if (autoThrottlingEnabled.get().present() && autoThrottlingEnabled.get().get() == "0"_sr) {
 						CODE_PROBE(true, "Auto-throttling disabled");
-						if (self->autoThrottlingEnabled) {
-							TraceEvent("AutoTagThrottlingDisabled", self->id).log();
+						if (this->autoThrottlingEnabled) {
+							TraceEvent("AutoTagThrottlingDisabled", id).log();
 						}
-						self->autoThrottlingEnabled = false;
+						this->autoThrottlingEnabled = false;
 					} else if (autoThrottlingEnabled.get().present() && autoThrottlingEnabled.get().get() == "1"_sr) {
 						CODE_PROBE(true, "Auto-throttling enabled");
-						if (!self->autoThrottlingEnabled) {
-							TraceEvent("AutoTagThrottlingEnabled", self->id).log();
+						if (!this->autoThrottlingEnabled) {
+							TraceEvent("AutoTagThrottlingEnabled", id).log();
 						}
-						self->autoThrottlingEnabled = true;
+						this->autoThrottlingEnabled = true;
 					} else {
 						CODE_PROBE(true, "Auto-throttling unspecified");
 						if (autoThrottlingEnabled.get().present()) {
-							TraceEvent(SevWarnAlways, "InvalidAutoTagThrottlingValue", self->id)
+							TraceEvent(SevWarnAlways, "InvalidAutoTagThrottlingValue", id)
 							    .detail("Value", autoThrottlingEnabled.get().get());
 						}
-						self->autoThrottlingEnabled = SERVER_KNOBS->AUTO_TAG_THROTTLING_ENABLED;
+						this->autoThrottlingEnabled = SERVER_KNOBS->AUTO_TAG_THROTTLING_ENABLED;
 						if (!committed)
-							tr.set(tagThrottleAutoEnabledKey, self->autoThrottlingEnabled ? "1"_sr : "0"_sr);
+							tr.set(tagThrottleAutoEnabledKey, this->autoThrottlingEnabled ? "1"_sr : "0"_sr);
 					}
 
 					RkTagThrottleCollection updatedTagThrottles;
 
-					TraceEvent("RatekeeperReadThrottledTags", self->id)
+					TraceEvent("RatekeeperReadThrottledTags", id)
 					    .detail("NumThrottledTags", throttledTagKeys.get().size());
 					for (auto entry : throttledTagKeys.get()) {
 						TagThrottleKey tagKey = TagThrottleKey::fromKey(entry.key);
@@ -103,32 +104,28 @@ class TagThrottlerImpl {
 						if (tagValue.expirationTime > now()) {
 							TransactionTag tag = *tagKey.tags.begin();
 							Optional<ClientTagThrottleLimits> oldLimits =
-							    self->throttledTags.getManualTagThrottleLimits(tag, tagKey.priority);
+							    throttledTags.getManualTagThrottleLimits(tag, tagKey.priority);
 
 							if (tagKey.throttleType == TagThrottleType::AUTO) {
 								updatedTagThrottles.autoThrottleTag(
-								    self->id, tag, 0, tagValue.tpsRate, tagValue.expirationTime);
+								    id, tag, 0, tagValue.tpsRate, tagValue.expirationTime);
 								updatedTagThrottles.incrementBusyTagCount(tagValue.reason);
 							} else {
-								updatedTagThrottles.manualThrottleTag(self->id,
-								                                      tag,
-								                                      tagKey.priority,
-								                                      tagValue.tpsRate,
-								                                      tagValue.expirationTime,
-								                                      oldLimits);
+								updatedTagThrottles.manualThrottleTag(
+								    id, tag, tagKey.priority, tagValue.tpsRate, tagValue.expirationTime, oldLimits);
 							}
 						}
 					}
 
-					self->throttledTags = std::move(updatedTagThrottles);
-					++self->throttledTagChangeId;
+					throttledTags = std::move(updatedTagThrottles);
+					++throttledTagChangeId;
 
 					Future<Void> watchFuture = tr.watch(tagThrottleSignalKey);
 					co_await tr.commit();
 					committed = true;
 
 					co_await watchFuture;
-					TraceEvent("RatekeeperThrottleSignaled", self->id).log();
+					TraceEvent("RatekeeperThrottleSignaled", id).log();
 					CODE_PROBE(true, "Tag throttle changes detected");
 					break;
 				} catch (Error& e) {
@@ -138,12 +135,13 @@ class TagThrottlerImpl {
 					err = e;
 				}
 
-				TraceEvent("RatekeeperMonitorThrottlingChangesError", self->id).error(err);
+				TraceEvent("RatekeeperMonitorThrottlingChangesError", id).error(err);
 				co_await tr.onError(err);
 			}
 		}
 	}
 
+private:
 	Future<Void> tryUpdateAutoThrottling(TransactionTag tag, double rate, double busyness, TagThrottledReason reason) {
 		// NOTE: before the comparison with MIN_TAG_COST, the busiest tag rate also compares with MIN_TAG_PAGES_RATE
 		// currently MIN_TAG_PAGES_RATE > MIN_TAG_COST in our default knobs.
@@ -176,8 +174,6 @@ public:
 		expiredTagThrottleCleanup = recurring(std::bind_front(&TagThrottlerImpl::cleanupExpiredTagThrottles, this),
 		                                      SERVER_KNOBS->TAG_THROTTLE_EXPIRED_CLEANUP_INTERVAL);
 	}
-	Future<Void> monitorThrottlingChanges() { return monitorThrottlingChanges(this); }
-
 	void addRequests(TransactionTag tag, int count) { throttledTags.addRequests(tag, count); }
 	uint64_t getThrottledTagChangeId() const { return throttledTagChangeId; }
 	PrioritizedTransactionTagMap<ClientTagThrottleLimits> getClientRates() {

--- a/fdbserver/sequencer/ResolutionBalancer.cpp
+++ b/fdbserver/sequencer/ResolutionBalancer.cpp
@@ -110,18 +110,18 @@ static std::pair<KeyRangeRef, bool> findRange(CoalescedKeyRangeMap<int>& key_res
 }
 
 // Balance key ranges among resolvers so that their load are evenly distributed.
-Future<Void> ResolutionBalancer::resolutionBalancing_impl(ResolutionBalancer* self) {
-	co_await self->triggerResolution.onTrigger();
+Future<Void> ResolutionBalancer::resolutionBalancing() {
+	co_await triggerResolution.onTrigger();
 
 	CoalescedKeyRangeMap<int> key_resolver(
 	    0, SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS ? normalKeys.end : allKeys.end);
 	key_resolver.insert(SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS ? normalKeys : allKeys, 0);
 	while (true) {
 		co_await delay(SERVER_KNOBS->MIN_BALANCE_TIME, TaskPriority::ResolutionMetrics);
-		while (!self->resolverChanges.get().empty())
-			co_await self->resolverChanges.onChange();
+		while (!resolverChanges.get().empty())
+			co_await resolverChanges.onChange();
 		std::vector<Future<ResolutionMetricsReply>> futures;
-		for (auto& p : self->resolvers)
+		for (auto& p : resolvers)
 			futures.push_back(
 			    brokenPromiseToNever(p.metrics.getReply(ResolutionMetricsRequest(), TaskPriority::ResolutionMetrics)));
 		co_await waitForAll(futures);
@@ -137,8 +137,8 @@ Future<Void> ResolutionBalancer::resolutionBalancing_impl(ResolutionBalancer* se
 			try {
 				int src = metrics.lastItem()->second;
 				int dest = metrics.begin()->second;
-				int64_t amount = std::min(metrics.lastItem()->first - total / self->resolvers.size(),
-				                          total / self->resolvers.size() - metrics.begin()->first) /
+				int64_t amount = std::min(metrics.lastItem()->first - total / resolvers.size(),
+				                          total / resolvers.size() - metrics.begin()->first) /
 				                 2;
 				Standalone<VectorRef<ResolverMoveRef>> movedRanges;
 
@@ -150,9 +150,8 @@ Future<Void> ResolutionBalancer::resolutionBalancing_impl(ResolutionBalancer* se
 					req.offset = amount;
 					req.range = range.first;
 
-					ResolutionSplitReply split =
-					    co_await brokenPromiseToNever(self->resolvers[metrics.lastItem()->second].split.getReply(
-					        req, TaskPriority::ResolutionMetrics));
+					ResolutionSplitReply split = co_await brokenPromiseToNever(
+					    resolvers[metrics.lastItem()->second].split.getReply(req, TaskPriority::ResolutionMetrics));
 					KeyRangeRef moveRange = range.second ? KeyRangeRef(range.first.begin, split.key)
 					                                     : KeyRangeRef(split.key, range.first.end);
 					movedRanges.push_back_deep(movedRanges.arena(), ResolverMoveRef(moveRange, dest));
@@ -173,10 +172,10 @@ Future<Void> ResolutionBalancer::resolutionBalancing_impl(ResolutionBalancer* se
 				// for(auto& it : key_resolver.ranges())
 				//	TraceEvent("KeyResolver").detail("Range", it.range()).detail("Value", it.value());
 
-				self->resolverChangesVersion = *self->pVersion + 1;
-				for (auto& p : self->commitProxies)
-					self->resolverNeedingChanges.insert(p.id());
-				self->resolverChanges.set(movedRanges);
+				resolverChangesVersion = *pVersion + 1;
+				for (auto& p : commitProxies)
+					resolverNeedingChanges.insert(p.id());
+				resolverChanges.set(movedRanges);
 			} catch (Error& e) {
 				if (e.code() != error_code_operation_failed)
 					throw;

--- a/fdbserver/sequencer/ResolutionBalancer.h
+++ b/fdbserver/sequencer/ResolutionBalancer.h
@@ -43,9 +43,7 @@ struct ResolutionBalancer {
 
 	explicit(false) ResolutionBalancer(Version* version) : pVersion(version) {}
 
-	Future<Void> resolutionBalancing() { return resolutionBalancing_impl(this); }
-
-	static Future<Void> resolutionBalancing_impl(ResolutionBalancer* self);
+	Future<Void> resolutionBalancing();
 
 	// Sets resolver interfaces. Trigger resolutionBalancing() actor if more
 	// than one resolvers are present.

--- a/flow/Net2.cpp
+++ b/flow/Net2.cpp
@@ -811,19 +811,14 @@ public:
 	void delref() override { ReferenceCounted<Listener>::delref(); }
 
 	// Returns one incoming connection when it is available
-	Future<Reference<IConnection>> accept() override { return doAccept(this); }
-
-	NetworkAddress getListenAddress() const override { return listenAddress; }
-
-private:
-	static Future<Reference<IConnection>> doAccept(Listener* self) {
-		Reference<Connection> conn(new Connection(self->io_service));
+	Future<Reference<IConnection>> accept() override {
+		Reference<Connection> conn(new Connection(io_service));
 		tcp::acceptor::endpoint_type peer_endpoint;
 		try {
 			// Peer address not known until accept succeeds
 			BindPromise p("N2_AcceptError", UID(), NetworkAddress());
 			auto f = p.getFuture();
-			self->acceptor.async_accept(conn->getSocket(), peer_endpoint, std::move(p));
+			acceptor.async_accept(conn->getSocket(), peer_endpoint, std::move(p));
 			co_await f;
 			auto peer_address = peer_endpoint.address().is_v6() ? IPAddress(peer_endpoint.address().to_v6().to_bytes())
 			                                                    : IPAddress(peer_endpoint.address().to_v4().to_ulong());
@@ -835,6 +830,8 @@ private:
 			throw;
 		}
 	}
+
+	NetworkAddress getListenAddress() const override { return listenAddress; }
 };
 
 using ssl_socket = boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>;
@@ -1340,19 +1337,14 @@ public:
 	void delref() override { ReferenceCounted<SSLListener>::delref(); }
 
 	// Returns one incoming connection when it is available
-	Future<Reference<IConnection>> accept() override { return doAccept(this); }
-
-	NetworkAddress getListenAddress() const override { return listenAddress; }
-
-private:
-	static Future<Reference<IConnection>> doAccept(SSLListener* self) {
-		Reference<SSLConnection> conn(new SSLConnection(self->io_service, self->contextVar->get()));
+	Future<Reference<IConnection>> accept() override {
+		Reference<SSLConnection> conn(new SSLConnection(io_service, contextVar->get()));
 		tcp::acceptor::endpoint_type peer_endpoint;
 		try {
 			// Peer address not known until accept succeeds
 			BindPromise p("N2_AcceptError", UID(), NetworkAddress());
 			auto f = p.getFuture();
-			self->acceptor.async_accept(conn->getSocket(), peer_endpoint, std::move(p));
+			acceptor.async_accept(conn->getSocket(), peer_endpoint, std::move(p));
 			co_await f;
 			auto peer_address = peer_endpoint.address().is_v6() ? IPAddress(peer_endpoint.address().to_v6().to_bytes())
 			                                                    : IPAddress(peer_endpoint.address().to_v4().to_ulong());
@@ -1365,6 +1357,8 @@ private:
 			throw;
 		}
 	}
+
+	NetworkAddress getListenAddress() const override { return listenAddress; }
 };
 
 // 5MB for loading files into memory

--- a/flow/include/flow/genericactors.h
+++ b/flow/include/flow/genericactors.h
@@ -478,15 +478,15 @@ struct WorkerCache {
 		return id_interface[id];
 	}
 
-	Future<Void> removeOnReady(UID id, Future<Void> const& ready) { return removeOnReady(this, id, ready); }
+	Future<Void> removeOnReady(UID id, Future<Void> const& ready) { return removeOnReadyImpl(id, ready); }
 
 private:
-	static Future<Void> removeOnReady(WorkerCache* self, UID id, Future<Void> ready) {
+	Future<Void> removeOnReadyImpl(UID id, Future<Void> ready) {
 		try {
 			co_await ready;
-			self->id_interface.erase(id);
+			id_interface.erase(id);
 		} catch (Error& e) {
-			self->id_interface.erase(id);
+			id_interface.erase(id);
 			throw;
 		}
 	}
@@ -2058,9 +2058,9 @@ struct FlowLock : NonCopyable, public ReferenceCounted<FlowLock> {
 	Future<Void> take(TaskPriority taskID = TaskPriority::DefaultYield, int64_t amount = 1) {
 		if (active + amount <= permits || active == 0) {
 			active += amount;
-			return safeYieldActor(this, taskID, amount);
+			return safeYieldActor(taskID, amount);
 		}
-		return takeActor(this, taskID, amount);
+		return takeActor(taskID, amount);
 	}
 	void release(int64_t amount = 1) {
 		ASSERT((active > 0 || amount == 0) && active - amount >= 0);
@@ -2078,13 +2078,11 @@ struct FlowLock : NonCopyable, public ReferenceCounted<FlowLock> {
 		}
 	}
 
-	Future<Void> releaseWhen(Future<Void> const& signal, int amount = 1) {
-		return releaseWhenActor(this, signal, amount);
-	}
+	Future<Void> releaseWhen(Future<Void> const& signal, int amount = 1) { return releaseWhenActor(signal, amount); }
 
 	// returns when any permits are available, having taken as many as possible up to the given amount, and modifies
 	// amount to the number of permits taken
-	Future<Void> takeUpTo(int64_t& amount) { return takeMoreActor(this, &amount); }
+	Future<Void> takeUpTo(int64_t& amount) { return takeMoreActor(&amount); }
 
 	int64_t available() const { return permits - active; }
 	int64_t activePermits() const { return active; }
@@ -2106,15 +2104,15 @@ private:
 	int64_t active;
 	Promise<Void> broken_on_destruct;
 
-	static Future<Void> takeActor(FlowLock* lock, TaskPriority taskID, int64_t amount) {
-		auto it = lock->takers.emplace(lock->takers.end(), Promise<Void>(), amount);
+	Future<Void> takeActor(TaskPriority taskID, int64_t amount) {
+		auto it = takers.emplace(takers.end(), Promise<Void>(), amount);
 
 		try {
 			co_await it->first.getFuture();
 		} catch (Error& e) {
 			if (e.code() == error_code_actor_cancelled) {
-				lock->takers.erase(it);
-				lock->release(0);
+				takers.erase(it);
+				release(0);
 			}
 			throw;
 		}
@@ -2122,34 +2120,34 @@ private:
 			double duration =
 			    buggify(.001) ? deterministicRandom()->random01() * FLOW_KNOBS->BUGGIFY_FLOW_LOCK_RELEASE_DELAY : 0.0;
 			// Yield so releasing the lock does not run arbitrary code on the release() stack.
-			co_await race(delay(duration, taskID), lock->broken_on_destruct.getFuture());
+			co_await race(delay(duration, taskID), broken_on_destruct.getFuture());
 		} catch (...) {
 			CODE_PROBE(true,
 			           "If we get cancelled here, we are holding the lock but the caller doesn't know, so release it");
-			lock->release(amount);
+			release(amount);
 			throw;
 		}
 	}
 
-	static Future<Void> takeMoreActor(FlowLock* lock, int64_t* amount) {
-		co_await lock->take();
-		int64_t extra = std::min(lock->available(), *amount - 1);
-		lock->active += extra;
+	Future<Void> takeMoreActor(int64_t* amount) {
+		co_await take();
+		int64_t extra = std::min(available(), *amount - 1);
+		active += extra;
 		*amount = 1 + extra;
 	}
 
-	static Future<Void> safeYieldActor(FlowLock* lock, TaskPriority taskID, int64_t amount) {
+	Future<Void> safeYieldActor(TaskPriority taskID, int64_t amount) {
 		try {
-			co_await race(yield(taskID), lock->broken_on_destruct.getFuture());
+			co_await race(yield(taskID), broken_on_destruct.getFuture());
 		} catch (Error& e) {
-			lock->release(amount);
+			release(amount);
 			throw;
 		}
 	}
 
-	static Future<Void> releaseWhenActor(FlowLock* self, Future<Void> signal, int64_t amount) {
+	Future<Void> releaseWhenActor(Future<Void> signal, int64_t amount) {
 		co_await signal;
-		self->release(amount);
+		release(amount);
 	}
 };
 
@@ -2240,7 +2238,7 @@ struct BoundedFlowLock : NonCopyable, public ReferenceCounted<BoundedFlowLock> {
 	  : minOutstanding(0), nextPermitNumber(0), unrestrictedPermits(unrestrictedPermits),
 	    boundedPermits(boundedPermits) {}
 
-	Future<int64_t> take() { return takeActor(this); }
+	Future<int64_t> take() { return takeActor(); }
 	void release(int64_t permitNumber) {
 		outstanding.erase(permitNumber);
 		updateMinOutstanding();
@@ -2262,11 +2260,11 @@ private:
 		}
 	}
 
-	static Future<int64_t> takeActor(BoundedFlowLock* lock) {
-		int64_t permitNumber = ++lock->nextPermitNumber;
-		lock->outstanding.insert(permitNumber, 1);
-		lock->updateMinOutstanding();
-		co_await lock->minOutstanding.whenAtLeast(std::max<int64_t>(0, permitNumber - lock->boundedPermits));
+	Future<int64_t> takeActor() {
+		int64_t permitNumber = ++nextPermitNumber;
+		outstanding.insert(permitNumber, 1);
+		updateMinOutstanding();
+		co_await minOutstanding.whenAtLeast(std::max<int64_t>(0, permitNumber - boundedPermits));
 		co_return permitNumber;
 	}
 };


### PR DESCRIPTION
## Summary

Replace 20 actor-compiler-era static helpers that take an explicit receiver with ordinary C++ coroutine members. Fold pure forwarding wrappers into the existing entry points where possible.

The nine commits cover mutation-log readers, Net2 listeners, Flow cache and lock helpers, team metrics, coordinator liveness checking, exclusion tracking, tag throttling, resolution balancing, and backup-file writers. Matching declarations are updated in the same commit as their implementation.

Preserve the existing instance and virtual entry-point signatures, by-value Future ownership, synchronous lock fast paths, cancellation cleanup, retry and suspension order, and backup-file encoding. Remove obsolete static helper declarations. No behavior change is intended.

## Validation

- Clang-format 19.1.5; receiver-normalized comparison of all 20 coroutine bodies.
- Full `flow_test --seed 1`: 184 passed.
- Focused `fdbclient_test` mutation-log-reader tests in normal and simulation modes, plus local backup-container tests: 10 passed.
- Data Distributor and coordinator tests in normal and simulation modes, plus sequencer tests: 61 passed. `fdbserver_ratekeeperlinktest` also passed.
- Full `fdbserver` build, followed by `MutationLogReaderCorrectness.toml`, `CycleTest.toml`, `BackupCorrectnessClean.toml`, and `TransactionTagApiCorrectness.toml`: all five test cases passed with seed 1. Buggify was on for Cycle and off for the other three files.
