### PR TITLE
bindings/python: update pycodestyle test

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -66,19 +66,21 @@ set(out_files "${out_files};${options_file};${apiversion_file}")
 
 # Create Python package in tar.gz format
 configure_file(${CMAKE_SOURCE_DIR}/LICENSE ${CMAKE_CURRENT_BINARY_DIR}/LICENSE COPYONLY)
-find_program(pycodestyle pycodestyle)
-if (pycodestyle)
-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/check_py_code_style
-    COMMAND ${pycodestyle} bindings/python --config=${CMAKE_CURRENT_SOURCE_DIR}/pycodestyle.cfg &&
-            ${CMAKE_COMMAND} -E ${CMAKE_CURRENT_BINARY_DIR}/check_py_code_style
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    DEPENDS ${out_files}
-    COMMENT "Check python code style")
-  add_custom_target(fdb_python_check DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/check_py_code_style)
-else()
-  add_custom_target(fdb_python_check COMMAND ${CMAKE_COMMAND} -E echo "Skipped Python style check! Missing: pycodestyle")
-endif()
 
+add_test(
+  NAME              python_pycodestyle
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  BUILD_DEPENDS     ${out_files}
+  COMMAND sh -c "
+    if ! which pycodestyle >/dev/null; then
+      exit 66
+    fi
+    echo PWD=$PWD
+    echo CFG=${CMAKE_CURRENT_SOURCE_DIR}/pycodestyle.cfg
+    pycodestyle . --config=${CMAKE_CURRENT_SOURCE_DIR}/pycodestyle.cfg
+    "
+)
+set_tests_properties(python_pycodestyle PROPERTIES SKIP_RETURN_CODE 66)
 
 set(setup_file_name foundationdb-${FDB_PY_VERSION}.tar.gz)
 set(wheel_file_name foundationdb-${FDB_PY_VERSION}-py3-none-any.whl)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -74,8 +74,6 @@ add_test(
     if ! which pycodestyle >/dev/null; then
       exit 66
     fi
-    echo PWD=$PWD
-    echo CFG=${CMAKE_CURRENT_SOURCE_DIR}/pycodestyle.cfg
     pycodestyle . --config=${CMAKE_CURRENT_SOURCE_DIR}/pycodestyle.cfg
     "
 )

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -70,7 +70,6 @@ configure_file(${CMAKE_SOURCE_DIR}/LICENSE ${CMAKE_CURRENT_BINARY_DIR}/LICENSE C
 add_test(
   NAME              python_pycodestyle
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  BUILD_DEPENDS     ${out_files}
   COMMAND sh -c "
     if ! which pycodestyle >/dev/null; then
       exit 66

--- a/bindings/python/fdb/__init__.py
+++ b/bindings/python/fdb/__init__.py
@@ -30,7 +30,6 @@ __version__ = fdb.apiversion.FDB_VERSION
 LATEST_API_VERSION = fdb.apiversion.LATEST_API_VERSION
 
 
-
 def open(*args, **kwargs):
     raise RuntimeError("You must call api_version() before using any fdb methods")
 

--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -163,6 +163,7 @@ def add_operation(fname, v):
     setattr(globals()["Database"], fname, f)
     setattr(globals()["Transaction"], fname, f)
 
+
 def fill_operations():
     _dict = getattr(_opts, "MutationType")
 
@@ -1499,7 +1500,8 @@ def read_pth_file():
 
 for pth in [
     lambda: os.path.join(this_dir, capi_name),
-    # lambda: os.path.join(this_dir, "../../lib", capi_name),  # For compatibility with existing unix installation process... should be removed
+    # For compatibility with existing unix installation process... should be removed
+    # lambda: os.path.join(this_dir, "../../lib", capi_name),
     read_pth_file,
 ]:
     p = pth()

--- a/bindings/python/pycodestyle.cfg
+++ b/bindings/python/pycodestyle.cfg
@@ -1,4 +1,10 @@
 [pycodestyle]
-max-line-length = 150
+max-line-length = 130
 exclude = fdboptions.py
-ignore = E266, E402, E711, E712, E721, E722, W503, W504
+ignore = E203, E266, E402, W503, E711, E721
+# E203 whitespace before ':'
+# E266 too many leading '#' for block comment
+# E402 module level import not at top of file
+# E503 line break before binary operator
+# E711 comparison to None should be 'if cond is None:'
+# E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`

--- a/bindings/python/tests/unit_tests.py
+++ b/bindings/python/tests/unit_tests.py
@@ -183,7 +183,8 @@ def test_watches(db):
 @fdb.transactional
 def test_locality(tr):
     tr.options.set_timeout(60 * 1000)
-    tr.options.set_read_system_keys()  # We do this because the last shard (for now, someday the last N shards) is in the /FF/ keyspace
+    # We do this because the last shard (for now, someday the last N shards) is in the /FF/ keyspace
+    tr.options.set_read_system_keys()
 
     # This isn't strictly transactional, thought we expect it to be given the size of our database
     boundary_keys = list(fdb.locality.get_boundary_keys(tr, b"", b"\xff\xff")) + [


### PR DESCRIPTION
It must not have been run in a while, there were 10 or so violations of "E203 whitespace before ':'" and a couple others. So:
 * add E203 to the ignore list
 * reduce max-line-length to 130
 * 2 spots to normalize to 2 blank lines between top-level stuff
 * 2 spots to fix very long comment lines
 * run pycodestyle as a proper ctest

-----------

Tested locally, of course. Before this PR, the test was a target for ninja, not a ctest, but only if pycodestyle was already installed, and it seems like it still wasn't in the default "all" target set? Not only would it find style violations if it ran, it couldn't actually run:

```
$ ninja fdb_python_check
[0/2] Re-checking globbed directories...
[1/2] Check python code style
FAILED: [code=1] bindings/python/check_py_code_style /Users/pierce/scratch/buildfdb/bindings/python/check_py_code_style 
cd /Users/pierce/scratch/okteto-rhel9/foundationdb/bindings/python && /Users/pierce/scratch/venv312/bin/pycodestyle bindings/python --config=/Users/pierce/scratch/okteto-rhel9/foundationdb/bindings/python/pycodestyle.cfg && /opt/homebrew/bin/cmake -E /Users/pierce/scratch/buildfdb/bindings/python/check_py_code_style
bindings/python:1:1: E902 FileNotFoundError: [Errno 2] No such file or directory: 'bindings/python'
ninja: build stopped: subcommand failed.
```

Anyway ... I can add pycodestyle to the base build images, and it will finally run in CI, for the main branch, when _ctest_ is run. I think it will still be skipped by default for the release-7.4 branch? but we may want to backport this to get it running there too.