### PR TITLE
fdbclient: after unlink of per-thread library copy, symlink to original

### DIFF
--- a/bindings/c/test/apitester/TesterOptions.h
+++ b/bindings/c/test/apitester/TesterOptions.h
@@ -56,6 +56,7 @@ public:
 	std::string tlsKeyFile;
 	std::string tlsCaFile;
 	bool retainClientLibCopies = false;
+	bool symlinkClientLibCopies = false;
 };
 
 } // namespace FdbApiTester

--- a/bindings/c/test/apitester/fdb_c_api_tester.cpp
+++ b/bindings/c/test/apitester/fdb_c_api_tester.cpp
@@ -58,6 +58,7 @@ enum TesterOptionId {
 	OPT_TLS_KEY_FILE,
 	OPT_TLS_CA_FILE,
 	OPT_RETAIN_CLIENT_LIB_COPIES,
+	OPT_SYMLINK_CLIENT_LIB_COPIES,
 };
 
 CSimpleOpt::SOption TesterOptionDefs[] = //
@@ -85,6 +86,7 @@ CSimpleOpt::SOption TesterOptionDefs[] = //
 	  { OPT_TLS_KEY_FILE, "--tls-key-file", SO_REQ_SEP },
 	  { OPT_TLS_CA_FILE, "--tls-ca-file", SO_REQ_SEP },
 	  { OPT_RETAIN_CLIENT_LIB_COPIES, "--retain-client-lib-copies", SO_NONE },
+	  { OPT_SYMLINK_CLIENT_LIB_COPIES, "--symlink-client-lib-copies", SO_NONE },
 	  SO_END_OF_OPTIONS };
 
 void printProgramUsage(const char* execName) {
@@ -224,6 +226,9 @@ bool processArg(TesterOptions& options, const CSimpleOpt& args) {
 	case OPT_RETAIN_CLIENT_LIB_COPIES:
 		options.retainClientLibCopies = true;
 		break;
+	case OPT_SYMLINK_CLIENT_LIB_COPIES:
+		options.symlinkClientLibCopies = true;
+		break;
 	}
 	return true;
 }
