### PR TITLE
Restore region recovery configuration after simulation restart

### DIFF
--- a/fdbserver/SimulatedCluster.cpp
+++ b/fdbserver/SimulatedCluster.cpp
@@ -2064,20 +2064,8 @@ void SimulationConfig::setRegions(const TestConfig& testConfig) {
 	}
 
 	if (needsRemote) {
-		fdbSimulationPolicyState().originalRegions =
-		    "regions=" + json_spirit::write_string(json_spirit::mValue(regionArr), json_spirit::Output_options::none);
-
-		StatusArray disablePrimary = regionArr;
-		disablePrimary[0].get_obj()["datacenters"].get_array()[0].get_obj()["priority"] = -1;
-		fdbSimulationPolicyState().disablePrimary =
-		    "regions=" +
-		    json_spirit::write_string(json_spirit::mValue(disablePrimary), json_spirit::Output_options::none);
-
-		StatusArray disableRemote = regionArr;
-		disableRemote[1].get_obj()["datacenters"].get_array()[0].get_obj()["priority"] = -1;
-		fdbSimulationPolicyState().disableRemote =
-		    "regions=" +
-		    json_spirit::write_string(json_spirit::mValue(disableRemote), json_spirit::Output_options::none);
+		fdbSimulationPolicyState().setRegionConfiguration(
+		    regionArr, primaryDcObj["id"].get_str(), remoteDcObj["id"].get_str());
 	} else {
 		// In order to generate a starting configuration with the remote disabled, do not apply the region
 		// configuration to the DatabaseConfiguration until after creating the starting conf string.

--- a/fdbserver/core/FDBSimulationPolicy.cpp
+++ b/fdbserver/core/FDBSimulationPolicy.cpp
@@ -21,14 +21,18 @@
 #include "fdbserver/core/FDBSimulationPolicy.h"
 
 #include <algorithm>
+#include <map>
 #include <set>
 #include <vector>
 
+#include "fdbclient/GenericManagementAPI.h"
+#include "fdbclient/SystemData.h"
 #include "fdbrpc/Replication.h"
 #include "fdbrpc/ReplicationUtils.h"
 #include "fdbrpc/SimulatorProcessInfo.h"
 #include "fdbrpc/simulator.h"
 #include "fdbserver/core/FDBSimulatorProcessInfo.h"
+#include "flow/UnitTest.h"
 
 FDBExtraDatabaseMode stringToFDBExtraDatabaseMode(const std::string& databaseMode) {
 	if (databaseMode == "Disabled") {
@@ -49,6 +53,44 @@ FDBExtraDatabaseMode stringToFDBExtraDatabaseMode(const std::string& databaseMod
 }
 
 namespace {
+
+std::string regionConfigurationString(StatusArray const& regions) {
+	return "regions=" + json_spirit::write_string(json_spirit::mValue(regions), json_spirit::Output_options::none);
+}
+
+std::string disabledRegionConfiguration(StatusArray regions, std::string const& dcId) {
+	int matches = 0;
+	for (auto& region : regions) {
+		for (auto& datacenter : region.get_obj().at("datacenters").get_array()) {
+			auto& dc = datacenter.get_obj();
+			auto satellite = dc.find("satellite");
+			if ((satellite == dc.end() || satellite->second.get_int() != 1) && dc.at("id").get_str() == dcId) {
+				dc["priority"] = -1;
+				++matches;
+			}
+		}
+	}
+	ASSERT_EQ(matches, 1);
+	return regionConfigurationString(regions);
+}
+
+void restoreRestartedRegionConfiguration(FDBSimulationPolicyState& state,
+                                         DatabaseConfiguration const& configuration,
+                                         bool restartingTest) {
+	if (!restartingTest || configuration.usableRegions < 2 || configuration.regions.size() != 2 ||
+	    !state.originalRegions.empty()) {
+		return;
+	}
+
+	// Older restart files do not contain these commands. Preserve the persisted region JSON, including its
+	// ordering and satellite settings, and capture it only once before a workload changes the configuration.
+	Optional<ValueRef> storedRegions = configuration.get("regions"_sr.withPrefix(configKeysPrefix));
+	ASSERT(storedRegions.present());
+	StatusObject regions = BinaryReader::fromStringRef<StatusObject>(storedRegions.get(), IncludeVersion());
+	state.setRegionConfiguration(regions.at("regions").get_array(),
+	                             configuration.regions[0].dcId.toString(),
+	                             configuration.regions[1].dcId.toString());
+}
 
 FDBSimulationPolicyState& policyState() {
 	static auto* state = new FDBSimulationPolicyState;
@@ -354,8 +396,22 @@ FDBSimulationPolicyState& fdbSimulationPolicyState() {
 	return policyState();
 }
 
+void FDBSimulationPolicyState::setRegionConfiguration(StatusArray const& regions,
+                                                      std::string const& primaryDc,
+                                                      std::string const& remoteDc) {
+	ASSERT_EQ(regions.size(), 2);
+	ASSERT_NE(primaryDc, remoteDc);
+	std::string original = regionConfigurationString(regions);
+	std::string primary = disabledRegionConfiguration(regions, primaryDc);
+	std::string remote = disabledRegionConfiguration(regions, remoteDc);
+	originalRegions = std::move(original);
+	disablePrimary = std::move(primary);
+	disableRemote = std::move(remote);
+}
+
 void updateFDBSimulationPolicy(DatabaseConfiguration const& configuration, bool restartingTest) {
 	auto& state = fdbSimulationPolicyState();
+	restoreRestartedRegionConfiguration(state, configuration, restartingTest);
 	state.storagePolicy = configuration.storagePolicy;
 	state.tLogPolicy = configuration.tLogPolicy;
 	state.tLogWriteAntiQuorum = configuration.tLogWriteAntiQuorum;
@@ -403,4 +459,103 @@ void updateFDBSimulationPolicy(DatabaseConfiguration const& configuration, bool 
 
 void setFDBSimulationPolicyRemoteTLogPolicy(Reference<IReplicationPolicy> remoteTLogPolicy) {
 	fdbSimulationPolicyState().remoteTLogPolicy = remoteTLogPolicy;
+}
+
+namespace {
+
+StatusArray regionCommandTestRegions() {
+	json_spirit::mValue value;
+	const std::string json = R"json([
+          {
+            "datacenters": [
+              {"id":"region-b","priority":8,"satellite":1,"satellite_logs":2},
+              {"id":"region-a","priority":3},
+              {"id":"satellite-a","priority":4,"satellite":1}
+            ],
+            "satellite_redundancy_mode":"two_satellite_fast",
+            "satellite_logs":4,
+            "preserved_extension":{"value":1}
+          },
+          {
+            "datacenters": [
+              {"id":"region-a","priority":7,"satellite":1},
+              {"id":"region-b","priority":9}
+            ],
+            "satellite_redundancy_mode":"one_satellite_double",
+            "satellite_logs":3
+          }
+        ])json";
+	ASSERT(json_spirit::read_string(json, value));
+	return value.get_array();
+}
+
+DatabaseConfiguration regionCommandTestConfiguration(StatusArray const& regions, int usableRegions = 2) {
+	std::map<std::string, std::string> options;
+	ASSERT(
+	    buildConfiguration("usable_regions=" + std::to_string(usableRegions) + " " + regionConfigurationString(regions),
+	                       options) == ConfigurationResult::SUCCESS);
+	DatabaseConfiguration configuration;
+	for (auto const& [key, value] : options) {
+		configuration.set(StringRef(key), StringRef(value));
+	}
+	return configuration;
+}
+
+void checkRegionCommand(std::string const& command, StatusArray const& expected) {
+	std::map<std::string, std::string> options;
+	ASSERT(buildConfiguration(command + " repopulate_anti_quorum=1", options) == ConfigurationResult::SUCCESS);
+	ASSERT_EQ(options.size(), 2);
+	ASSERT_EQ(options.at(configKeysPrefix.toString() + "repopulate_anti_quorum"), "1");
+	StatusObject decoded = BinaryReader::fromStringRef<StatusObject>(
+	    StringRef(options.at(configKeysPrefix.toString() + "regions")), IncludeVersion());
+	ASSERT_EQ(regionConfigurationString(decoded.at("regions").get_array()), regionConfigurationString(expected));
+}
+
+} // namespace
+
+TEST_CASE("/fdbserver/FDBSimulationPolicy/RestartRegionCommands") {
+	StatusArray regions = regionCommandTestRegions();
+	DatabaseConfiguration configuration = regionCommandTestConfiguration(regions);
+	ASSERT_EQ(configuration.regions[0].dcId, "region-b"_sr);
+	ASSERT_EQ(configuration.regions[1].dcId, "region-a"_sr);
+
+	FDBSimulationPolicyState state;
+	restoreRestartedRegionConfiguration(state, configuration, true);
+	ASSERT_EQ(state.originalRegions, regionConfigurationString(regions));
+	ASSERT(state.startingDisabledConfiguration.empty());
+
+	StatusArray primaryDisabled = regions;
+	primaryDisabled[1].get_obj().at("datacenters").get_array()[1].get_obj()["priority"] = -1;
+	checkRegionCommand(state.disablePrimary, primaryDisabled);
+	StatusArray remoteDisabled = regions;
+	remoteDisabled[0].get_obj().at("datacenters").get_array()[1].get_obj()["priority"] = -1;
+	checkRegionCommand(state.disableRemote, remoteDisabled);
+	return Void();
+}
+
+TEST_CASE("/fdbserver/FDBSimulationPolicy/RegionCommandInitialization") {
+	StatusArray regions = regionCommandTestRegions();
+	DatabaseConfiguration configuration = regionCommandTestConfiguration(regions);
+	FDBSimulationPolicyState state;
+	restoreRestartedRegionConfiguration(state, configuration, false);
+	ASSERT(state.originalRegions.empty());
+	restoreRestartedRegionConfiguration(state, regionCommandTestConfiguration(regions, 1), true);
+	ASSERT(state.originalRegions.empty());
+	StatusArray singleRegion;
+	singleRegion.push_back(regions[0]);
+	restoreRestartedRegionConfiguration(state, regionCommandTestConfiguration(singleRegion), true);
+	ASSERT(state.originalRegions.empty());
+	restoreRestartedRegionConfiguration(state, DatabaseConfiguration(), true);
+	ASSERT(state.originalRegions.empty());
+
+	state.setRegionConfiguration(regions, "region-b", "region-a");
+	const std::string original = state.originalRegions;
+	const std::string primary = state.disablePrimary;
+	const std::string remote = state.disableRemote;
+	regions[0].get_obj().at("datacenters").get_array()[1].get_obj()["priority"] = 10;
+	restoreRestartedRegionConfiguration(state, regionCommandTestConfiguration(regions), true);
+	ASSERT_EQ(state.originalRegions, original);
+	ASSERT_EQ(state.disablePrimary, primary);
+	ASSERT_EQ(state.disableRemote, remote);
+	return Void();
 }

--- a/fdbserver/core/QuietDatabase.cpp
+++ b/fdbserver/core/QuietDatabase.cpp
@@ -30,6 +30,7 @@
 #include "fdbrpc/simulator.h"
 #include "flow/flow.h"
 #include "flow/ProcessEvents.h"
+#include "flow/ScopeExit.h"
 #include "flow/Trace.h"
 #include "fdbclient/DatabaseContext.h"
 #include "fdbclient/NativeAPI.actor.h"
@@ -737,26 +738,50 @@ Future<Void> repairDeadDatacenter(Database cx, Reference<AsyncVar<ServerDBInfo> 
 				    .detail("Servers", describe(servers));
 				co_await excludeServers(cx, servers, false);
 			}
+			if (simPolicy.usableRegions <= 1 || simPolicy.quiesced || simPolicy.primaryDcId != primaryDcId ||
+			    simPolicy.remoteDcId != remoteDcId) {
+				co_return;
+			}
 
 			TraceEvent(SevWarnAlways, "DisablingFearlessConfiguration")
 			    .detail("Location", context)
 			    .detail("Stage", "Repopulate")
 			    .detail("RemoteDead", remoteDead)
 			    .detail("PrimaryDead", primaryDead);
-			simPolicy.usableRegions = 1;
 
-			co_await ManagementAPI::changeConfig(
-			    cx.getReference(),
-			    (primaryDead ? fdbSimulationPolicyState().disablePrimary : fdbSimulationPolicyState().disableRemote) +
-			        " repopulate_anti_quorum=1",
-			    true);
+			const std::string regionConfiguration = primaryDead ? simPolicy.disablePrimary : simPolicy.disableRemote;
+			ASSERT(!regionConfiguration.empty());
+			const int previousUsableRegions = simPolicy.usableRegions;
+			bool repopulated = false;
+			ScopeExit restorePolicy([&simPolicy, previousUsableRegions, &repopulated]() {
+				if (!repopulated) {
+					simPolicy.usableRegions = previousUsableRegions;
+				}
+			});
+			// Keep concurrent repair callers out while the configuration transaction is in flight.
+			simPolicy.usableRegions = 1;
+			ConfigurationResult result = co_await ManagementAPI::changeConfig(
+			    cx.getReference(), regionConfiguration + " repopulate_anti_quorum=1", true);
+			if (result != ConfigurationResult::SUCCESS) {
+				TraceEvent(SevError, "DisablingFearlessConfigurationFailed")
+				    .detail("Stage", "Repopulate")
+				    .detail("Result", result);
+				throw operation_failed();
+			}
+			repopulated = true;
 			while (dbInfo->get().recoveryState < RecoveryState::STORAGE_RECOVERED) {
 				co_await dbInfo->onChange();
 			}
 			TraceEvent(SevWarnAlways, "DisablingFearlessConfiguration")
 			    .detail("Location", context)
 			    .detail("Stage", "Usable_Regions");
-			co_await ManagementAPI::changeConfig(cx.getReference(), "usable_regions=1", true);
+			result = co_await ManagementAPI::changeConfig(cx.getReference(), "usable_regions=1", true);
+			if (result != ConfigurationResult::SUCCESS) {
+				TraceEvent(SevError, "DisablingFearlessConfigurationFailed")
+				    .detail("Stage", "Usable_Regions")
+				    .detail("Result", result);
+				throw operation_failed();
+			}
 		}
 	}
 }

--- a/fdbserver/core/include/fdbserver/core/FDBSimulationPolicy.h
+++ b/fdbserver/core/include/fdbserver/core/FDBSimulationPolicy.h
@@ -102,6 +102,8 @@ struct FDBSimulationPolicyState {
 	std::map<NetworkAddress, bool> corruptWorkerMap;
 	FDBTSSMode tssMode = FDBTSSMode::Disabled;
 
+	void setRegionConfiguration(StatusArray const& regions, std::string const& primaryDc, std::string const& remoteDc);
+
 	bool updateConsistencyScanState(FDBSimConsistencyScanState expectedCurrent, FDBSimConsistencyScanState desired) {
 		if (consistencyScanState == expectedCurrent && desired > consistencyScanState) {
 			consistencyScanState = desired;


### PR DESCRIPTION
## Summary

A paired simulation restart can lose the region commands that fresh setup initializes. If a datacenter later becomes unavailable, dead-region repair submits an incomplete configuration command, ignores `UNKNOWN_OPTION`, and can wait until the trace limit aborts the test.

- Reconstruct the original and disabled-region commands once from the persisted two-region configuration, preserving region ordering and satellite settings.
- Share command construction with fresh setup and check both recovery configuration results while preserving the concurrent-repair guard.
- Add focused coverage for datacenter selection, satellite and extension-field preservation, configuration parsing, and initialization boundaries.

No workload or fault settings change.

## Validation

- `fdbserver_core_test -f /fdbserver/FDBSimulationPolicy/`: two tests passed in both normal mode and Sim2.
- The unchanged `restarting/from_7.3.29/ClientTransactionProfilingCorrectness` test pair passed with the historical 7.3 server, buggify, and fault injection preserved. The recovery trace confirms the configuration was applied, old log generations drained, full recovery completed, and no severe errors occurred.
