### PR TITLE
tests: simpler fallible authorization_venv_setup

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -559,17 +559,12 @@ if(WITH_PYTHON)
 
     set(authz_venv_dir ${CMAKE_CURRENT_BINARY_DIR}/authorization_test_venv)
     set(authz_venv_activate ". ${authz_venv_dir}/bin/activate")
-    set(authz_venv_stamp_file ${authz_venv_dir}/venv.ready)
     set(authz_venv_cmd "")
-    string(APPEND authz_venv_cmd "[[ ! -f ${authz_venv_stamp_file} ]] && ")
     string(APPEND authz_venv_cmd "${Python3_EXECUTABLE} -m venv ${authz_venv_dir} ")
     string(APPEND authz_venv_cmd "&& ${authz_venv_activate} ")
-    string(APPEND authz_venv_cmd "&& pip install --upgrade pip ")
     string(APPEND authz_venv_cmd "&& pip install -r ${CMAKE_SOURCE_DIR}/tests/authorization/requirements.txt ")
 	# NOTE: Here we are already in the venv so Python3_EXECUTABLE is not available anymore
     string(APPEND authz_venv_cmd "&& (cd ${CMAKE_BINARY_DIR}/bindings/python && python3 -m pip install .) ")
-    string(APPEND authz_venv_cmd "&& touch ${authz_venv_stamp_file} ")
-    string(APPEND authz_venv_cmd "|| echo 'venv already set up'")
     add_test(
       NAME authorization_venv_setup
       COMMAND bash -c ${authz_venv_cmd}


### PR DESCRIPTION
The "|| echo 'venv already set up'" part was suppressing errors from pip/pypi (e.g. when pypi is under stress and gives 502 responses). All that can be simplified away, it is OK to run venv and pip again on the next ctest run, they work (and skip what is already done). This is already how test_venv_setup works in cmake/AddFdbTest.cmake. Also no need to pip upgrade pip.

-------------------

In the past few days when PyPI was often giving 502 responses to our CI Codebuild VMs, you would sometimes see a few tests fail with "pytest not found" instead of showing the failure in the venv install, because this was suppressing it.

This is not present on the main-branch / 8.x, the tenant authz stuff was all removed.