### PR TITLE
Retry old-epoch backup mutation-log uploads

### DIFF
--- a/fdbserver/backupworker/BackupWorker.cpp
+++ b/fdbserver/backupworker/BackupWorker.cpp
@@ -21,6 +21,7 @@
 #include "fdbclient/BackupAgent.h"
 #include "fdbclient/BackupFileFormat.h"
 #include "fdbclient/BackupContainer.h"
+#include "fdbclient/BackupContainerFileSystem.h"
 #include "fdbclient/DatabaseContext.h"
 #include "fdbclient/CommitProxyInterface.h"
 #include "fdbclient/SystemData.h"
@@ -40,6 +41,7 @@
 #include "flow/IRandom.h"
 #include "fdbclient/Tracing.h"
 #include "flow/CoroUtils.h"
+#include "flow/UnitTest.h"
 
 #define SevDebugMemory SevVerbose
 
@@ -284,33 +286,6 @@ struct BackupData {
 	bool allMessageSaved() const { return (endVersion.present() && savedVersion >= endVersion.get()) || stopped; }
 
 	Version maxPopVersion() const { return endVersion.present() ? endVersion.get() : minKnownCommittedVersion; }
-
-	// Inserts a backup's single range into rangeMap.
-	template <class T>
-	void insertRange(KeyRangeMap<std::set<T>>& keyRangeMap, KeyRangeRef range, T value) {
-		for (auto& logRange : keyRangeMap.modify(range)) {
-			logRange->value().insert(value);
-		}
-		for (auto& logRange : keyRangeMap.modify(singleKeyRange(metadataVersionKey))) {
-			logRange->value().insert(value);
-		}
-		TraceEvent("BackupWorkerInsertRange", myId)
-		    .detail("Value", value)
-		    .detail("Begin", range.begin)
-		    .detail("End", range.end);
-	}
-
-	// Inserts a backup's ranges into rangeMap.
-	template <class T>
-	void insertRanges(KeyRangeMap<std::set<T>>& keyRangeMap, const Optional<std::vector<KeyRange>>& ranges, T value) {
-		if (!ranges.present() || ranges.get().empty()) {
-			// insert full ranges of normal keys
-			return insertRange(keyRangeMap, normalKeys, value);
-		}
-		for (const auto& range : ranges.get()) {
-			insertRange(keyRangeMap, range, value);
-		}
-	}
 
 	void pop() {
 		if (backupEpoch > oldestBackupEpoch || stopped) {
@@ -684,12 +659,113 @@ Future<Void> addMutation(Reference<IBackupFile> logFile,
 	co_await logFile->append(mutation.begin(), mutation.size());
 }
 
-static Future<Void> updateLogBytesWritten(BackupData* self,
-                                          std::vector<UID> backupUids,
-                                          std::vector<Reference<IBackupFile>> logFiles) {
+static Future<Void> addClearMutationAfter(Future<Void> previous,
+                                          Reference<IBackupFile> logFile,
+                                          VersionedMessage message,
+                                          Standalone<StringRef> mutation,
+                                          int64_t* blockEnd,
+                                          int blockSize) {
+	co_await previous;
+	co_await addMutation(logFile, message, mutation, blockEnd, blockSize);
+}
+
+struct CompletedMutationLogFile {
+	UID backupUid;
+	Reference<IBackupFile> file;
+};
+
+struct MutationLogBackup {
+	UID uid;
+	Version beginVersion;
+	Reference<IBackupContainer> container;
+	Optional<std::vector<KeyRange>> ranges;
+};
+
+// The range boundaries affect ClearRange serialization, not just routing. Keep
+// them fixed even if a recipient stops, so an ambiguous finish can only produce
+// byte-identical duplicate files on a retry.
+class MutationLogBatch {
+public:
+	MutationLogBatch(UID workerId,
+	                 Tag tag,
+	                 int totalTags,
+	                 Version popVersion,
+	                 int numMessages,
+	                 int blockSize,
+	                 std::vector<MutationLogBackup> backups)
+	  : workerId(workerId), tag(tag), totalTags(totalTags), popVersion(popVersion), numMessages(numMessages),
+	    blockSize(blockSize), backups(std::move(backups)) {
+		for (int i = 0; i < this->backups.size(); ++i) {
+			const auto& backup = this->backups[i];
+			ASSERT(backup.container.isValid() && backup.beginVersion <= popVersion);
+			if (!backup.ranges.present() || backup.ranges.get().empty()) {
+				insertRange(normalKeys, i);
+			} else {
+				for (const auto& range : backup.ranges.get()) {
+					insertRange(range, i);
+				}
+			}
+		}
+		keyRangeMap.coalesce(allKeys);
+	}
+
+	template <class IsStopped>
+	Future<std::vector<CompletedMutationLogFile>> write(std::vector<VersionedMessage>* messages,
+	                                                    Version minKnownCommittedVersion,
+	                                                    Version savedVersion,
+	                                                    IsStopped isStopped) const;
+
+private:
+	void insertRange(KeyRangeRef range, int index) {
+		for (auto& logRange : keyRangeMap.modify(range)) {
+			logRange->value().insert(index);
+		}
+		for (auto& logRange : keyRangeMap.modify(singleKeyRange(metadataVersionKey))) {
+			logRange->value().insert(index);
+		}
+		TraceEvent("BackupWorkerInsertRange", workerId)
+		    .detail("Value", index)
+		    .detail("Begin", range.begin)
+		    .detail("End", range.end);
+	}
+
+	const UID workerId;
+	const Tag tag;
+	const int totalTags;
+	const Version popVersion;
+	const int numMessages;
+	const int blockSize;
+	const std::vector<MutationLogBackup> backups;
+	KeyRangeMap<std::set<int>> keyRangeMap;
+};
+
+template <class WriteFiles, class WaitRetry>
+static Future<std::vector<CompletedMutationLogFile>> retryMutationLogUpload(LogEpoch backupEpoch,
+                                                                            LogEpoch recruitedEpoch,
+                                                                            const bool* stopped,
+                                                                            WriteFiles writeFiles,
+                                                                            WaitRetry waitRetry) {
+	while (true) {
+		Error err;
+		try {
+			co_return co_await writeFiles();
+		} catch (Error& e) {
+			if ((e.code() != error_code_io_error && e.code() != error_code_io_timeout) ||
+			    backupEpoch >= recruitedEpoch || *stopped) {
+				throw;
+			}
+			err = e;
+		}
+		co_await waitRetry(err);
+		if (*stopped) {
+			throw err;
+		}
+	}
+}
+
+static Future<Void> updateLogBytesWritten(BackupData* self, std::vector<CompletedMutationLogFile> completedFiles) {
 	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
 
-	ASSERT(backupUids.size() == logFiles.size());
 	while (true) {
 		Error err;
 		try {
@@ -697,9 +773,9 @@ static Future<Void> updateLogBytesWritten(BackupData* self,
 			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
-			for (int i = 0; i < backupUids.size(); i++) {
-				BackupConfig config(backupUids[i]);
-				config.logBytesWritten().atomicOp(tr, logFiles[i]->size(), MutationRef::AddValue);
+			for (const auto& completed : completedFiles) {
+				BackupConfig config(completed.backupUid);
+				config.logBytesWritten().atomicOp(tr, completed.file->size(), MutationRef::AddValue);
 			}
 			co_await tr->commit();
 			co_return;
@@ -710,54 +786,66 @@ static Future<Void> updateLogBytesWritten(BackupData* self,
 	}
 }
 
-// Saves messages in the range of [0, numMsg) to a file and then remove these
-// messages. The file content format is a sequence of (Version, sub#, msgSize, message).
-// Note only ready backups are saved.
-Future<Void> saveMutationsToFile(BackupData* self, Version popVersion, int numMsg) {
-	int blockSize = SERVER_KNOBS->BACKUP_FILE_BLOCK_BYTES;
-	std::vector<Future<Reference<IBackupFile>>> logFileFutures;
-	std::vector<Reference<IBackupFile>> logFiles;
-	std::vector<int64_t> blockEnds;
-	std::vector<UID> activeUids; // active Backups' UIDs
-	std::vector<Version> beginVersions; // logFiles' begin versions
-	KeyRangeMap<std::set<int>> keyRangeMap; // range to index in logFileFutures, logFiles, & blockEnds
-	std::vector<Standalone<StringRef>> mutations;
-	int idx{ 0 };
-
-	// Make sure all backups are ready, otherwise mutations will be lost.
-	while (!self->isAllInfoReady()) {
-		co_await self->waitAllInfoReady();
-	}
-
-	for (auto it = self->backups.begin(); it != self->backups.end();) {
+static std::vector<MutationLogBackup> snapshotMutationLogBackups(std::map<UID, BackupData::PerBackupInfo>& backups,
+                                                                 UID workerId,
+                                                                 Version workerStartVersion,
+                                                                 Version savedVersion,
+                                                                 Optional<Version> firstMessageVersion,
+                                                                 Version popVersion) {
+	std::vector<MutationLogBackup> snapshot;
+	for (auto it = backups.begin(); it != backups.end();) {
+		ASSERT(it->second.isReady());
 		if (it->second.stopped || !it->second.container.get().present()) {
-			TraceEvent("BackupWorkerNoContainer", self->myId).detail("BackupId", it->first);
-			it = self->backups.erase(it);
+			TraceEvent("BackupWorkerNoContainer", workerId).detail("BackupId", it->first);
+			it = backups.erase(it);
 			continue;
 		}
-		const int index = logFileFutures.size();
-		activeUids.push_back(it->first);
-		self->insertRanges(keyRangeMap, it->second.ranges.get(), index);
-
-		if (it->second.lastSavedVersion == invalidVersion) {
-			if (it->second.startVersion > self->startVersion && !self->messages.empty()) {
-				// True-up first mutation log's begin version
-				it->second.lastSavedVersion = self->messages[0].getVersion();
-			} else {
-				it->second.lastSavedVersion = std::max({ self->savedVersion, self->startVersion });
-			}
-			TraceEvent("BackupWorkerTrueUp", self->myId).detail("LastSavedVersion", it->second.lastSavedVersion);
+		if (it->second.startVersion > popVersion || it->second.lastSavedVersion > popVersion) {
+			++it;
+			continue;
 		}
-		// The true-up version can be larger than first message version, so keep
-		// the begin versions for later muation filtering.
-		beginVersions.push_back(it->second.lastSavedVersion);
-
-		logFileFutures.push_back(it->second.container.get().get()->writeTaggedLogFile(
-		    it->second.lastSavedVersion, popVersion + 1, blockSize, self->tag.id, self->totalTags));
-		it++;
+		if (it->second.lastSavedVersion == invalidVersion) {
+			if (it->second.startVersion > workerStartVersion && firstMessageVersion.present()) {
+				// True-up first mutation log's begin version
+				it->second.lastSavedVersion = firstMessageVersion.get();
+			} else {
+				it->second.lastSavedVersion = std::max(savedVersion, workerStartVersion);
+			}
+			TraceEvent("BackupWorkerTrueUp", workerId).detail("LastSavedVersion", it->second.lastSavedVersion);
+		}
+		if (it->second.lastSavedVersion <= popVersion) {
+			snapshot.push_back(
+			    { it->first, it->second.lastSavedVersion, it->second.container.get().get(), it->second.ranges.get() });
+		}
+		++it;
 	}
+	return snapshot;
+}
 
-	keyRangeMap.coalesce(allKeys);
+static void advanceMutationLogVersions(std::map<UID, BackupData::PerBackupInfo>& backups,
+                                       const std::vector<CompletedMutationLogFile>& completedFiles,
+                                       Version popVersion) {
+	for (const auto& completed : completedFiles) {
+		auto info = backups.find(completed.backupUid);
+		ASSERT(info != backups.end());
+		info->second.lastSavedVersion = popVersion + 1;
+	}
+}
+
+template <class IsStopped>
+Future<std::vector<CompletedMutationLogFile>> MutationLogBatch::write(std::vector<VersionedMessage>* messages,
+                                                                      Version minKnownCommittedVersion,
+                                                                      Version savedVersion,
+                                                                      IsStopped isStopped) const {
+	ASSERT(numMessages <= messages->size());
+	std::vector<Future<Reference<IBackupFile>>> logFileFutures;
+	std::vector<Reference<IBackupFile>> logFiles;
+	for (const auto& backup : backups) {
+		logFileFutures.push_back(isStopped(backup.uid)
+		                             ? Future<Reference<IBackupFile>>(Reference<IBackupFile>())
+		                             : backup.container->writeTaggedLogFile(
+		                                   backup.beginVersion, popVersion + 1, blockSize, tag.id, totalTags));
+	}
 	co_await waitForAll(logFileFutures);
 
 	std::transform(logFileFutures.begin(),
@@ -765,30 +853,32 @@ Future<Void> saveMutationsToFile(BackupData* self, Version popVersion, int numMs
 	               std::back_inserter(logFiles),
 	               [](const Future<Reference<IBackupFile>>& f) { return f.get(); });
 
-	ASSERT(activeUids.size() == logFiles.size() && beginVersions.size() == logFiles.size());
+	ASSERT(backups.size() == logFiles.size());
 	for (int i = 0; i < logFiles.size(); i++) {
-		TraceEvent("OpenMutationFile", self->myId)
-		    .detail("BackupID", activeUids[i])
-		    .detail("TagId", self->tag.id)
-		    .detail("File", logFiles[i]->getFileName());
+		if (logFiles[i].isValid()) {
+			TraceEvent("OpenMutationFile", workerId)
+			    .detail("BackupID", backups[i].uid)
+			    .detail("TagId", tag.id)
+			    .detail("File", logFiles[i]->getFileName());
+		}
 	}
 
-	blockEnds = std::vector<int64_t>(logFiles.size(), 0);
-	for (idx = 0; idx < numMsg; idx++) {
-		auto& message = self->messages[idx];
+	std::vector<int64_t> blockEnds(logFiles.size(), 0);
+	for (int idx = 0; idx < numMessages; idx++) {
+		auto& message = (*messages)[idx];
 		MutationRef m;
 		if (!message.isCandidateBackupMessage(&m)) {
 			continue;
 		}
 
-		DEBUG_MUTATION("addMutation", message.version.version, m, self->myId)
-		    .detail("KCV", self->minKnownCommittedVersion)
-		    .detail("SavedVersion", self->savedVersion);
+		DEBUG_MUTATION("addMutation", message.version.version, m, workerId)
+		    .detail("KCV", minKnownCommittedVersion)
+		    .detail("SavedVersion", savedVersion);
 
 		std::vector<Future<Void>> adds;
 		if (m.type != MutationRef::Type::ClearRange) {
 			for (int index : keyRangeMap[m.param1]) {
-				if (message.getVersion() >= beginVersions[index]) {
+				if (logFiles[index].isValid() && message.getVersion() >= backups[index].beginVersion) {
 					adds.push_back(
 					    addMutation(logFiles[index], message, message.message, &blockEnds[index], blockSize));
 				}
@@ -796,6 +886,7 @@ Future<Void> saveMutationsToFile(BackupData* self, Version popVersion, int numMs
 		} else {
 			KeyRangeRef mutationRange(m.param1, m.param2);
 			KeyRangeRef intersectionRange;
+			adds.resize(logFiles.size(), Void());
 
 			// Find intersection ranges and create mutations for sub-ranges
 			for (auto range : keyRangeMap.intersectingRanges(mutationRange)) {
@@ -804,37 +895,115 @@ Future<Void> saveMutationsToFile(BackupData* self, Version popVersion, int numMs
 				MutationRef subm(MutationRef::Type::ClearRange, intersectionRange.begin, intersectionRange.end);
 				BinaryWriter wr(AssumeVersion(g_network->protocolVersion()));
 				wr << subm;
-				mutations.push_back(wr.toValue());
+				Standalone<StringRef> mutation = wr.toValue();
 				for (int index : range.value()) {
-					if (message.getVersion() >= beginVersions[index]) {
-						adds.push_back(
-						    addMutation(logFiles[index], message, mutations.back(), &blockEnds[index], blockSize));
+					if (logFiles[index].isValid() && message.getVersion() >= backups[index].beginVersion) {
+						// A file permits only one outstanding append. Chain its
+						// sub-ranges so I/O timing cannot reorder the encoded bytes.
+						adds[index] = addClearMutationAfter(
+						    adds[index], logFiles[index], message, mutation, &blockEnds[index], blockSize);
 					}
 				}
 			}
 		}
 		co_await waitForAll(adds);
-		mutations.clear();
 	}
 
 	std::vector<Future<Void>> finished;
-	std::transform(logFiles.begin(), logFiles.end(), std::back_inserter(finished), [](const Reference<IBackupFile>& f) {
-		return f->finish();
-	});
+	for (const auto& file : logFiles) {
+		if (file.isValid()) {
+			finished.push_back(file->finish());
+		}
+	}
 
 	co_await waitForAll(finished);
 
-	for (const auto& file : logFiles) {
-		TraceEvent("CloseMutationFile", self->myId)
+	std::vector<CompletedMutationLogFile> completedFiles;
+	for (int i = 0; i < logFiles.size(); i++) {
+		const auto& file = logFiles[i];
+		if (!file.isValid()) {
+			continue;
+		}
+		TraceEvent("CloseMutationFile", workerId)
 		    .detail("FileSize", file->size())
-		    .detail("TagId", self->tag.id)
+		    .detail("TagId", tag.id)
 		    .detail("File", file->getFileName());
+		completedFiles.push_back({ backups[i].uid, file });
 	}
-	for (const UID& uid : activeUids) {
-		self->backups[uid].lastSavedVersion = popVersion + 1;
-	}
+	co_return completedFiles;
+}
 
-	co_await updateLogBytesWritten(self, activeUids, logFiles);
+Future<Void> saveMutationsToFile(BackupData* self, Version popVersion, int numMsg) {
+	ASSERT(self->backupEpoch == self->recruitedEpoch || self->endVersion.present());
+	bool startedBatch = false;
+	while (true) {
+		// A newly observed backup can have an earlier start version. Finish any
+		// such recipient before the caller discards this fixed message prefix.
+		while (!self->isAllInfoReady()) {
+			co_await self->waitAllInfoReady();
+		}
+		auto backups = snapshotMutationLogBackups(
+		    self->backups,
+		    self->myId,
+		    self->startVersion,
+		    self->savedVersion,
+		    self->messages.empty() ? Optional<Version>() : Optional<Version>(self->messages.front().getVersion()),
+		    popVersion);
+		if (backups.empty()) {
+			co_return;
+		}
+		if (startedBatch && self->stopped) {
+			// An in-flight drain may finish after displacement, but additional
+			// recipients must be replayed before global progress can advance.
+			throw worker_removed();
+		}
+		startedBatch = true;
+		MutationLogBatch batch(self->myId,
+		                       self->tag,
+		                       self->totalTags,
+		                       popVersion,
+		                       numMsg,
+		                       SERVER_KNOBS->BACKUP_FILE_BLOCK_BYTES,
+		                       std::move(backups));
+		const double maxRetryDelay = std::max(1.0, CLIENT_KNOBS->BACKUP_ERROR_DELAY);
+		double retryDelay = 1.0;
+		int retries = 0;
+		// Current-epoch failures still drive transaction-system recovery. Old-epoch
+		// failures do not, so retain ownership and retry transient destination I/O.
+		std::vector<CompletedMutationLogFile> completedFiles = co_await retryMutationLogUpload(
+		    self->backupEpoch,
+		    self->recruitedEpoch,
+		    &self->stopped,
+		    [&]() {
+			    return batch.write(&self->messages, self->minKnownCommittedVersion, self->savedVersion, [=](UID uid) {
+				    auto info = self->backups.find(uid);
+				    return info == self->backups.end() || info->second.stopped;
+			    });
+		    },
+		    [&](Error err) {
+			    const double waitSeconds = retryDelay;
+			    retryDelay = std::min(retryDelay * 2, maxRetryDelay);
+			    ++retries;
+			    TraceEvent(SevWarn, "BackupWorkerUploadRetry", self->myId)
+			        .suppressFor(10.0)
+			        .errorUnsuppressed(err)
+			        .detail("BackupEpoch", self->backupEpoch)
+			        .detail("Version", popVersion)
+			        .detail("Retries", retries)
+			        .detail("Delay", waitSeconds);
+			    return delay(waitSeconds) || self->doneTrigger.onTrigger();
+		    });
+		if (!completedFiles.empty()) {
+			co_await updateLogBytesWritten(self, completedFiles);
+			advanceMutationLogVersions(self->backups, completedFiles, popVersion);
+		}
+		if (retries > 0) {
+			TraceEvent("BackupWorkerUploadRetryDone", self->myId)
+			    .detail("BackupEpoch", self->backupEpoch)
+			    .detail("Version", popVersion)
+			    .detail("Retries", retries);
+		}
+	}
 }
 
 // Uploads self->messages to cloud storage and updates savedVersion.
@@ -1121,4 +1290,367 @@ Future<Void> backupWorker(BackupInterface interf,
 	if (err.code() != error_code_actor_cancelled && err.code() != error_code_worker_removed) {
 		throw err;
 	}
+}
+
+namespace {
+
+class MutationLogUploadTestFile final : public IBackupFile, ReferenceCounted<MutationLogUploadTestFile> {
+public:
+	enum class Failure { NONE, CREATE, APPEND, FINISH };
+
+	MutationLogUploadTestFile(std::string name,
+	                          Failure failure,
+	                          Future<Void> firstAppend = Void(),
+	                          Future<Void> finishResult = Void())
+	  : IBackupFile(name), failure(failure), firstAppend(firstAppend), finishResult(finishResult) {}
+
+	Future<Void> appendImpl(const void* data, size_t len) override {
+		ASSERT(!finished && !failed);
+		ASSERT(appends == 0 || firstAppend.isReady());
+		contents.append(static_cast<const char*>(data), len);
+		if (++appends == 2 && failure == Failure::APPEND) {
+			failed = true;
+			return io_error();
+		}
+		return appends == 1 ? firstAppend : Future<Void>(Void());
+	}
+
+	Future<Void> finish() override {
+		ASSERT(!finished && !failed);
+		finished = true;
+		if (failure == Failure::FINISH) {
+			failed = true;
+			return io_timeout();
+		}
+		return finishResult;
+	}
+
+	int64_t size() const override { return contents.size(); }
+	void addref() override { ReferenceCounted<MutationLogUploadTestFile>::addref(); }
+	void delref() override { ReferenceCounted<MutationLogUploadTestFile>::delref(); }
+	const std::string& bytes() const { return contents; }
+	bool isFinished() const { return finished; }
+
+private:
+	const Failure failure;
+	const Future<Void> firstAppend;
+	const Future<Void> finishResult;
+	std::string contents;
+	int appends = 0;
+	bool finished = false;
+	bool failed = false;
+};
+
+class MutationLogUploadTestContainer final : public BackupContainerFileSystem,
+                                             ReferenceCounted<MutationLogUploadTestContainer> {
+public:
+	using Failure = MutationLogUploadTestFile::Failure;
+
+	explicit MutationLogUploadTestContainer(std::vector<Failure> failures,
+	                                        Future<Void> firstAppend = Void(),
+	                                        Future<Void> firstFinish = Void())
+	  : failures(std::move(failures)), firstAppend(firstAppend), firstFinish(firstFinish) {}
+
+	Future<Reference<IBackupFile>> writeFile(const std::string& name) override {
+		Failure failure = attempts < failures.size() ? failures[attempts] : Failure::NONE;
+		++attempts;
+		if (failure == Failure::CREATE) {
+			return io_error();
+		}
+		auto file = makeReference<MutationLogUploadTestFile>(name,
+		                                                     failure,
+		                                                     attempts == 1 ? firstAppend : Future<Void>(Void()),
+		                                                     attempts == 1 ? firstFinish : Future<Void>(Void()));
+		files.push_back(file);
+		return Reference<IBackupFile>(file);
+	}
+
+	int getAttempts() const { return attempts; }
+	const std::vector<Reference<MutationLogUploadTestFile>>& getFiles() const { return files; }
+	void addref() override { ReferenceCounted<MutationLogUploadTestContainer>::addref(); }
+	void delref() override { ReferenceCounted<MutationLogUploadTestContainer>::delref(); }
+	Future<Void> create() override { return Void(); }
+	Future<bool> exists() override { return true; }
+	Future<Reference<IAsyncFile>> readFile(const std::string&) override { return operation_failed(); }
+	Future<Void> writeEntireFile(const std::string&, const std::string&) override { return operation_failed(); }
+	Future<Void> deleteFile(const std::string&) override { return operation_failed(); }
+	Future<FilesAndSizesT> listFiles(const std::string&, std::function<bool(std::string const&)>) override {
+		return operation_failed();
+	}
+	Future<Void> deleteContainer(int*) override { return operation_failed(); }
+
+private:
+	const std::vector<Failure> failures;
+	const Future<Void> firstAppend;
+	const Future<Void> firstFinish;
+	int attempts = 0;
+	std::vector<Reference<MutationLogUploadTestFile>> files;
+};
+
+static VersionedMessage testMutationLogMessage(MutationRef mutation) {
+	BinaryWriter wr(AssumeVersion(g_network->protocolVersion()));
+	wr << mutation;
+	Standalone<StringRef> bytes = wr.toValue();
+	return VersionedMessage(LogMessageVersion(100, 7), bytes, {}, bytes.arena());
+}
+
+static BackupData::PerBackupInfo testMutationLogBackup(Reference<IBackupContainer> container,
+                                                       Version startVersion,
+                                                       std::vector<KeyRange> ranges,
+                                                       Version lastSavedVersion = invalidVersion) {
+	BackupData::PerBackupInfo info;
+	info.startVersion = startVersion;
+	info.lastSavedVersion = lastSavedVersion;
+	info.container = Optional<Reference<IBackupContainer>>(container);
+	info.ranges = Optional<std::vector<KeyRange>>(std::move(ranges));
+	return info;
+}
+
+} // namespace
+
+TEST_CASE("/BackupWorker/MutationLogUpload/RetryFreshFiles") {
+	bool stopped = false;
+	int retries = 0;
+	Promise<Void> firstRetry;
+	using Failure = MutationLogUploadTestFile::Failure;
+	auto container = makeReference<MutationLogUploadTestContainer>(
+	    std::vector<Failure>{ Failure::CREATE, Failure::APPEND, Failure::FINISH, Failure::NONE });
+	std::vector<VersionedMessage> messages{ testMutationLogMessage(
+		MutationRef(MutationRef::SetValue, "key"_sr, "v"_sr)) };
+	MutationLogBatch batch(
+	    UID(9, 9), Tag(tagLocalityLogRouter, 0), 1, 100, 1, 1024, { { UID(1, 1), 100, container, {} } });
+	auto result = retryMutationLogUpload(
+	    4,
+	    5,
+	    &stopped,
+	    [&]() { return batch.write(&messages, 100, 99, [](UID) { return false; }); },
+	    [&](Error err) -> Future<Void> {
+		    ASSERT(err.code() == error_code_io_error || err.code() == error_code_io_timeout);
+		    return ++retries == 1 ? firstRetry.getFuture() : Future<Void>(Void());
+	    });
+
+	ASSERT_EQ(container->getAttempts(), 1);
+	ASSERT(!result.isReady());
+	firstRetry.send(Void());
+	std::vector<CompletedMutationLogFile> completed = co_await result;
+	ASSERT_EQ(container->getAttempts(), 4);
+	ASSERT_EQ(retries, 3);
+	const auto& files = container->getFiles();
+	ASSERT_EQ(files.size(), 3);
+	ASSERT_EQ(completed.size(), 1);
+	ASSERT_EQ(completed.front().backupUid, UID(1, 1));
+	ASSERT_EQ(completed.front().file->getFileName(), files.back()->getFileName());
+	ASSERT(files[0]->bytes().size() < files[2]->bytes().size());
+	ASSERT(files[2]->bytes().starts_with(files[0]->bytes()));
+	ASSERT(!files[0]->isFinished());
+	ASSERT(files[1]->isFinished() && files[2]->isFinished());
+	ASSERT_EQ(files[1]->bytes(), files[2]->bytes());
+	ASSERT(files[1]->getFileName() != files[2]->getFileName());
+	for (const auto& file : files) {
+		ASSERT(file->getFileName().find("/log,100,101,") != std::string::npos);
+	}
+}
+
+TEST_CASE("/BackupWorker/MutationLogUpload/ChangingRecipients") {
+	using Failure = MutationLogUploadTestFile::Failure;
+	const UID firstUid(1, 1);
+	const UID stoppedUid(2, 2);
+	const UID lateUid(3, 3);
+	const UID workerId(9, 9);
+	const Tag tag(tagLocalityLogRouter, 0);
+	Promise<Void> appendReady;
+	Promise<Void> retryReady;
+	auto first = makeReference<MutationLogUploadTestContainer>(std::vector<Failure>{}, appendReady.getFuture());
+	auto other = makeReference<MutationLogUploadTestContainer>(std::vector<Failure>{ Failure::FINISH });
+	auto late = makeReference<MutationLogUploadTestContainer>(std::vector<Failure>{});
+	std::map<UID, BackupData::PerBackupInfo> infos;
+	infos.emplace(firstUid, testMutationLogBackup(first, 90, { KeyRangeRef("a"_sr, "z"_sr) }, 100));
+	infos.emplace(stoppedUid, testMutationLogBackup(other, 90, { KeyRangeRef("m"_sr, "n"_sr) }, 100));
+	std::vector<VersionedMessage> messages{ testMutationLogMessage(
+		MutationRef(MutationRef::ClearRange, "a"_sr, "z"_sr)) };
+	auto isStopped = [&](UID uid) {
+		auto info = infos.find(uid);
+		return info == infos.end() || info->second.stopped;
+	};
+	auto snapshot = snapshotMutationLogBackups(infos, workerId, 50, 99, Optional<Version>(100), 100);
+	ASSERT_EQ(snapshot.size(), 2);
+	MutationLogBatch batch(workerId, tag, 1, 100, 1, 1024, std::move(snapshot));
+	bool stopped = false;
+	int retries = 0;
+	auto result = retryMutationLogUpload(
+	    4,
+	    5,
+	    &stopped,
+	    [&]() { return batch.write(&messages, 100, 99, isStopped); },
+	    [&](Error err) {
+		    ASSERT_EQ(err.code(), error_code_io_timeout);
+		    ++retries;
+		    return retryReady.getFuture();
+	    });
+	ASSERT(!result.isReady());
+	ASSERT_EQ(first->getFiles().size(), 1);
+	appendReady.send(Void());
+	ASSERT_EQ(retries, 1);
+	ASSERT(!result.isReady());
+	ASSERT(first->getFiles().front()->isFinished());
+	ASSERT_EQ(infos.at(firstUid).lastSavedVersion, 100);
+
+	infos.at(stoppedUid).stop();
+	infos.emplace(lateUid, testMutationLogBackup(late, 99, { KeyRangeRef("g"_sr, "t"_sr) }));
+	retryReady.send(Void());
+	auto completed = co_await result;
+	ASSERT_EQ(completed.size(), 1);
+	ASSERT_EQ(completed.front().backupUid, firstUid);
+	ASSERT_EQ(first->getAttempts(), 2);
+	ASSERT_EQ(other->getAttempts(), 1);
+	ASSERT_EQ(first->getFiles()[0]->bytes(), first->getFiles()[1]->bytes());
+	advanceMutationLogVersions(infos, completed, 100);
+
+	// A stopped backup's boundaries must still split the first backup's retry.
+	auto unsplit = makeReference<MutationLogUploadTestFile>("unsplit", Failure::NONE);
+	int64_t blockEnd = 0;
+	co_await addMutation(unsplit, messages.front(), messages.front().message, &blockEnd, 1024);
+	co_await unsplit->finish();
+	ASSERT(first->getFiles()[0]->size() > unsplit->size());
+
+	// The late-published job still needs this retained old-epoch message.
+	auto pending = snapshotMutationLogBackups(infos, workerId, 50, 99, Optional<Version>(100), 100);
+	ASSERT_EQ(pending.size(), 1);
+	ASSERT_EQ(pending.front().uid, lateUid);
+	ASSERT_EQ(pending.front().beginVersion, 100);
+	MutationLogBatch lateBatch(workerId, tag, 1, 100, 1, 1024, std::move(pending));
+	auto lateCompleted = co_await lateBatch.write(&messages, 100, 99, isStopped);
+	advanceMutationLogVersions(infos, lateCompleted, 100);
+	ASSERT(snapshotMutationLogBackups(infos, workerId, 50, 99, Optional<Version>(100), 100).empty());
+	ASSERT_EQ(late->getFiles().size(), 1);
+	auto expected = makeReference<MutationLogUploadTestFile>("expected", Failure::NONE);
+	auto clipped = testMutationLogMessage(MutationRef(MutationRef::ClearRange, "g"_sr, "t"_sr));
+	blockEnd = 0;
+	co_await addMutation(expected, clipped, clipped.message, &blockEnd, 1024);
+	co_await expected->finish();
+	ASSERT_EQ(late->getFiles().front()->bytes(), expected->bytes());
+}
+
+TEST_CASE("/BackupWorker/MutationLogUpload/PreserveFailurePolicy") {
+	for (Error error :
+	     { io_error(), io_timeout(), actor_cancelled(), worker_removed(), broken_promise(), http_request_failed() }) {
+		for (bool oldEpoch : { false, true }) {
+			for (bool stopped : { false, true }) {
+				const bool shouldRetry = oldEpoch && !stopped &&
+				                         (error.code() == error_code_io_error || error.code() == error_code_io_timeout);
+				int attempts = 0;
+				int retries = 0;
+				auto result = retryMutationLogUpload(
+				    oldEpoch ? 4 : 5,
+				    5,
+				    &stopped,
+				    [&]() -> Future<std::vector<CompletedMutationLogFile>> {
+					    if (++attempts == 1) {
+						    return error;
+					    }
+					    return std::vector<CompletedMutationLogFile>();
+				    },
+				    [&](Error err) -> Future<Void> {
+					    ASSERT_EQ(err.code(), error.code());
+					    ++retries;
+					    return Void();
+				    });
+				ASSERT(result.isReady());
+				ASSERT_EQ(result.isError(), !shouldRetry);
+				ASSERT_EQ(attempts, shouldRetry ? 2 : 1);
+				ASSERT_EQ(retries, shouldRetry ? 1 : 0);
+				if (result.isError()) {
+					ASSERT_EQ(result.getError().code(), error.code());
+				}
+			}
+		}
+	}
+	bool stopped = false;
+	int attempts = 0;
+	auto longOutage = retryMutationLogUpload(
+	    4,
+	    5,
+	    &stopped,
+	    [&]() -> Future<std::vector<CompletedMutationLogFile>> {
+		    if (++attempts <= 32) {
+			    return io_error();
+		    }
+		    return std::vector<CompletedMutationLogFile>();
+	    },
+	    [](Error) -> Future<Void> { return Void(); });
+	ASSERT(longOutage.isReady() && !longOutage.isError());
+	ASSERT_EQ(attempts, 33);
+	return Void();
+}
+
+TEST_CASE("/BackupWorker/MutationLogUpload/StopDuringRetry") {
+	for (bool cancel : { false, true }) {
+		bool stopped = false;
+		int attempts = 0;
+		Promise<Void> retryReady;
+		auto result = retryMutationLogUpload(
+		    4,
+		    5,
+		    &stopped,
+		    [&]() -> Future<std::vector<CompletedMutationLogFile>> {
+			    ++attempts;
+			    return io_timeout();
+		    },
+		    [&](Error) { return retryReady.getFuture(); });
+		ASSERT_EQ(attempts, 1);
+		ASSERT(!result.isReady());
+		if (cancel) {
+			result.cancel();
+		} else {
+			stopped = true;
+		}
+		retryReady.send(Void());
+		ASSERT(result.isReady() && result.isError());
+		ASSERT_EQ(result.getError().code(), cancel ? error_code_actor_cancelled : error_code_io_timeout);
+		ASSERT_EQ(attempts, 1);
+	}
+	return Void();
+}
+
+TEST_CASE("/BackupWorker/MutationLogUpload/StopDuringWrite") {
+	using Failure = MutationLogUploadTestFile::Failure;
+	for (int outcome = 0; outcome < 3; ++outcome) {
+		bool stopped = false;
+		int retries = 0;
+		Promise<Void> finishReady;
+		auto container = makeReference<MutationLogUploadTestContainer>(
+		    std::vector<Failure>{}, Future<Void>(Void()), finishReady.getFuture());
+		std::vector<VersionedMessage> messages{ testMutationLogMessage(
+			MutationRef(MutationRef::SetValue, "key"_sr, "v"_sr)) };
+		MutationLogBatch batch(
+		    UID(9, 9), Tag(tagLocalityLogRouter, 0), 1, 100, 1, 1024, { { UID(1, 1), 100, container, {} } });
+		auto result = retryMutationLogUpload(
+		    4,
+		    5,
+		    &stopped,
+		    [&]() { return batch.write(&messages, 100, 99, [](UID) { return false; }); },
+		    [&](Error) -> Future<Void> {
+			    ++retries;
+			    return Void();
+		    });
+		ASSERT(!result.isReady());
+		ASSERT(container->getFiles().front()->isFinished());
+		stopped = true;
+		if (outcome == 2) {
+			result.cancel();
+		}
+		if (outcome == 1) {
+			finishReady.sendError(io_timeout());
+		} else {
+			finishReady.send(Void());
+		}
+		ASSERT(result.isReady());
+		ASSERT_EQ(result.isError(), outcome != 0);
+		if (outcome != 0) {
+			ASSERT_EQ(result.getError().code(), outcome == 1 ? error_code_io_timeout : error_code_actor_cancelled);
+		}
+		ASSERT_EQ(container->getAttempts(), 1);
+		ASSERT_EQ(retries, 0);
+	}
+	return Void();
 }


### PR DESCRIPTION
## Summary

An I/O error while writing partitioned backup logs can terminate an old-epoch backup worker. Those failures deliberately do not restart transaction recovery, so the old log generation can remain retained and backup progress can stop indefinitely.

Retry transient file and blob-store request failures for old-epoch mutation-log uploads while retaining the same role and message prefix. Each attempt opens fresh files. Freeze the recipient ranges and encoding boundaries so an ambiguous finish produces byte-identical duplicates, and handle newly observed overlapping backups before discarding messages or advancing durable progress. Preserve current-epoch recovery, cancellation, and displacement behavior.

Add focused regression coverage for file creation, partial append, ambiguous finish, changing recipients, and stopping during an upload or retry.

## Validation

- `fdbserver_backupworker_test`: 8/8 in native mode and 8/8 in simulation mode after test consolidation.

Earlier validation of the unchanged production logic:
- `BackupCorrectnessPartitioned.toml` with buggify and fault injection enabled: passed; backup and restore completed.
- A matched control with only old-epoch retries disabled reproduces the stalled backup; enabling retries completes the same test.
- The workload and fault settings are unchanged.

This change covers transient destination I/O failures. It does not add replacement of an already-terminated process or recovery from a permanently hung destination.