@@ -323,6 +328,10 @@ void applyNetworkOptions(TesterOptions& options) {
 
 	if (options.retainClientLibCopies) {
 		fdb::network::setOption(FDBNetworkOption::FDB_NET_OPTION_RETAIN_CLIENT_LIBRARY_COPIES);
+	}
+
+	if (options.symlinkClientLibCopies) {
+		fdb::network::setOption(FDBNetworkOption::FDB_NET_OPTION_SYMLINK_CLIENT_LIBRARY_COPIES);
 	}
 
 	for (const auto& knob : options.testSpec.knobs) {

--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -25,7 +25,7 @@
 
 // To regenerate this file, from the top level of a FoundationDB repository
 // checkout, run:
-// $ go run bindings/go/src/_util/translate_fdb_options.go < fdbclient/vexillographer/fdb.options > bindings/go/src/fdb/generated.go
+// $ go run bindings/go/src/internal/translate_fdb_options.go < fdbclient/vexillographer/fdb.options > bindings/go/src/fdb/generated.go
 
 package fdb
 

--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -341,6 +341,11 @@ func (o NetworkOptions) SetClientTmpDir(param string) error {
 	return o.setOpt(91, []byte(param))
 }
 
+// After unlinking client library copies that are created for enabling multi-threading, replace with symlinks for debuggers/profilers.
+func (o NetworkOptions) SetSymlinkClientLibraryCopies() error {
+	return o.setOpt(92, nil)
+}
+
 // Set the size of the client location cache. Raising this value can boost performance in very large databases where clients access data in a near-random pattern. Defaults to 100000.
 //
 // Parameter: Max location cache entries

--- a/bindings/go/src/internal/translate_fdb_options.go
+++ b/bindings/go/src/internal/translate_fdb_options.go
@@ -204,7 +204,7 @@ func main() {
 
 // To regenerate this file, from the top level of a FoundationDB repository
 // checkout, run:
-// $ go run bindings/go/src/_util/translate_fdb_options.go < fdbclient/vexillographer/fdb.options > bindings/go/src/fdb/generated.go
+// $ go run bindings/go/src/internal/translate_fdb_options.go < fdbclient/vexillographer/fdb.options > bindings/go/src/fdb/generated.go
 
 package fdb
 

--- a/fdbclient/MultiVersionTransaction.cpp
+++ b/fdbclient/MultiVersionTransaction.cpp
@@ -709,8 +709,8 @@ void loadClientFunction(T* fp, void* lib, std::string libPath, const char* funct
 	}
 }
 
-DLApi::DLApi(std::string fdbCPath, std::string origPath, bool unlinkOnLoad)
-  : fdbCPath(fdbCPath), origPath(origPath), unlinkOnLoad(unlinkOnLoad), api(new FdbCApi()), networkSetup(false) {}
+DLApi::DLApi(std::string fdbCPath, std::string origPath, bool unlinkOnLoad, bool symlinkOnLoad)
+  : fdbCPath(fdbCPath), origPath(origPath), unlinkOnLoad(unlinkOnLoad), symlinkOnLoad(symlinkOnLoad), api(new FdbCApi()), networkSetup(false) {}
 
 // Loads client API functions (definitions are in FdbCApi struct)
 void DLApi::init() {
@@ -723,17 +723,19 @@ void DLApi::init() {
 		TraceEvent(SevError, "ErrorLoadingExternalClientLibrary").detail("LibraryPath", fdbCPath);
 		throw platform_error();
 	}
-	if (unlinkOnLoad) {
+	if (unlinkOnLoad || symlinkOnLoad) {
 		int err = unlink(fdbCPath.c_str());
 		if (err) {
 			TraceEvent(SevError, "ErrorUnlinkingTempClientLibraryFile").GetLastError().detail("LibraryPath", fdbCPath);
 			throw platform_error();
 		}
-		// Add symlink so debugger/profiler can find the lib file for symbols and build-id.
-		// Will not work on Windows, but Windows does not support unlinkOnLoad (nor multi-threaded fdb client).
-		err = symlink(origPath.c_str(), fdbCPath.c_str());
-		if (err) {
-			TraceEvent(SevWarn, "ErrorSymlinkingTempClientLibraryFile").GetLastError().detail("LibraryPath", fdbCPath);
+		if (symlinkOnLoad) {
+			// Add symlink so debugger/profiler can find the lib file for symbols and build-id.
+			// Will not work on Windows, but Windows does not support unlinkOnLoad nor multi-threaded client.
+			err = symlink(origPath.c_str(), fdbCPath.c_str());
+			if (err) {
+				TraceEvent(SevWarn, "ErrorSymlinkingTempClientLibraryFile").GetLastError().detail("LibraryPath", fdbCPath);
+			}
 		}
 	}
 
@@ -2445,6 +2447,9 @@ void MultiVersionApi::setNetworkOptionInternal(FDBNetworkOptions::Option option,
 	} else if (option == FDBNetworkOptions::RETAIN_CLIENT_LIBRARY_COPIES) {
 		validateOption(value, CanBePresent::False, CanBeAbsent::True);
 		retainClientLibCopies = true;
+	} else if (option == FDBNetworkOptions::SYMLINK_CLIENT_LIBRARY_COPIES) {
+		validateOption(value, CanBePresent::False, CanBeAbsent::True);
+		symlinkClientLibCopies = true;
 	} else {
 		forwardOption = true;
 	}
@@ -2519,8 +2524,9 @@ void MultiVersionApi::setupNetwork() {
 					auto libCopies = copyExternalLibraryPerThread(path);
 					for (int idx = 0; idx < libCopies.size(); ++idx) {
 						bool unlinkOnLoad = libCopies[idx].second && !retainClientLibCopies;
+						bool symlinkOnLoad = libCopies[idx].second && symlinkClientLibCopies;
 						externalClients[filename].push_back(makeReference<ClientInfo>(
-						    new DLApi(libCopies[idx].first, path, unlinkOnLoad), path, useFutureVersion, idx));
+						    new DLApi(libCopies[idx].first, path, unlinkOnLoad, symlinkOnLoad), path, useFutureVersion, idx));
 					}
 				}
 			}
@@ -2918,8 +2924,8 @@ void MultiVersionApi::loadEnvironmentVariableNetworkOptions() {
 MultiVersionApi::MultiVersionApi()
   : callbackOnMainThread(true), localClientDisabled(false), networkStartSetup(false), networkSetup(false),
     disableBypass(false), bypassMultiClientApi(false), externalClient(false), ignoreExternalClientFailures(false),
-    failIncompatibleClient(false), retainClientLibCopies(false), apiVersion(0), threadCount(0), tmpDir("/tmp"),
-    traceShareBaseNameAmongThreads(false), envOptionsLoaded(false) {}
+    failIncompatibleClient(false), retainClientLibCopies(false), symlinkClientLibCopies(false), apiVersion(0),
+    threadCount(0), tmpDir("/tmp"), traceShareBaseNameAmongThreads(false), envOptionsLoaded(false) {}
 
 MultiVersionApi* MultiVersionApi::api = new MultiVersionApi();
 

--- a/fdbclient/MultiVersionTransaction.cpp
+++ b/fdbclient/MultiVersionTransaction.cpp
@@ -2519,11 +2519,8 @@ void MultiVersionApi::setupNetwork() {
 					auto libCopies = copyExternalLibraryPerThread(path);
 					for (int idx = 0; idx < libCopies.size(); ++idx) {
 						bool unlinkOnLoad = libCopies[idx].second && !retainClientLibCopies;
-						externalClients[filename].push_back(
-						    makeReference<ClientInfo>(new DLApi(libCopies[idx].first, path, unlinkOnLoad),
-						                              path,
-						                              useFutureVersion,
-						                              idx));
+						externalClients[filename].push_back(makeReference<ClientInfo>(
+						    new DLApi(libCopies[idx].first, path, unlinkOnLoad), path, useFutureVersion, idx));
 					}
 				}
 			}

--- a/fdbclient/MultiVersionTransaction.cpp
+++ b/fdbclient/MultiVersionTransaction.cpp
@@ -710,7 +710,8 @@ void loadClientFunction(T* fp, void* lib, std::string libPath, const char* funct
 }
 
 DLApi::DLApi(std::string fdbCPath, std::string origPath, bool unlinkOnLoad, bool symlinkOnLoad)
-  : fdbCPath(fdbCPath), origPath(origPath), unlinkOnLoad(unlinkOnLoad), symlinkOnLoad(symlinkOnLoad), api(new FdbCApi()), networkSetup(false) {}
+  : fdbCPath(fdbCPath), origPath(origPath), unlinkOnLoad(unlinkOnLoad), symlinkOnLoad(symlinkOnLoad),
+    api(new FdbCApi()), networkSetup(false) {}
 
 // Loads client API functions (definitions are in FdbCApi struct)
 void DLApi::init() {
@@ -734,7 +735,9 @@ void DLApi::init() {
 			// Will not work on Windows, but Windows does not support unlinkOnLoad nor multi-threaded client.
 			err = symlink(origPath.c_str(), fdbCPath.c_str());
 			if (err) {
-				TraceEvent(SevWarn, "ErrorSymlinkingTempClientLibraryFile").GetLastError().detail("LibraryPath", fdbCPath);
+				TraceEvent(SevWarn, "ErrorSymlinkingTempClientLibraryFile")
+				    .GetLastError()
+				    .detail("LibraryPath", fdbCPath);
 			}
 		}
 	}
@@ -2526,7 +2529,10 @@ void MultiVersionApi::setupNetwork() {
 						bool unlinkOnLoad = libCopies[idx].second && !retainClientLibCopies;
 						bool symlinkOnLoad = libCopies[idx].second && symlinkClientLibCopies;
 						externalClients[filename].push_back(makeReference<ClientInfo>(
-						    new DLApi(libCopies[idx].first, path, unlinkOnLoad, symlinkOnLoad), path, useFutureVersion, idx));
+						    new DLApi(libCopies[idx].first, path, unlinkOnLoad, symlinkOnLoad),
+						    path,
+						    useFutureVersion,
+						    idx));
 					}
 				}
 			}

--- a/fdbclient/MultiVersionTransaction.cpp
+++ b/fdbclient/MultiVersionTransaction.cpp
@@ -709,8 +709,8 @@ void loadClientFunction(T* fp, void* lib, std::string libPath, const char* funct
 	}
 }
 
-DLApi::DLApi(std::string fdbCPath, bool unlinkOnLoad)
-  : fdbCPath(fdbCPath), api(new FdbCApi()), unlinkOnLoad(unlinkOnLoad), networkSetup(false) {}
+DLApi::DLApi(std::string fdbCPath, std::string origPath, bool unlinkOnLoad)
+  : fdbCPath(fdbCPath), origPath(origPath), unlinkOnLoad(unlinkOnLoad), api(new FdbCApi()), networkSetup(false) {}
 
 // Loads client API functions (definitions are in FdbCApi struct)
 void DLApi::init() {
@@ -728,6 +728,12 @@ void DLApi::init() {
 		if (err) {
 			TraceEvent(SevError, "ErrorUnlinkingTempClientLibraryFile").GetLastError().detail("LibraryPath", fdbCPath);
 			throw platform_error();
+		}
+		// Add symlink so debugger/profiler can find the lib file for symbols and build-id.
+		// Will not work on Windows, but Windows does not support unlinkOnLoad (nor multi-threaded fdb client).
+		err = symlink(origPath.c_str(), fdbCPath.c_str());
+		if (err) {
+			TraceEvent(SevWarn, "ErrorSymlinkingTempClientLibraryFile").GetLastError().detail("LibraryPath", fdbCPath);
 		}
 	}
 
@@ -2514,7 +2520,7 @@ void MultiVersionApi::setupNetwork() {
 					for (int idx = 0; idx < libCopies.size(); ++idx) {
 						bool unlinkOnLoad = libCopies[idx].second && !retainClientLibCopies;
 						externalClients[filename].push_back(
-						    makeReference<ClientInfo>(new DLApi(libCopies[idx].first, unlinkOnLoad /*unlink on load*/),
+						    makeReference<ClientInfo>(new DLApi(libCopies[idx].first, path, unlinkOnLoad),
 						                              path,
 						                              useFutureVersion,
 						                              idx));

--- a/fdbclient/include/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/include/fdbclient/MultiVersionTransaction.h
@@ -456,7 +456,7 @@ private:
 // The DL prefix stands for "dynamic library".
 class DLApi : public IClientApi {
 public:
-	explicit DLApi(std::string fdbCPath, bool unlinkOnLoad = false);
+	explicit DLApi(std::string fdbCPath, std::string origPath, bool unlinkOnLoad = false);
 
 	void selectApiVersion(int apiVersion) override;
 	const char* getClientVersion() override;
@@ -476,6 +476,7 @@ public:
 
 private:
 	const std::string fdbCPath;
+	const std::string origPath; // for symlink after unlinkOnLoad
 	const Reference<FdbCApi> api;
 	const bool unlinkOnLoad;
 	int headerVersion;

--- a/fdbclient/include/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/include/fdbclient/MultiVersionTransaction.h
@@ -456,7 +456,7 @@ private:
 // The DL prefix stands for "dynamic library".
 class DLApi : public IClientApi {
 public:
-	explicit DLApi(std::string fdbCPath, std::string origPath, bool unlinkOnLoad = false);
+	explicit DLApi(std::string fdbCPath, std::string origPath, bool unlinkOnLoad = false, bool symlinkOnLoad = false);
 
 	void selectApiVersion(int apiVersion) override;
 	const char* getClientVersion() override;
@@ -476,9 +476,10 @@ public:
 
 private:
 	const std::string fdbCPath;
-	const std::string origPath; // for symlink after unlinkOnLoad
+	const std::string origPath; // for symlinkOnLoad
 	const Reference<FdbCApi> api;
 	const bool unlinkOnLoad;
+	const bool symlinkOnLoad;
 	int headerVersion;
 	bool networkSetup;
 
@@ -920,6 +921,7 @@ private:
 	bool ignoreExternalClientFailures;
 	bool failIncompatibleClient;
 	bool retainClientLibCopies;
+	bool symlinkClientLibCopies;
 	ApiVersion apiVersion;
 
 	int nextThread = 0;

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -157,6 +157,8 @@ description is not currently required but encouraged.
     <Option name="client_tmp_dir" code="91"
             paramType="String" paramDescription="Client directory for temporary files. "
             description="Sets the directory for storing temporary files created by FDB client, such as temporary copies of client libraries. Defaults to /tmp" />
+    <Option name="symlink_client_library_copies" code="92"
+            description="After unlinking client library copies that are created for enabling multi-threading, replace with symlinks for debuggers/profilers." />
     <Option name="supported_client_versions" code="1000"
             paramType="String" paramDescription="[release version],[source version],[protocol version];..."
             description="This option is set automatically to communicate the list of supported clients to the active client."


### PR DESCRIPTION
This is an attempt to enable profilers (and debuggers etc) to find the dynamic library file for symbols and "buildid" (used to lookup debug symbols if they are separate).

There is a lot to explain about these behaviors in libfdb_c:

It seems the library must have global state that should not be shared between threads, so there must be separate loaded copies that get their own global data/bss areas in the process memory space. Real file copies need to be used instead of symlinks in the first place, otherwise the OS kernel will treat it as the already-loaded dynamic library.

The `unlinkOnLoad` is to prevent many copies of library file accumulating and filling the storage volume, if the process is being restarted periodically. After the name in the filesystem is unlinked, the loaded library reference in the running process keeps the inode and filedata alive in the filesystem, until the process ends and the OS kernel cleans up. There is no place in fdbclient or libfdb_c where the "external" loaded dynamic library is explicitly unloaded, there are no destructors for these client objects. Anyway, if the running process was crashing and restarting, graceful cleanup would not run, so the unlinkOnLoad trick makes sense to let the OS kernel clean up.

There is already a "network" option to keep  the library file copies. This new symlink behavior should be a much lighter-weight alternative that can be left on everywhere.

-------------------

I haven't really tested this, I'll need some help to figure out a semi-realistic setup.

I assume that another copy of the original library path, in each DLApi class (in each thread), is no problem. But it is slightly awkward, making this kinda awkward logic a tiny bit worse. I tried a refactor, ran into a bit of awkwardness, maybe I should try again...