### PR TITLE
Convert CoroFlow actors to standard C++ coroutines

### DIFF
--- a/fdbserver/bench/CMakeLists.txt
+++ b/fdbserver/bench/CMakeLists.txt
@@ -26,3 +26,5 @@ target_include_directories(
           "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 target_link_libraries(fdbserver_bench PRIVATE Threads::Threads fdb_google_benchmark flow)
+
+add_subdirectory(coroflow)

--- a/fdbserver/bench/coroflow/BenchCoroFlow.cpp
+++ b/fdbserver/bench/coroflow/BenchCoroFlow.cpp
@@ -128,6 +128,79 @@ Future<Void> runStartStopBenchmark(benchmark::State* state) {
 	state->SetItemsProcessed(state->iterations());
 }
 
+Future<Void> runZeroWorkerCreateDropBenchmark(benchmark::State* state) {
+	while (state->KeepRunning()) {
+		Reference<IThreadPool> pool = CoroThreadPool::createThreadPool();
+		benchmark::DoNotOptimize(pool.getPtr());
+		pool.clear();
+	}
+	state->SetItemsProcessed(state->iterations());
+	return Void();
+}
+
+// No owning pool reference may escape setup into the final-reference-drop measurement.
+Future<Void> startBenchWorker(IThreadPool* pool) {
+	auto* receiver = new BenchReceiver();
+	Future<Void> started = receiver->onStarted();
+	pool->addThread(receiver);
+	co_await started;
+}
+
+enum class LifecyclePhase { ExplicitStop, FinalReferenceDrop };
+
+template <LifecyclePhase phase>
+Future<Void> runLifecyclePhaseBenchmark(benchmark::State* state) {
+	while (state->KeepRunning()) {
+		state->PauseTiming();
+		Reference<IThreadPool> pool;
+		Optional<Error> err;
+		bool stopped = false;
+		bool timing = false;
+		try {
+			pool = CoroThreadPool::createThreadPool();
+			co_await startBenchWorker(pool.getPtr());
+			if constexpr (phase == LifecyclePhase::FinalReferenceDrop) {
+				co_await pool->stop();
+				stopped = true;
+			}
+
+			state->ResumeTiming();
+			timing = true;
+			if constexpr (phase == LifecyclePhase::ExplicitStop) {
+				co_await pool->stop();
+				stopped = true;
+			} else {
+				pool.clear();
+			}
+			state->PauseTiming();
+			timing = false;
+		} catch (Error& e) {
+			err = e;
+		} catch (...) {
+			err = unknown_error();
+		}
+
+		if (timing) {
+			state->PauseTiming();
+		}
+		if (pool.isValid() && !stopped) {
+			try {
+				co_await pool->stop();
+			} catch (Error& e) {
+				if (!err.present()) {
+					err = e;
+				}
+			}
+		}
+		pool.clear();
+		state->ResumeTiming();
+		if (err.present()) {
+			throw err.get();
+		}
+	}
+	state->SetItemsProcessed(state->iterations());
+}
+
 template <WaitKind kind>
 void benchWait(benchmark::State& state) {
 	onMainThread([&state] { return runWaitBenchmark<kind>(&state); }).getBlocking();
@@ -137,8 +210,24 @@ void benchStartStop(benchmark::State& state) {
 	onMainThread([&state] { return runStartStopBenchmark(&state); }).getBlocking();
 }
 
+void benchZeroWorkerCreateDrop(benchmark::State& state) {
+	onMainThread([&state] { return runZeroWorkerCreateDropBenchmark(&state); }).getBlocking();
+}
+
+template <LifecyclePhase phase>
+void benchLifecyclePhase(benchmark::State& state) {
+	onMainThread([&state] { return runLifecyclePhaseBenchmark<phase>(&state); }).getBlocking();
+}
+
 BENCHMARK_TEMPLATE(benchWait, WaitKind::Ready)->Name("coroflow_wait_ready")->UseRealTime();
 BENCHMARK_TEMPLATE(benchWait, WaitKind::Suspended)->Name("coroflow_wait_suspended")->UseRealTime();
 BENCHMARK(benchStartStop)->Name("coroflow_start_stop")->UseRealTime();
+BENCHMARK(benchZeroWorkerCreateDrop)->Name("coroflow_zero_worker_create_drop")->UseRealTime();
+BENCHMARK_TEMPLATE(benchLifecyclePhase, LifecyclePhase::ExplicitStop)
+    ->Name("coroflow_explicit_stop_only")
+    ->UseRealTime();
+BENCHMARK_TEMPLATE(benchLifecyclePhase, LifecyclePhase::FinalReferenceDrop)
+    ->Name("coroflow_final_reference_drop_only")
+    ->UseRealTime();
 
 } // namespace

--- a/fdbserver/bench/coroflow/BenchCoroFlow.cpp
+++ b/fdbserver/bench/coroflow/BenchCoroFlow.cpp
@@ -223,11 +223,15 @@ BENCHMARK_TEMPLATE(benchWait, WaitKind::Ready)->Name("coroflow_wait_ready")->Use
 BENCHMARK_TEMPLATE(benchWait, WaitKind::Suspended)->Name("coroflow_wait_suspended")->UseRealTime();
 BENCHMARK(benchStartStop)->Name("coroflow_start_stop")->UseRealTime();
 BENCHMARK(benchZeroWorkerCreateDrop)->Name("coroflow_zero_worker_create_drop")->UseRealTime();
+// These rows exclude worker startup, so time-based calibration can spend excessive wall time on setup.
+constexpr int lifecyclePhaseIterations = 16384;
 BENCHMARK_TEMPLATE(benchLifecyclePhase, LifecyclePhase::ExplicitStop)
     ->Name("coroflow_explicit_stop_only")
+    ->Iterations(lifecyclePhaseIterations)
     ->UseRealTime();
 BENCHMARK_TEMPLATE(benchLifecyclePhase, LifecyclePhase::FinalReferenceDrop)
     ->Name("coroflow_final_reference_drop_only")
+    ->Iterations(lifecyclePhaseIterations)
     ->UseRealTime();
 
 } // namespace

--- a/fdbserver/bench/coroflow/BenchCoroFlow.cpp
+++ b/fdbserver/bench/coroflow/BenchCoroFlow.cpp
@@ -1,0 +1,144 @@
+/*
+ * BenchCoroFlow.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "benchmark/benchmark.h"
+
+#include "fdbserver/CoroFlow.h"
+#include "flow/ThreadHelper.h"
+
+namespace {
+
+enum class WaitKind { Ready, Suspended };
+
+class BenchReceiver final : public IThreadPoolReceiver {
+public:
+	Future<Void> onStarted() const { return started.getFuture(); }
+	void init() override { started.send(Void()); }
+
+private:
+	ThreadReturnPromise<Void> started;
+};
+
+template <WaitKind kind>
+class WaitAction final : public ThreadAction {
+public:
+	explicit WaitAction(benchmark::State* state) : state(state) {}
+
+	Future<Void> getFuture() const { return completed.getFuture(); }
+
+	void operator()(IThreadPoolReceiver*) override {
+		Optional<Error> err;
+		try {
+			Future<Void> ready = Void();
+			while (state->KeepRunning()) {
+				if constexpr (kind == WaitKind::Ready) {
+					CoroThreadPool::waitFor(ready);
+					benchmark::DoNotOptimize(ready);
+				} else {
+					Future<Void> pending = delay(0, g_network->getCurrentTask());
+					ASSERT(!pending.isReady());
+					CoroThreadPool::waitFor(pending);
+					benchmark::DoNotOptimize(pending);
+				}
+			}
+			state->SetItemsProcessed(state->iterations());
+		} catch (Error& e) {
+			err = e;
+		} catch (...) {
+			err = unknown_error();
+		}
+
+		// Defer delivery until control is back on the network stack.
+		if (err.present()) {
+			completed.sendError(err.get());
+		} else {
+			completed.send(Void());
+		}
+		delete this;
+	}
+
+	void cancel() override {
+		completed.sendError(actor_cancelled());
+		delete this;
+	}
+
+	double getTimeEstimate() const override { return 0; }
+
+private:
+	benchmark::State* state;
+	ThreadReturnPromise<Void> completed;
+};
+
+Future<Void> stopPoolAfter(Reference<IThreadPool> pool, Future<Void> done) {
+	Optional<Error> err;
+	try {
+		co_await done;
+	} catch (Error& e) {
+		err = e;
+	}
+	co_await pool->stop();
+	if (err.present()) {
+		throw err.get();
+	}
+}
+
+template <WaitKind kind>
+Future<Void> runWaitAction(Reference<IThreadPool> pool, Future<Void> started, benchmark::State* state) {
+	co_await started;
+	auto* action = new WaitAction<kind>(state);
+	Future<Void> completed = action->getFuture();
+	pool->post(action);
+	co_await completed;
+}
+
+template <WaitKind kind>
+Future<Void> runWaitBenchmark(benchmark::State* state) {
+	Reference<IThreadPool> pool = CoroThreadPool::createThreadPool();
+	auto* receiver = new BenchReceiver();
+	Future<Void> started = receiver->onStarted();
+	pool->addThread(receiver);
+	co_await stopPoolAfter(pool, runWaitAction<kind>(pool, started, state));
+}
+
+Future<Void> runStartStopBenchmark(benchmark::State* state) {
+	while (state->KeepRunning()) {
+		Reference<IThreadPool> pool = CoroThreadPool::createThreadPool();
+		auto* receiver = new BenchReceiver();
+		Future<Void> started = receiver->onStarted();
+		pool->addThread(receiver);
+		co_await stopPoolAfter(pool, started);
+	}
+	state->SetItemsProcessed(state->iterations());
+}
+
+template <WaitKind kind>
+void benchWait(benchmark::State& state) {
+	onMainThread([&state] { return runWaitBenchmark<kind>(&state); }).getBlocking();
+}
+
+void benchStartStop(benchmark::State& state) {
+	onMainThread([&state] { return runStartStopBenchmark(&state); }).getBlocking();
+}
+
+BENCHMARK_TEMPLATE(benchWait, WaitKind::Ready)->Name("coroflow_wait_ready")->UseRealTime();
+BENCHMARK_TEMPLATE(benchWait, WaitKind::Suspended)->Name("coroflow_wait_suspended")->UseRealTime();
+BENCHMARK(benchStartStop)->Name("coroflow_start_stop")->UseRealTime();
+
+} // namespace

--- a/fdbserver/bench/coroflow/BenchMain.cpp
+++ b/fdbserver/bench/coroflow/BenchMain.cpp
@@ -1,0 +1,26 @@
+/*
+ * BenchMain.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbserver/CoroFlow.h"
+#include "flow/BenchMain.h"
+
+int main(int argc, char** argv) {
+	return runBenchmarks(argc, argv, [] { CoroThreadPool::init(); });
+}

--- a/fdbserver/bench/coroflow/CMakeLists.txt
+++ b/fdbserver/bench/coroflow/CMakeLists.txt
@@ -1,0 +1,11 @@
+include(FDBBenchmark)
+
+add_flow_target(EXECUTABLE NAME fdbserver_coroflow_bench
+  SRCS BenchMain.cpp BenchCoroFlow.cpp)
+
+fdb_setup_googlebenchmark()
+
+target_include_directories(fdbserver_coroflow_bench
+  PRIVATE "${CMAKE_SOURCE_DIR}/fdbserver/include")
+target_link_libraries(fdbserver_coroflow_bench
+  PRIVATE Threads::Threads fdb_google_benchmark fdbserver_core)

--- a/fdbserver/core/CMakeLists.txt
+++ b/fdbserver/core/CMakeLists.txt
@@ -2,9 +2,9 @@ fdb_find_sources(FDBSERVER_CORE_LOCAL_SRCS)
 
 set(FDBSERVER_CORE_SRCS ${FDBSERVER_CORE_LOCAL_SRCS})
 if(${COROUTINE_IMPL} STREQUAL libcoro)
-  list(APPEND FDBSERVER_CORE_SRCS ../coroimpl/CoroFlowCoro.actor.cpp)
+  list(APPEND FDBSERVER_CORE_SRCS ../coroimpl/CoroFlowCoro.cpp)
 else()
-  list(APPEND FDBSERVER_CORE_SRCS ../coroimpl/CoroFlow.actor.cpp)
+  list(APPEND FDBSERVER_CORE_SRCS ../coroimpl/CoroFlow.cpp)
 endif()
 
 add_flow_target(STATIC_LIBRARY NAME fdbserver_core SRCS ${FDBSERVER_CORE_SRCS})

--- a/fdbserver/core/CoroFlowTests.cpp
+++ b/fdbserver/core/CoroFlowTests.cpp
@@ -199,6 +199,31 @@ private:
 	std::function<void()> work;
 };
 
+class DropPoolOnCancelAction final : public ThreadAction {
+public:
+	DropPoolOnCancelAction(Reference<ActionState> state, Reference<IThreadPool> pool)
+	  : state(std::move(state)), pool(std::move(pool)) {}
+	~DropPoolOnCancelAction() { state->destroy(); }
+
+	void operator()(IThreadPoolReceiver*) override {
+		std::unique_ptr<DropPoolOnCancelAction> destroyOnReturn(this);
+		state->start();
+		state->fail(operation_failed().asInjectedFault());
+	}
+
+	void cancel() override {
+		state->cancel();
+		pool.clear();
+		delete this;
+	}
+
+	double getTimeEstimate() const override { return 0.; }
+
+private:
+	Reference<ActionState> state;
+	Reference<IThreadPool> pool;
+};
+
 Reference<ActionState> postAction(Reference<IThreadPool> const& pool, std::function<void()> work) {
 	auto state = makeReference<ActionState>();
 	pool->post(new TestAction(state, std::move(work)));
@@ -391,6 +416,40 @@ TEST_CASE("/fdbserver/CoroFlow/DropBusyPool") {
 
 	gate.sendError(io_error());
 	co_await assertActionCompleted(active);
+	co_await queued->onDestroyed();
+	co_await receiver->onDestroyed();
+	queued->assertCancelled();
+	ASSERT_EQ(receiver->getInitCount(), 1);
+	ASSERT_EQ(receiver->getDestroyCount(), 1);
+}
+
+TEST_CASE("/fdbserver/CoroFlow/EmptyPoolLifecycle") {
+	{
+		auto pool = CoroThreadPool::createThreadPool();
+		co_await pool->stop();
+	}
+	auto pool = CoroThreadPool::createThreadPool();
+	pool.clear();
+}
+
+TEST_CASE("/fdbserver/CoroFlow/ErrorStopDropsLastOwner") {
+	auto receiver = makeReference<ReceiverState>();
+	auto pool = CoroThreadPool::createThreadPool();
+	const Error expectedError = operation_failed().asInjectedFault();
+	auto poolError = pool->getError();
+	pool->addThread(new FailingTestReceiver(receiver, expectedError));
+	auto queued = makeReference<ActionState>();
+	pool->post(new DropPoolOnCancelAction(queued, pool));
+
+	// The queued action is the only external owner when stopOnError cancels it.
+	pool.clear();
+	ASSERT(!poolError.isReady());
+	ASSERT_EQ(queued->getCancelCount(), 0);
+
+	ErrorOr<Void> result = co_await coro::errorOr(poolError);
+	ASSERT(result.isError());
+	ASSERT_EQ(result.getError().code(), expectedError.code());
+	ASSERT(result.getError().isInjectedFault());
 	co_await queued->onDestroyed();
 	co_await receiver->onDestroyed();
 	queued->assertCancelled();

--- a/fdbserver/core/CoroFlowTests.cpp
+++ b/fdbserver/core/CoroFlowTests.cpp
@@ -1,0 +1,399 @@
+/*
+ * CoroFlowTests.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbserver/CoroFlow.h"
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include "flow/Coroutines.h"
+#include "flow/UnitTest.h"
+
+void forceLinkCoroFlowTests() {}
+
+namespace {
+
+// Notifications must return through the network task queue, not resume a test on a stackful worker's stack.
+class ReceiverState final : public ReferenceCounted<ReceiverState> {
+public:
+	ReceiverState() : initializedFuture(initialized.getFuture()), destroyedFuture(destroyed.getFuture()) {}
+
+	Future<Void> onInitialized() const { return initializedFuture; }
+	Future<Void> onDestroyed() const { return destroyedFuture; }
+	int getInitCount() const { return initCount; }
+	int getDestroyCount() const { return destroyCount; }
+
+	void initialize() {
+		ASSERT_EQ(initCount, 0);
+		ASSERT_EQ(destroyCount, 0);
+		++initCount;
+		initialized.send(Void());
+	}
+
+	void destroy() {
+		ASSERT_EQ(destroyCount, 0);
+		++destroyCount;
+		if (initCount == 0) {
+			initialized.sendError(actor_cancelled());
+		}
+		destroyed.send(Void());
+	}
+
+private:
+	ThreadReturnPromise<Void> initialized;
+	ThreadReturnPromise<Void> destroyed;
+	Future<Void> initializedFuture;
+	Future<Void> destroyedFuture;
+	int initCount{ 0 };
+	int destroyCount{ 0 };
+};
+
+class TestReceiver final : public IThreadPoolReceiver {
+public:
+	explicit TestReceiver(Reference<ReceiverState> state) : state(std::move(state)) {}
+	~TestReceiver() override { state->destroy(); }
+	void init() override { state->initialize(); }
+
+private:
+	Reference<ReceiverState> state;
+};
+
+class FailingTestReceiver final : public IThreadPoolReceiver {
+public:
+	FailingTestReceiver(Reference<ReceiverState> state, Error error) : state(std::move(state)), error(error) {}
+	~FailingTestReceiver() override { state->destroy(); }
+	void init() override {
+		state->initialize();
+		throw error;
+	}
+
+private:
+	Reference<ReceiverState> state;
+	Error error;
+};
+
+class ActionState final : public ReferenceCounted<ActionState> {
+public:
+	ActionState()
+	  : startedFuture(started.getFuture()), completedFuture(completed.getFuture()),
+	    destroyedFuture(destroyed.getFuture()) {}
+
+	Future<Void> onStarted() const { return startedFuture; }
+	Future<Void> onCompleted() const { return completedFuture; }
+	Future<Void> onDestroyed() const { return destroyedFuture; }
+	int getRunCount() const { return runCount; }
+	int getCancelCount() const { return cancelCount; }
+
+	void start() {
+		ASSERT_EQ(runCount, 0);
+		ASSERT_EQ(cancelCount, 0);
+		++runCount;
+		started.send(Void());
+	}
+
+	void complete() {
+		finish();
+		completed.send(Void());
+	}
+
+	void fail(Error error) {
+		finish();
+		completed.sendError(error);
+	}
+
+	void cancel() {
+		ASSERT_EQ(runCount, 0);
+		ASSERT_EQ(cancelCount, 0);
+		ASSERT(!finished);
+		++cancelCount;
+		finished = true;
+		started.sendError(actor_cancelled());
+		completed.sendError(actor_cancelled());
+	}
+
+	void destroy() {
+		ASSERT(finished);
+		ASSERT_EQ(destroyCount, 0);
+		++destroyCount;
+		destroyed.send(Void());
+	}
+
+	void assertCompleted() const {
+		ASSERT_EQ(runCount, 1);
+		ASSERT_EQ(cancelCount, 0);
+		ASSERT_EQ(destroyCount, 1);
+	}
+
+	void assertCancelled() const {
+		ASSERT_EQ(runCount, 0);
+		ASSERT_EQ(cancelCount, 1);
+		ASSERT_EQ(destroyCount, 1);
+	}
+
+private:
+	void finish() {
+		ASSERT_EQ(runCount, 1);
+		ASSERT_EQ(cancelCount, 0);
+		ASSERT(!finished);
+		finished = true;
+	}
+
+	ThreadReturnPromise<Void> started;
+	ThreadReturnPromise<Void> completed;
+	ThreadReturnPromise<Void> destroyed;
+	Future<Void> startedFuture;
+	Future<Void> completedFuture;
+	Future<Void> destroyedFuture;
+	int runCount{ 0 };
+	int cancelCount{ 0 };
+	int destroyCount{ 0 };
+	bool finished{ false };
+};
+
+class TestAction final : public ThreadAction {
+public:
+	TestAction(Reference<ActionState> state, std::function<void()> work)
+	  : state(std::move(state)), work(std::move(work)) {}
+	~TestAction() { state->destroy(); }
+
+	void operator()(IThreadPoolReceiver*) override {
+		std::unique_ptr<TestAction> destroyOnReturn(this);
+		state->start();
+		try {
+			work();
+			state->complete();
+		} catch (Error& e) {
+			state->fail(e);
+		} catch (...) {
+			state->fail(unknown_error());
+		}
+	}
+
+	void cancel() override {
+		state->cancel();
+		delete this;
+	}
+
+	double getTimeEstimate() const override { return 0.; }
+
+private:
+	Reference<ActionState> state;
+	std::function<void()> work;
+};
+
+Reference<ActionState> postAction(Reference<IThreadPool> const& pool, std::function<void()> work) {
+	auto state = makeReference<ActionState>();
+	pool->post(new TestAction(state, std::move(work)));
+	return state;
+}
+
+template <class F>
+void assertThrowsError(F&& f, int expectedCode) {
+	try {
+		std::forward<F>(f)();
+	} catch (Error& e) {
+		ASSERT_EQ(e.code(), expectedCode);
+		return;
+	}
+	ASSERT(false);
+}
+
+Future<Void> assertActionCompleted(Reference<ActionState> action) {
+	co_await action->onCompleted();
+	co_await action->onDestroyed();
+	action->assertCompleted();
+}
+
+} // namespace
+
+TEST_CASE("/fdbserver/CoroFlow/DeferredStartAndReadyWaits") {
+	auto receiver = makeReference<ReceiverState>();
+	auto pool = CoroThreadPool::createThreadPool();
+	ASSERT(pool->isCoro());
+	pool->addThread(new TestReceiver(receiver));
+	ASSERT_EQ(receiver->getInitCount(), 0);
+
+	auto action = postAction(pool, [] {
+		waitFor(Future<Void>(Void()));
+		ASSERT_EQ(waitForAndGet(Future<int>(42)), 42);
+		assertThrowsError([] { waitFor(Future<Void>(operation_failed())); }, error_code_operation_failed);
+		assertThrowsError([] { waitForAndGet(Future<int>(io_error())); }, error_code_io_error);
+	});
+	ASSERT_EQ(action->getRunCount(), 0);
+	co_await assertActionCompleted(action);
+	ASSERT_EQ(receiver->getInitCount(), 1);
+	ASSERT(!pool->getError().isReady());
+
+	co_await pool->stop();
+	co_await receiver->onDestroyed();
+	ASSERT_EQ(receiver->getDestroyCount(), 1);
+	co_await pool->stop();
+}
+
+TEST_CASE("/fdbserver/CoroFlow/SuspendedWaits") {
+	auto receiver = makeReference<ReceiverState>();
+	auto pool = CoroThreadPool::createThreadPool();
+	pool->addThread(new TestReceiver(receiver));
+
+	Promise<int> value;
+	auto valueAction = postAction(pool, [input = value.getFuture()] { ASSERT_EQ(waitForAndGet(input), 17); });
+	co_await valueAction->onStarted();
+	ASSERT(!valueAction->onCompleted().isReady());
+	value.send(17);
+	co_await assertActionCompleted(valueAction);
+
+	Promise<Void> ready;
+	auto voidAction = postAction(pool, [input = ready.getFuture()] { waitFor(input); });
+	co_await voidAction->onStarted();
+	ASSERT(!voidAction->onCompleted().isReady());
+	ready.send(Void());
+	co_await assertActionCompleted(voidAction);
+
+	Promise<int> failedValue;
+	auto valueErrorAction = postAction(pool, [input = failedValue.getFuture()] {
+		assertThrowsError([&] { waitForAndGet(input); }, error_code_io_error);
+	});
+	co_await valueErrorAction->onStarted();
+	ASSERT(!valueErrorAction->onCompleted().isReady());
+	failedValue.sendError(io_error());
+	co_await assertActionCompleted(valueErrorAction);
+
+	Promise<Void> failedVoid;
+	auto voidErrorAction = postAction(pool, [input = failedVoid.getFuture()] {
+		assertThrowsError([&] { waitFor(input); }, error_code_operation_failed);
+	});
+	co_await voidErrorAction->onStarted();
+	ASSERT(!voidErrorAction->onCompleted().isReady());
+	failedVoid.sendError(operation_failed());
+	co_await assertActionCompleted(voidErrorAction);
+
+	ASSERT(!pool->getError().isReady());
+	co_await pool->stop();
+	co_await receiver->onDestroyed();
+	ASSERT_EQ(receiver->getInitCount(), 1);
+	ASSERT_EQ(receiver->getDestroyCount(), 1);
+}
+
+TEST_CASE("/fdbserver/CoroFlow/StopCancelsQueuedAction") {
+	auto receiver = makeReference<ReceiverState>();
+	auto pool = CoroThreadPool::createThreadPool();
+	pool->addThread(new TestReceiver(receiver));
+	Promise<Void> gate;
+	auto active = postAction(pool, [input = gate.getFuture()] { waitFor(input); });
+	co_await active->onStarted();
+	auto queued = postAction(pool, [] { ASSERT(false); });
+
+	auto stopped = pool->stop();
+	queued->assertCancelled();
+	ASSERT_EQ(active->getCancelCount(), 0);
+	ASSERT(!active->onCompleted().isReady());
+	ASSERT(!stopped.isReady());
+	ASSERT_EQ(receiver->getDestroyCount(), 0);
+
+	gate.send(Void());
+	co_await assertActionCompleted(active);
+	co_await queued->onDestroyed();
+	co_await stopped;
+	co_await receiver->onDestroyed();
+	queued->assertCancelled();
+	ASSERT_EQ(receiver->getDestroyCount(), 1);
+}
+
+TEST_CASE("/fdbserver/CoroFlow/WorkerInitErrorStopsPool") {
+	auto receiver = makeReference<ReceiverState>();
+	auto pool = CoroThreadPool::createThreadPool();
+	const Error expectedError = operation_failed().asInjectedFault();
+	auto poolError = pool->getError();
+	pool->addThread(new FailingTestReceiver(receiver, expectedError));
+	auto queued = postAction(pool, [] { ASSERT(false); });
+	ASSERT(!poolError.isReady());
+
+	bool caughtError{ false };
+	try {
+		co_await poolError;
+	} catch (Error& e) {
+		ASSERT_EQ(e.code(), expectedError.code());
+		ASSERT(e.isInjectedFault());
+		caughtError = true;
+	}
+	ASSERT(caughtError);
+
+	// Cancellation must come from stopOnError, before any explicit stop call.
+	co_await queued->onDestroyed();
+	co_await receiver->onDestroyed();
+	queued->assertCancelled();
+	ASSERT_EQ(receiver->getInitCount(), 1);
+	ASSERT_EQ(receiver->getDestroyCount(), 1);
+	co_await pool->stop(expectedError);
+}
+
+TEST_CASE("/fdbserver/CoroFlow/DropBeforeStart") {
+	auto receiver = makeReference<ReceiverState>();
+	auto pool = CoroThreadPool::createThreadPool();
+	pool->addThread(new TestReceiver(receiver));
+	auto queued = postAction(pool, [] { ASSERT(false); });
+	ASSERT_EQ(receiver->getInitCount(), 0);
+
+	pool.clear();
+	queued->assertCancelled();
+	co_await queued->onDestroyed();
+	co_await receiver->onDestroyed();
+	ASSERT_EQ(receiver->getInitCount(), 0);
+	ASSERT_EQ(receiver->getDestroyCount(), 1);
+}
+
+TEST_CASE("/fdbserver/CoroFlow/DropIdlePool") {
+	auto receiver = makeReference<ReceiverState>();
+	auto pool = CoroThreadPool::createThreadPool();
+	pool->addThread(new TestReceiver(receiver));
+	co_await receiver->onInitialized();
+	ASSERT_EQ(receiver->getDestroyCount(), 0);
+
+	pool.clear();
+	co_await receiver->onDestroyed();
+	ASSERT_EQ(receiver->getInitCount(), 1);
+	ASSERT_EQ(receiver->getDestroyCount(), 1);
+}
+
+TEST_CASE("/fdbserver/CoroFlow/DropBusyPool") {
+	auto receiver = makeReference<ReceiverState>();
+	auto pool = CoroThreadPool::createThreadPool();
+	pool->addThread(new TestReceiver(receiver));
+	Promise<Void> gate;
+	auto active = postAction(
+	    pool, [input = gate.getFuture()] { assertThrowsError([&] { waitFor(input); }, error_code_io_error); });
+	co_await active->onStarted();
+	auto queued = postAction(pool, [] { ASSERT(false); });
+
+	pool.clear();
+	queued->assertCancelled();
+	ASSERT_EQ(active->getCancelCount(), 0);
+	ASSERT(!active->onCompleted().isReady());
+	ASSERT_EQ(receiver->getDestroyCount(), 0);
+
+	gate.sendError(io_error());
+	co_await assertActionCompleted(active);
+	co_await queued->onDestroyed();
+	co_await receiver->onDestroyed();
+	queued->assertCancelled();
+	ASSERT_EQ(receiver->getInitCount(), 1);
+	ASSERT_EQ(receiver->getDestroyCount(), 1);
+}

--- a/fdbserver/core/CoroFlowTests.cpp
+++ b/fdbserver/core/CoroFlowTests.cpp
@@ -68,126 +68,96 @@ private:
 
 class TestReceiver final : public IThreadPoolReceiver {
 public:
-	explicit TestReceiver(Reference<ReceiverState> state) : state(std::move(state)) {}
+	explicit TestReceiver(Reference<ReceiverState> state, Error initError = Error())
+	  : state(std::move(state)), initError(initError) {}
 	~TestReceiver() override { state->destroy(); }
-	void init() override { state->initialize(); }
-
-private:
-	Reference<ReceiverState> state;
-};
-
-class FailingTestReceiver final : public IThreadPoolReceiver {
-public:
-	FailingTestReceiver(Reference<ReceiverState> state, Error error) : state(std::move(state)), error(error) {}
-	~FailingTestReceiver() override { state->destroy(); }
 	void init() override {
 		state->initialize();
-		throw error;
+		if (initError.isValid()) {
+			throw initError;
+		}
 	}
 
 private:
 	Reference<ReceiverState> state;
-	Error error;
+	Error initError;
 };
 
 class ActionState final : public ReferenceCounted<ActionState> {
 public:
-	ActionState()
-	  : startedFuture(started.getFuture()), completedFuture(completed.getFuture()),
-	    destroyedFuture(destroyed.getFuture()) {}
+	ActionState() : startedFuture(started.getFuture()), doneFuture(done.getFuture()) {}
 
 	Future<Void> onStarted() const { return startedFuture; }
-	Future<Void> onCompleted() const { return completedFuture; }
-	Future<Void> onDestroyed() const { return destroyedFuture; }
-	int getRunCount() const { return runCount; }
-	int getCancelCount() const { return cancelCount; }
+	Future<Void> onDone() const { return doneFuture; }
+	void assertQueued() const { ASSERT(phase == Phase::Queued); }
+	void assertRunning() const { ASSERT(phase == Phase::Running); }
+	void assertCompleted() const { ASSERT(phase == Phase::Completed && destroyed); }
+	void assertCancelled() const { ASSERT(phase == Phase::Cancelled && destroyed); }
 
 	void start() {
-		ASSERT_EQ(runCount, 0);
-		ASSERT_EQ(cancelCount, 0);
-		++runCount;
+		assertQueued();
+		phase = Phase::Running;
 		started.send(Void());
 	}
 
-	void complete() {
-		finish();
-		completed.send(Void());
-	}
-
-	void fail(Error error) {
-		finish();
-		completed.sendError(error);
+	void finish(Error error = Error()) {
+		assertRunning();
+		phase = Phase::Completed;
+		workError = error;
 	}
 
 	void cancel() {
-		ASSERT_EQ(runCount, 0);
-		ASSERT_EQ(cancelCount, 0);
-		ASSERT(!finished);
-		++cancelCount;
-		finished = true;
+		assertQueued();
+		phase = Phase::Cancelled;
 		started.sendError(actor_cancelled());
-		completed.sendError(actor_cancelled());
 	}
 
 	void destroy() {
-		ASSERT(finished);
-		ASSERT_EQ(destroyCount, 0);
-		++destroyCount;
-		destroyed.send(Void());
-	}
-
-	void assertCompleted() const {
-		ASSERT_EQ(runCount, 1);
-		ASSERT_EQ(cancelCount, 0);
-		ASSERT_EQ(destroyCount, 1);
-	}
-
-	void assertCancelled() const {
-		ASSERT_EQ(runCount, 0);
-		ASSERT_EQ(cancelCount, 1);
-		ASSERT_EQ(destroyCount, 1);
+		ASSERT(!destroyed && (phase == Phase::Completed || phase == Phase::Cancelled));
+		destroyed = true;
+		if (workError.isValid()) {
+			done.sendError(workError);
+		} else {
+			done.send(Void());
+		}
 	}
 
 private:
-	void finish() {
-		ASSERT_EQ(runCount, 1);
-		ASSERT_EQ(cancelCount, 0);
-		ASSERT(!finished);
-		finished = true;
-	}
-
+	enum class Phase { Queued, Running, Completed, Cancelled };
 	ThreadReturnPromise<Void> started;
-	ThreadReturnPromise<Void> completed;
-	ThreadReturnPromise<Void> destroyed;
+	ThreadReturnPromise<Void> done;
 	Future<Void> startedFuture;
-	Future<Void> completedFuture;
-	Future<Void> destroyedFuture;
-	int runCount{ 0 };
-	int cancelCount{ 0 };
-	int destroyCount{ 0 };
-	bool finished{ false };
+	Future<Void> doneFuture;
+	Phase phase{ Phase::Queued };
+	Error workError;
+	bool destroyed{ false };
 };
 
 class TestAction final : public ThreadAction {
 public:
-	TestAction(Reference<ActionState> state, std::function<void()> work)
-	  : state(std::move(state)), work(std::move(work)) {}
+	TestAction(Reference<ActionState> state, std::function<void()> work, std::function<void()> beforeCancel)
+	  : state(std::move(state)), work(std::move(work)), beforeCancel(std::move(beforeCancel)) {}
 	~TestAction() { state->destroy(); }
 
 	void operator()(IThreadPoolReceiver*) override {
 		std::unique_ptr<TestAction> destroyOnReturn(this);
 		state->start();
+		Error error;
 		try {
 			work();
-			state->complete();
 		} catch (Error& e) {
-			state->fail(e);
+			error = e;
 		} catch (...) {
-			state->fail(unknown_error());
+			error = unknown_error();
 		}
+		state->finish(error);
 	}
 
 	void cancel() override {
+		// A throwing callback must leave this action queued and available for a later stop() retry.
+		if (beforeCancel) {
+			beforeCancel();
+		}
 		state->cancel();
 		delete this;
 	}
@@ -197,79 +167,14 @@ public:
 private:
 	Reference<ActionState> state;
 	std::function<void()> work;
+	std::function<void()> beforeCancel;
 };
 
-class DropPoolOnCancelAction final : public ThreadAction {
-public:
-	DropPoolOnCancelAction(Reference<ActionState> state, Reference<IThreadPool> pool)
-	  : state(std::move(state)), pool(std::move(pool)) {}
-	~DropPoolOnCancelAction() { state->destroy(); }
-
-	void operator()(IThreadPoolReceiver*) override {
-		std::unique_ptr<DropPoolOnCancelAction> destroyOnReturn(this);
-		state->start();
-		state->fail(operation_failed().asInjectedFault());
-	}
-
-	void cancel() override {
-		state->cancel();
-		pool.clear();
-		delete this;
-	}
-
-	double getTimeEstimate() const override { return 0.; }
-
-private:
-	Reference<ActionState> state;
-	Reference<IThreadPool> pool;
-};
-
-class CancelRetryState final : public ReferenceCounted<CancelRetryState> {
-public:
-	explicit CancelRetryState(Error firstError) : firstError(firstError) {}
-	int getAttemptCount() const { return attemptCount; }
-
-	void attempt() {
-		++attemptCount;
-		if (attemptCount == 1) {
-			throw firstError;
-		}
-		ASSERT_EQ(attemptCount, 2);
-	}
-
-private:
-	Error firstError;
-	int attemptCount{ 0 };
-};
-
-class ThrowOnceOnCancelAction final : public ThreadAction {
-public:
-	ThrowOnceOnCancelAction(Reference<ActionState> state, Reference<CancelRetryState> retry)
-	  : state(std::move(state)), retry(std::move(retry)) {}
-	~ThrowOnceOnCancelAction() { state->destroy(); }
-
-	void operator()(IThreadPoolReceiver*) override {
-		std::unique_ptr<ThrowOnceOnCancelAction> destroyOnReturn(this);
-		state->start();
-		state->fail(operation_failed().asInjectedFault());
-	}
-
-	void cancel() override {
-		retry->attempt();
-		state->cancel();
-		delete this;
-	}
-
-	double getTimeEstimate() const override { return 0.; }
-
-private:
-	Reference<ActionState> state;
-	Reference<CancelRetryState> retry;
-};
-
-Reference<ActionState> postAction(Reference<IThreadPool> const& pool, std::function<void()> work) {
+Reference<ActionState> postAction(Reference<IThreadPool> const& pool,
+                                  std::function<void()> work,
+                                  std::function<void()> beforeCancel = {}) {
 	auto state = makeReference<ActionState>();
-	pool->post(new TestAction(state, std::move(work)));
+	pool->post(new TestAction(state, std::move(work), std::move(beforeCancel)));
 	return state;
 }
 
@@ -285,8 +190,7 @@ void assertThrowsError(F&& f, int expectedCode) {
 }
 
 Future<Void> assertActionCompleted(Reference<ActionState> action) {
-	co_await action->onCompleted();
-	co_await action->onDestroyed();
+	co_await action->onDone();
 	action->assertCompleted();
 }
 
@@ -305,14 +209,13 @@ TEST_CASE("/fdbserver/CoroFlow/DeferredStartAndReadyWaits") {
 		assertThrowsError([] { waitFor(Future<Void>(operation_failed())); }, error_code_operation_failed);
 		assertThrowsError([] { waitForAndGet(Future<int>(io_error())); }, error_code_io_error);
 	});
-	ASSERT_EQ(action->getRunCount(), 0);
+	action->assertQueued();
 	co_await assertActionCompleted(action);
 	ASSERT_EQ(receiver->getInitCount(), 1);
 	ASSERT(!pool->getError().isReady());
 
 	co_await pool->stop();
 	co_await receiver->onDestroyed();
-	ASSERT_EQ(receiver->getDestroyCount(), 1);
 	co_await pool->stop();
 }
 
@@ -324,14 +227,14 @@ TEST_CASE("/fdbserver/CoroFlow/SuspendedWaits") {
 	Promise<int> value;
 	auto valueAction = postAction(pool, [input = value.getFuture()] { ASSERT_EQ(waitForAndGet(input), 17); });
 	co_await valueAction->onStarted();
-	ASSERT(!valueAction->onCompleted().isReady());
+	valueAction->assertRunning();
 	value.send(17);
 	co_await assertActionCompleted(valueAction);
 
 	Promise<Void> ready;
 	auto voidAction = postAction(pool, [input = ready.getFuture()] { waitFor(input); });
 	co_await voidAction->onStarted();
-	ASSERT(!voidAction->onCompleted().isReady());
+	voidAction->assertRunning();
 	ready.send(Void());
 	co_await assertActionCompleted(voidAction);
 
@@ -340,7 +243,7 @@ TEST_CASE("/fdbserver/CoroFlow/SuspendedWaits") {
 		assertThrowsError([&] { waitForAndGet(input); }, error_code_io_error);
 	});
 	co_await valueErrorAction->onStarted();
-	ASSERT(!valueErrorAction->onCompleted().isReady());
+	valueErrorAction->assertRunning();
 	failedValue.sendError(io_error());
 	co_await assertActionCompleted(valueErrorAction);
 
@@ -349,7 +252,7 @@ TEST_CASE("/fdbserver/CoroFlow/SuspendedWaits") {
 		assertThrowsError([&] { waitFor(input); }, error_code_operation_failed);
 	});
 	co_await voidErrorAction->onStarted();
-	ASSERT(!voidErrorAction->onCompleted().isReady());
+	voidErrorAction->assertRunning();
 	failedVoid.sendError(operation_failed());
 	co_await assertActionCompleted(voidErrorAction);
 
@@ -357,60 +260,6 @@ TEST_CASE("/fdbserver/CoroFlow/SuspendedWaits") {
 	co_await pool->stop();
 	co_await receiver->onDestroyed();
 	ASSERT_EQ(receiver->getInitCount(), 1);
-	ASSERT_EQ(receiver->getDestroyCount(), 1);
-}
-
-TEST_CASE("/fdbserver/CoroFlow/StopCancelsQueuedAction") {
-	auto receiver = makeReference<ReceiverState>();
-	auto pool = CoroThreadPool::createThreadPool();
-	pool->addThread(new TestReceiver(receiver));
-	Promise<Void> gate;
-	auto active = postAction(pool, [input = gate.getFuture()] { waitFor(input); });
-	co_await active->onStarted();
-	auto queued = postAction(pool, [] { ASSERT(false); });
-
-	auto stopped = pool->stop();
-	queued->assertCancelled();
-	ASSERT_EQ(active->getCancelCount(), 0);
-	ASSERT(!active->onCompleted().isReady());
-	ASSERT(!stopped.isReady());
-	ASSERT_EQ(receiver->getDestroyCount(), 0);
-
-	gate.send(Void());
-	co_await assertActionCompleted(active);
-	co_await queued->onDestroyed();
-	co_await stopped;
-	co_await receiver->onDestroyed();
-	queued->assertCancelled();
-	ASSERT_EQ(receiver->getDestroyCount(), 1);
-}
-
-TEST_CASE("/fdbserver/CoroFlow/WorkerInitErrorStopsPool") {
-	auto receiver = makeReference<ReceiverState>();
-	auto pool = CoroThreadPool::createThreadPool();
-	const Error expectedError = operation_failed().asInjectedFault();
-	auto poolError = pool->getError();
-	pool->addThread(new FailingTestReceiver(receiver, expectedError));
-	auto queued = postAction(pool, [] { ASSERT(false); });
-	ASSERT(!poolError.isReady());
-
-	bool caughtError{ false };
-	try {
-		co_await poolError;
-	} catch (Error& e) {
-		ASSERT_EQ(e.code(), expectedError.code());
-		ASSERT(e.isInjectedFault());
-		caughtError = true;
-	}
-	ASSERT(caughtError);
-
-	// Cancellation must come from stopOnError, before any explicit stop call.
-	co_await queued->onDestroyed();
-	co_await receiver->onDestroyed();
-	queued->assertCancelled();
-	ASSERT_EQ(receiver->getInitCount(), 1);
-	ASSERT_EQ(receiver->getDestroyCount(), 1);
-	co_await pool->stop(expectedError);
 }
 
 TEST_CASE("/fdbserver/CoroFlow/DropBeforeStart") {
@@ -422,10 +271,9 @@ TEST_CASE("/fdbserver/CoroFlow/DropBeforeStart") {
 
 	pool.clear();
 	queued->assertCancelled();
-	co_await queued->onDestroyed();
+	co_await queued->onDone();
 	co_await receiver->onDestroyed();
 	ASSERT_EQ(receiver->getInitCount(), 0);
-	ASSERT_EQ(receiver->getDestroyCount(), 1);
 }
 
 TEST_CASE("/fdbserver/CoroFlow/DropIdlePool") {
@@ -438,7 +286,6 @@ TEST_CASE("/fdbserver/CoroFlow/DropIdlePool") {
 	pool.clear();
 	co_await receiver->onDestroyed();
 	ASSERT_EQ(receiver->getInitCount(), 1);
-	ASSERT_EQ(receiver->getDestroyCount(), 1);
 }
 
 TEST_CASE("/fdbserver/CoroFlow/DropBusyPool") {
@@ -453,25 +300,20 @@ TEST_CASE("/fdbserver/CoroFlow/DropBusyPool") {
 
 	pool.clear();
 	queued->assertCancelled();
-	ASSERT_EQ(active->getCancelCount(), 0);
-	ASSERT(!active->onCompleted().isReady());
+	active->assertRunning();
 	ASSERT_EQ(receiver->getDestroyCount(), 0);
 
 	gate.sendError(io_error());
 	co_await assertActionCompleted(active);
-	co_await queued->onDestroyed();
+	co_await queued->onDone();
 	co_await receiver->onDestroyed();
-	queued->assertCancelled();
 	ASSERT_EQ(receiver->getInitCount(), 1);
-	ASSERT_EQ(receiver->getDestroyCount(), 1);
 }
 
 TEST_CASE("/fdbserver/CoroFlow/EmptyPoolLifecycle") {
-	{
-		auto pool = CoroThreadPool::createThreadPool();
-		co_await pool->stop();
-	}
 	auto pool = CoroThreadPool::createThreadPool();
+	co_await pool->stop();
+	pool = CoroThreadPool::createThreadPool();
 	pool.clear();
 }
 
@@ -480,24 +322,23 @@ TEST_CASE("/fdbserver/CoroFlow/ErrorStopDropsLastOwner") {
 	auto pool = CoroThreadPool::createThreadPool();
 	const Error expectedError = operation_failed().asInjectedFault();
 	auto poolError = pool->getError();
-	pool->addThread(new FailingTestReceiver(receiver, expectedError));
-	auto queued = makeReference<ActionState>();
-	pool->post(new DropPoolOnCancelAction(queued, pool));
+	pool->addThread(new TestReceiver(receiver, expectedError));
+	auto queued = postAction(pool, [] { ASSERT(false); }, [owner = pool]() mutable { owner.clear(); });
 
 	// The queued action is the only external owner when stopOnError cancels it.
 	pool.clear();
 	ASSERT(!poolError.isReady());
-	ASSERT_EQ(queued->getCancelCount(), 0);
+	queued->assertQueued();
 
 	ErrorOr<Void> result = co_await coro::errorOr(poolError);
 	ASSERT(result.isError());
 	ASSERT_EQ(result.getError().code(), expectedError.code());
 	ASSERT(result.getError().isInjectedFault());
-	co_await queued->onDestroyed();
+	// Cancellation must come from stopOnError, without an explicit stop call.
+	co_await queued->onDone();
 	co_await receiver->onDestroyed();
 	queued->assertCancelled();
 	ASSERT_EQ(receiver->getInitCount(), 1);
-	ASSERT_EQ(receiver->getDestroyCount(), 1);
 }
 
 TEST_CASE("/fdbserver/CoroFlow/StopRetryAfterCancelError") {
@@ -508,9 +349,16 @@ TEST_CASE("/fdbserver/CoroFlow/StopRetryAfterCancelError") {
 	auto active = postAction(pool, [input = gate.getFuture()] { waitFor(input); });
 	co_await active->onStarted();
 	const Error expectedError = operation_failed().asInjectedFault();
-	auto retry = makeReference<CancelRetryState>(expectedError);
-	auto queued = makeReference<ActionState>();
-	pool->post(new ThrowOnceOnCancelAction(queued, retry));
+	auto attempts = std::make_shared<int>(0);
+	auto queued = postAction(
+	    pool,
+	    [] { ASSERT(false); },
+	    [attempts, expectedError] {
+		    if (++*attempts == 1) {
+			    throw expectedError;
+		    }
+		    ASSERT_EQ(*attempts, 2);
+	    });
 
 	Error observedError;
 	try {
@@ -520,26 +368,23 @@ TEST_CASE("/fdbserver/CoroFlow/StopRetryAfterCancelError") {
 	}
 	ASSERT_EQ(observedError.code(), expectedError.code());
 	ASSERT(observedError.isInjectedFault());
-	ASSERT_EQ(retry->getAttemptCount(), 1);
-	ASSERT_EQ(queued->getCancelCount(), 0);
-	ASSERT(!queued->onDestroyed().isReady());
-	ASSERT(!active->onCompleted().isReady());
+	ASSERT_EQ(*attempts, 1);
+	queued->assertQueued();
+	active->assertRunning();
 	ASSERT_EQ(receiver->getDestroyCount(), 0);
 
 	pool.clear();
-	ASSERT_EQ(retry->getAttemptCount(), 2);
+	ASSERT_EQ(*attempts, 2);
 	queued->assertCancelled();
-	ASSERT_EQ(active->getCancelCount(), 0);
-	ASSERT(!active->onCompleted().isReady());
+	active->assertRunning();
 	ASSERT_EQ(receiver->getDestroyCount(), 0);
 
 	gate.send(Void());
 	co_await assertActionCompleted(active);
-	co_await queued->onDestroyed();
+	co_await queued->onDone();
 	co_await receiver->onDestroyed();
-	ASSERT_EQ(retry->getAttemptCount(), 2);
+	ASSERT_EQ(*attempts, 2);
 	ASSERT_EQ(receiver->getInitCount(), 1);
-	ASSERT_EQ(receiver->getDestroyCount(), 1);
 }
 
 TEST_CASE("/fdbserver/CoroFlow/ExplicitStopDropsLastOwner") {
@@ -549,8 +394,7 @@ TEST_CASE("/fdbserver/CoroFlow/ExplicitStopDropsLastOwner") {
 	Promise<Void> gate;
 	auto active = postAction(pool, [input = gate.getFuture()] { waitFor(input); });
 	co_await active->onStarted();
-	auto queued = makeReference<ActionState>();
-	pool->post(new DropPoolOnCancelAction(queued, pool));
+	auto queued = postAction(pool, [] { ASSERT(false); }, [owner = pool]() mutable { owner.clear(); });
 
 	// The queued action keeps this pointer alive until stop() begins canceling it.
 	IThreadPool* poolToStop = pool.getPtr();
@@ -558,15 +402,13 @@ TEST_CASE("/fdbserver/CoroFlow/ExplicitStopDropsLastOwner") {
 	auto stopped = poolToStop->stop();
 	queued->assertCancelled();
 	ASSERT(!stopped.isReady());
-	ASSERT_EQ(active->getCancelCount(), 0);
-	ASSERT(!active->onCompleted().isReady());
+	active->assertRunning();
 	ASSERT_EQ(receiver->getDestroyCount(), 0);
 
 	gate.send(Void());
 	co_await assertActionCompleted(active);
-	co_await queued->onDestroyed();
+	co_await queued->onDone();
 	co_await stopped;
 	co_await receiver->onDestroyed();
 	ASSERT_EQ(receiver->getInitCount(), 1);
-	ASSERT_EQ(receiver->getDestroyCount(), 1);
 }

--- a/fdbserver/core/CoroFlowTests.cpp
+++ b/fdbserver/core/CoroFlowTests.cpp
@@ -224,6 +224,49 @@ private:
 	Reference<IThreadPool> pool;
 };
 
+class CancelRetryState final : public ReferenceCounted<CancelRetryState> {
+public:
+	explicit CancelRetryState(Error firstError) : firstError(firstError) {}
+	int getAttemptCount() const { return attemptCount; }
+
+	void attempt() {
+		++attemptCount;
+		if (attemptCount == 1) {
+			throw firstError;
+		}
+		ASSERT_EQ(attemptCount, 2);
+	}
+
+private:
+	Error firstError;
+	int attemptCount{ 0 };
+};
+
+class ThrowOnceOnCancelAction final : public ThreadAction {
+public:
+	ThrowOnceOnCancelAction(Reference<ActionState> state, Reference<CancelRetryState> retry)
+	  : state(std::move(state)), retry(std::move(retry)) {}
+	~ThrowOnceOnCancelAction() { state->destroy(); }
+
+	void operator()(IThreadPoolReceiver*) override {
+		std::unique_ptr<ThrowOnceOnCancelAction> destroyOnReturn(this);
+		state->start();
+		state->fail(operation_failed().asInjectedFault());
+	}
+
+	void cancel() override {
+		retry->attempt();
+		state->cancel();
+		delete this;
+	}
+
+	double getTimeEstimate() const override { return 0.; }
+
+private:
+	Reference<ActionState> state;
+	Reference<CancelRetryState> retry;
+};
+
 Reference<ActionState> postAction(Reference<IThreadPool> const& pool, std::function<void()> work) {
 	auto state = makeReference<ActionState>();
 	pool->post(new TestAction(state, std::move(work)));
@@ -453,6 +496,77 @@ TEST_CASE("/fdbserver/CoroFlow/ErrorStopDropsLastOwner") {
 	co_await queued->onDestroyed();
 	co_await receiver->onDestroyed();
 	queued->assertCancelled();
+	ASSERT_EQ(receiver->getInitCount(), 1);
+	ASSERT_EQ(receiver->getDestroyCount(), 1);
+}
+
+TEST_CASE("/fdbserver/CoroFlow/StopRetryAfterCancelError") {
+	auto receiver = makeReference<ReceiverState>();
+	auto pool = CoroThreadPool::createThreadPool();
+	pool->addThread(new TestReceiver(receiver));
+	Promise<Void> gate;
+	auto active = postAction(pool, [input = gate.getFuture()] { waitFor(input); });
+	co_await active->onStarted();
+	const Error expectedError = operation_failed().asInjectedFault();
+	auto retry = makeReference<CancelRetryState>(expectedError);
+	auto queued = makeReference<ActionState>();
+	pool->post(new ThrowOnceOnCancelAction(queued, retry));
+
+	Error observedError;
+	try {
+		pool->stop();
+	} catch (Error& e) {
+		observedError = e;
+	}
+	ASSERT_EQ(observedError.code(), expectedError.code());
+	ASSERT(observedError.isInjectedFault());
+	ASSERT_EQ(retry->getAttemptCount(), 1);
+	ASSERT_EQ(queued->getCancelCount(), 0);
+	ASSERT(!queued->onDestroyed().isReady());
+	ASSERT(!active->onCompleted().isReady());
+	ASSERT_EQ(receiver->getDestroyCount(), 0);
+
+	pool.clear();
+	ASSERT_EQ(retry->getAttemptCount(), 2);
+	queued->assertCancelled();
+	ASSERT_EQ(active->getCancelCount(), 0);
+	ASSERT(!active->onCompleted().isReady());
+	ASSERT_EQ(receiver->getDestroyCount(), 0);
+
+	gate.send(Void());
+	co_await assertActionCompleted(active);
+	co_await queued->onDestroyed();
+	co_await receiver->onDestroyed();
+	ASSERT_EQ(retry->getAttemptCount(), 2);
+	ASSERT_EQ(receiver->getInitCount(), 1);
+	ASSERT_EQ(receiver->getDestroyCount(), 1);
+}
+
+TEST_CASE("/fdbserver/CoroFlow/ExplicitStopDropsLastOwner") {
+	auto receiver = makeReference<ReceiverState>();
+	auto pool = CoroThreadPool::createThreadPool();
+	pool->addThread(new TestReceiver(receiver));
+	Promise<Void> gate;
+	auto active = postAction(pool, [input = gate.getFuture()] { waitFor(input); });
+	co_await active->onStarted();
+	auto queued = makeReference<ActionState>();
+	pool->post(new DropPoolOnCancelAction(queued, pool));
+
+	// The queued action keeps this pointer alive until stop() begins canceling it.
+	IThreadPool* poolToStop = pool.getPtr();
+	pool.clear();
+	auto stopped = poolToStop->stop();
+	queued->assertCancelled();
+	ASSERT(!stopped.isReady());
+	ASSERT_EQ(active->getCancelCount(), 0);
+	ASSERT(!active->onCompleted().isReady());
+	ASSERT_EQ(receiver->getDestroyCount(), 0);
+
+	gate.send(Void());
+	co_await assertActionCompleted(active);
+	co_await queued->onDestroyed();
+	co_await stopped;
+	co_await receiver->onDestroyed();
 	ASSERT_EQ(receiver->getInitCount(), 1);
 	ASSERT_EQ(receiver->getDestroyCount(), 1);
 }

--- a/fdbserver/coroimpl/CoroFlow.cpp
+++ b/fdbserver/coroimpl/CoroFlow.cpp
@@ -83,7 +83,7 @@ struct Coroutine /*: IThreadlike*/ {
 	}
 
 protected:
-	static Future<Void> switcher(Coroutine* self, Uncancellable = Uncancellable()) {
+	static coro::DetachedCoroutine switcher(Coroutine* self) {
 		std::shared_ptr<bool> alive = self->alive;
 		while (*alive && *self->coro) {
 			try {
@@ -235,7 +235,7 @@ public:
 		pool->allStopped.add(w->stopped.getFuture());
 		startWorker(w);
 	}
-	static Future<Void> startWorker(Worker* w, Uncancellable = Uncancellable()) {
+	static coro::DetachedCoroutine startWorker(Worker* w) {
 		// We want to make sure that coroutines are always started after Net2::run() is called, so the main coroutine is
 		// initialized.
 		co_await delay(0, g_network->getCurrentTask());

--- a/fdbserver/coroimpl/CoroFlow.cpp
+++ b/fdbserver/coroimpl/CoroFlow.cpp
@@ -261,8 +261,9 @@ public:
 			pool->idle.pop_back();
 			pool->queueLock.leave();
 			c->unblock();
-		} else
+		} else {
 			pool->queueLock.leave();
+		}
 	}
 	Future<Void> stop(Error const& e) override {
 		// User cancellation callbacks can release the last owner, except during implicit destruction itself.
@@ -307,7 +308,7 @@ public:
 	void delref() override { ReferenceCounted<WorkPool>::delref(); }
 };
 
-typedef WorkPool<Coroutine, ThreadUnsafeSpinLock, true> CoroPool;
+using CoroPool = WorkPool<Coroutine, ThreadUnsafeSpinLock, true>;
 
 void CoroThreadPool::waitFor(Future<Void> what) {
 	ASSERT(current_coro != nullptr);

--- a/fdbserver/coroimpl/CoroFlow.cpp
+++ b/fdbserver/coroimpl/CoroFlow.cpp
@@ -20,6 +20,7 @@
 
 #include "fdbserver/CoroFlow.h"
 #include "flow/ActorCollection.h"
+#include "flow/CoroUtils.h"
 #include "flow/TDMetric.h"
 #include "fdbrpc/simulator.h"
 #include "fdbrpc/SimulatorProcessInfo.h"
@@ -197,13 +198,15 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 	};
 
 	Reference<Pool> pool;
-	Future<Void> m_stopOnError; // must be last, because its cancellation calls stop()!
 	Error error;
+	bool destroying{ false };
+	Promise<Void> stopRequested;
+	Future<Void> m_stopOnError; // Cancel before releasing pool; cancellation performs implicit shutdown.
 
 	Future<Void> stopOnError(WorkPool* w) {
 		try {
-			co_await w->getError();
-			ASSERT(false);
+			auto result = co_await race(w->getError(), w->stopRequested.getFuture());
+			ASSERT(result.index() == 1);
 		} catch (Error& e) {
 			w->stop(e);
 		}
@@ -218,6 +221,7 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 
 public:
 	WorkPool() : pool(new Pool) { m_stopOnError = stopOnError(this); }
+	~WorkPool() override { destroying = true; }
 
 	Future<Void> getError() const override { return pool->anyError.getResult(); }
 	void addThread(IThreadPoolReceiver* userData, const char*) override {
@@ -251,6 +255,11 @@ public:
 			pool->queueLock.leave();
 	}
 	Future<Void> stop(Error const& e) override {
+		// User cancellation callbacks can release the last owner, except during implicit destruction itself.
+		Reference<WorkPool> keepAlive;
+		if (!destroying) {
+			keepAlive = Reference<WorkPool>::addRef(this);
+		}
 		if (error.code() == invalid_error_code) {
 			error = e;
 		}
@@ -275,6 +284,10 @@ public:
 		for (int i = 0; i < idle.size(); i++)
 			idle[i]->unblock();
 
+		// Keep the cancellation fallback if synchronous cleanup throws; finish before stop waiters can release us.
+		if (stopRequested.canBeSet()) {
+			stopRequested.send(Void());
+		}
 		pool->allStopped.add(Void());
 
 		return pool->allStopped.getResult();

--- a/fdbserver/coroimpl/CoroFlow.cpp
+++ b/fdbserver/coroimpl/CoroFlow.cpp
@@ -201,7 +201,7 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 	Error error;
 	bool destroying{ false };
 	Promise<Void> stopRequested;
-	Future<Void> m_stopOnError; // Cancel before releasing pool; cancellation performs implicit shutdown.
+	Future<Void> m_stopOnError; // Destroy before the shutdown signal and pool.
 
 	Future<Void> stopOnError(WorkPool* w) {
 		try {
@@ -209,6 +209,10 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 			ASSERT(result.index() == 1);
 		} catch (Error& e) {
 			w->stop(e);
+			co_return;
+		}
+		if (w->destroying) {
+			w->stop(actor_cancelled());
 		}
 	}
 
@@ -221,7 +225,13 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 
 public:
 	WorkPool() : pool(new Pool) { m_stopOnError = stopOnError(this); }
-	~WorkPool() override { destroying = true; }
+	~WorkPool() override {
+		destroying = true;
+		// Run implicit stop inside the watcher's exception boundary, not this noexcept destructor.
+		if (stopRequested.canBeSet()) {
+			stopRequested.send(Void());
+		}
+	}
 
 	Future<Void> getError() const override { return pool->anyError.getResult(); }
 	void addThread(IThreadPoolReceiver* userData, const char*) override {
@@ -284,7 +294,7 @@ public:
 		for (int i = 0; i < idle.size(); i++)
 			idle[i]->unblock();
 
-		// Keep the cancellation fallback if synchronous cleanup throws; finish before stop waiters can release us.
+		// Keep implicit shutdown pending if synchronous cleanup throws; finish before stop waiters can release us.
 		if (stopRequested.canBeSet()) {
 			stopRequested.send(Void());
 		}

--- a/fdbserver/coroimpl/CoroFlow.cpp
+++ b/fdbserver/coroimpl/CoroFlow.cpp
@@ -1,5 +1,5 @@
 /*
- * CoroFlowCoro.actor.cpp
+ * CoroFlow.cpp
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -20,21 +20,23 @@
 
 #include "fdbserver/CoroFlow.h"
 #include "flow/ActorCollection.h"
-#include "Coro.h"
 #include "flow/TDMetric.h"
 #include "fdbrpc/simulator.h"
 #include "fdbrpc/SimulatorProcessInfo.h"
-#include "flow/actorcompiler.h" // has to be last include
+#include <boost/coroutine2/all.hpp>
+#include <boost/coroutine2/coroutine.hpp>
+#include <functional>
+#include "flow/flow.h"
+#include "flow/network.h"
 
-// Old libcoroutine based implementation. Used on Windows until CI has
-// boost context installed
+using coro_t = boost::coroutines2::coroutine<Future<Void>>;
 
-Coro *current_coro = 0, *main_coro = 0;
-Coro* swapCoro(Coro* n) {
-	Coro* t = current_coro;
-	current_coro = n;
-	return t;
-}
+// Coro *current_coro = 0, *main_coro = 0;
+// Coro* swapCoro( Coro* n ) {
+// 	Coro* t = current_coro;
+// 	current_coro = n;
+// 	return t;
+// }
 
 /*struct IThreadlike {
 public:
@@ -48,27 +50,57 @@ protected:
 destroyed.
 };*/
 
-struct Coroutine /*: IThreadlike*/ {
-	Coroutine() {
-		coro = Coro_new();
-		if (coro == nullptr)
-			platform::outOfMemory();
-	}
+struct Coroutine;
+Coroutine* current_coro;
 
-	~Coroutine() { Coro_free(coro); }
+struct Coroutine /*: IThreadlike*/ {
+	Coroutine() = default;
+	~Coroutine() { *alive = false; }
+
+	static constexpr auto kStackSize = 256 * (1 << 10);
 
 	void start() {
-		int result = Coro_startCoro_(swapCoro(coro), coro, this, &entry);
-		if (result == ENOMEM)
-			platform::outOfMemory();
+		coro.reset(new coro_t::pull_type(boost::coroutines2::fixedsize_stack(kStackSize),
+		                                 [this](coro_t::push_type& sink) { entry(sink); }));
+		switcher(this);
 	}
 
 	void unblock() {
 		// Coro_switchTo_( swapCoro(coro), coro );
-		blocked.send(Void());
+
+		// Copy blocked before calling send, since the call to send might destroy it.
+		auto b = blocked;
+		b.send(Void());
+	}
+
+	void waitFor(Future<Void> const& what) {
+		ASSERT(current_coro == this);
+		current_coro = nullptr;
+		(*sink)(what); // Pass control back to the switcher coroutine
+		ASSERT(what.isReady());
+		current_coro = this;
 	}
 
 protected:
+	static Future<Void> switcher(Coroutine* self, Uncancellable = Uncancellable()) {
+		std::shared_ptr<bool> alive = self->alive;
+		while (*alive && *self->coro) {
+			try {
+				co_await self->coro->get();
+			} catch (Error& e) {
+				// We just want to transfer control back to the coroutine. The coroutine will handle the error.
+			}
+			(*self->coro)(); // Transfer control to the coroutine. This call "returns" after waitFor is called.
+			co_await delay(0, g_network->getCurrentTask());
+		}
+	}
+
+	void entry(coro_t::push_type& sink) {
+		current_coro = this;
+		this->sink = &sink;
+		run();
+	}
+
 	void block() {
 		// Coro_switchTo_( swapCoro(main_coro), main_coro );
 		blocked = Promise<Void>();
@@ -81,16 +113,10 @@ protected:
 	virtual void run() = 0;
 
 private:
-	void wrapRun() {
-		run();
-		Coro_switchTo_(swapCoro(main_coro), main_coro);
-		// block();
-	}
-
-	static void entry(void* _this) { ((Coroutine*)_this)->wrapRun(); }
-
-	Coro* coro;
+	coro_t::push_type* sink;
 	Promise<Void> blocked;
+	std::shared_ptr<bool> alive{ std::make_shared<bool>(true) };
+	std::unique_ptr<coro_t::pull_type> coro;
 };
 
 template <class Threadlike, class Mutex, bool IS_CORO>
@@ -112,11 +138,10 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 				delete workers[c];
 		}
 
-		ACTOR Future<Void> holdRefUntilStopped(Pool* p) {
+		Future<Void> holdRefUntilStopped(Pool* p) {
 			p->addref();
-			wait(p->allStopped.getResult());
+			co_await p->allStopped.getResult();
 			p->delref();
-			return Void();
 		}
 	};
 
@@ -175,14 +200,13 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 	Future<Void> m_stopOnError; // must be last, because its cancellation calls stop()!
 	Error error;
 
-	ACTOR Future<Void> stopOnError(WorkPool* w) {
+	Future<Void> stopOnError(WorkPool* w) {
 		try {
-			wait(w->getError());
+			co_await w->getError();
 			ASSERT(false);
 		} catch (Error& e) {
 			w->stop(e);
 		}
-		return Void();
 	}
 
 	void checkError() {
@@ -207,10 +231,10 @@ public:
 		pool->allStopped.add(w->stopped.getFuture());
 		startWorker(w);
 	}
-	ACTOR static void startWorker(Worker* w) {
+	static Future<Void> startWorker(Worker* w, Uncancellable = Uncancellable()) {
 		// We want to make sure that coroutines are always started after Net2::run() is called, so the main coroutine is
 		// initialized.
-		wait(delay(0, g_network->getCurrentTask()));
+		co_await delay(0, g_network->getCurrentTask());
 		w->start();
 	}
 	void post(PThreadAction action) override {
@@ -260,44 +284,19 @@ public:
 	void delref() override { ReferenceCounted<WorkPool>::delref(); }
 };
 
-using CoroPool = WorkPool<Coroutine, ThreadUnsafeSpinLock, true>;
-
-ACTOR void coroSwitcher(Future<Void> what, TaskPriority taskID, Coro* coro) {
-	try {
-		// state double t = now();
-		wait(what);
-		// if (g_network->isSimulated() && g_simulator->getCurrentProcess()->rebooting && now()!=t)
-		//	TraceEvent("NonzeroWaitDuringReboot").detail("TaskID", taskID).detail("Elapsed", now()-t).backtrace("Flow");
-	} catch (Error&) {
-	}
-	wait(delay(0, taskID));
-	Coro_switchTo_(swapCoro(coro), coro);
-}
+typedef WorkPool<Coroutine, ThreadUnsafeSpinLock, true> CoroPool;
 
 void CoroThreadPool::waitFor(Future<Void> what) {
-	ASSERT(current_coro != main_coro);
+	ASSERT(current_coro != nullptr);
 	if (what.isReady())
 		return;
 	// double t = now();
-	coroSwitcher(what, g_network->getCurrentTask(), current_coro);
-	Coro_switchTo_(swapCoro(main_coro), main_coro);
-	// if (g_network->isSimulated() && g_simulator->getCurrentProcess()->rebooting && now()!=t)
-	//	TraceEvent("NonzeroWaitDuringReboot").detail("TaskID", currentTaskID).detail("Elapsed",
-	// now()-t).backtrace("Coro");
-	ASSERT(what.isReady());
+	current_coro->waitFor(what);
+	what.get(); // Throw if |what| is an error
 }
 
 // Right After INet2::run
-void CoroThreadPool::init() {
-	if (!current_coro) {
-		current_coro = main_coro = Coro_new();
-		if (main_coro == nullptr)
-			platform::outOfMemory();
-
-		Coro_initializeMainCoro(main_coro);
-		// printf("Main thread: %d bytes stack presumed available\n", Coro_bytesLeftOnStack(current_coro));
-	}
-}
+void CoroThreadPool::init() {}
 
 Reference<IThreadPool> CoroThreadPool::createThreadPool() {
 	return Reference<IThreadPool>(new CoroPool);

--- a/fdbserver/coroimpl/CoroFlowCoro.cpp
+++ b/fdbserver/coroimpl/CoroFlowCoro.cpp
@@ -234,8 +234,9 @@ public:
 			pool->idle.pop_back();
 			pool->queueLock.leave();
 			c->unblock();
-		} else
+		} else {
 			pool->queueLock.leave();
+		}
 	}
 	Future<Void> stop(Error const& e) override {
 		// User cancellation callbacks can release the last owner, except during implicit destruction itself.

--- a/fdbserver/coroimpl/CoroFlowCoro.cpp
+++ b/fdbserver/coroimpl/CoroFlowCoro.cpp
@@ -208,7 +208,7 @@ public:
 		pool->allStopped.add(w->stopped.getFuture());
 		startWorker(w);
 	}
-	static Future<Void> startWorker(Worker* w, Uncancellable = Uncancellable()) {
+	static coro::DetachedCoroutine startWorker(Worker* w) {
 		// We want to make sure that coroutines are always started after Net2::run() is called, so the main coroutine is
 		// initialized.
 		co_await delay(0, g_network->getCurrentTask());
@@ -272,7 +272,7 @@ public:
 
 using CoroPool = WorkPool<Coroutine, ThreadUnsafeSpinLock, true>;
 
-Future<Void> coroSwitcher(Future<Void> what, TaskPriority taskID, Coro* coro, Uncancellable = Uncancellable()) {
+coro::DetachedCoroutine coroSwitcher(Future<Void> what, TaskPriority taskID, Coro* coro) {
 	try {
 		// state double t = now();
 		co_await what;

--- a/fdbserver/coroimpl/CoroFlowCoro.cpp
+++ b/fdbserver/coroimpl/CoroFlowCoro.cpp
@@ -1,5 +1,5 @@
 /*
- * CoroFlow.actor.cpp
+ * CoroFlowCoro.cpp
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -20,24 +20,20 @@
 
 #include "fdbserver/CoroFlow.h"
 #include "flow/ActorCollection.h"
+#include "Coro.h"
 #include "flow/TDMetric.h"
 #include "fdbrpc/simulator.h"
 #include "fdbrpc/SimulatorProcessInfo.h"
-#include <boost/coroutine2/all.hpp>
-#include <boost/coroutine2/coroutine.hpp>
-#include <functional>
-#include "flow/flow.h"
-#include "flow/network.h"
-#include "flow/actorcompiler.h" // has to be last include
 
-using coro_t = boost::coroutines2::coroutine<Future<Void>>;
+// Old libcoroutine based implementation. Used on Windows until CI has
+// boost context installed
 
-// Coro *current_coro = 0, *main_coro = 0;
-// Coro* swapCoro( Coro* n ) {
-// 	Coro* t = current_coro;
-// 	current_coro = n;
-// 	return t;
-// }
+Coro *current_coro = 0, *main_coro = 0;
+Coro* swapCoro(Coro* n) {
+	Coro* t = current_coro;
+	current_coro = n;
+	return t;
+}
 
 /*struct IThreadlike {
 public:
@@ -51,57 +47,27 @@ protected:
 destroyed.
 };*/
 
-struct Coroutine;
-Coroutine* current_coro;
-
 struct Coroutine /*: IThreadlike*/ {
-	Coroutine() = default;
-	~Coroutine() { *alive = false; }
+	Coroutine() {
+		coro = Coro_new();
+		if (coro == nullptr)
+			platform::outOfMemory();
+	}
 
-	static constexpr auto kStackSize = 256 * (1 << 10);
+	~Coroutine() { Coro_free(coro); }
 
 	void start() {
-		coro.reset(new coro_t::pull_type(boost::coroutines2::fixedsize_stack(kStackSize),
-		                                 [this](coro_t::push_type& sink) { entry(sink); }));
-		switcher(this);
+		int result = Coro_startCoro_(swapCoro(coro), coro, this, &entry);
+		if (result == ENOMEM)
+			platform::outOfMemory();
 	}
 
 	void unblock() {
 		// Coro_switchTo_( swapCoro(coro), coro );
-
-		// Copy blocked before calling send, since the call to send might destroy it.
-		auto b = blocked;
-		b.send(Void());
-	}
-
-	void waitFor(Future<Void> const& what) {
-		ASSERT(current_coro == this);
-		current_coro = nullptr;
-		(*sink)(what); // Pass control back to the switcher actor
-		ASSERT(what.isReady());
-		current_coro = this;
+		blocked.send(Void());
 	}
 
 protected:
-	ACTOR static void switcher(Coroutine* self) {
-		state std::shared_ptr<bool> alive = self->alive;
-		while (*alive && *self->coro) {
-			try {
-				wait(self->coro->get());
-			} catch (Error& e) {
-				// We just want to transfer control back to the coroutine. The coroutine will handle the error.
-			}
-			(*self->coro)(); // Transfer control to the coroutine. This call "returns" after waitFor is called.
-			wait(delay(0, g_network->getCurrentTask()));
-		}
-	}
-
-	void entry(coro_t::push_type& sink) {
-		current_coro = this;
-		this->sink = &sink;
-		run();
-	}
-
 	void block() {
 		// Coro_switchTo_( swapCoro(main_coro), main_coro );
 		blocked = Promise<Void>();
@@ -114,10 +80,16 @@ protected:
 	virtual void run() = 0;
 
 private:
-	coro_t::push_type* sink;
+	void wrapRun() {
+		run();
+		Coro_switchTo_(swapCoro(main_coro), main_coro);
+		// block();
+	}
+
+	static void entry(void* _this) { ((Coroutine*)_this)->wrapRun(); }
+
+	Coro* coro;
 	Promise<Void> blocked;
-	std::shared_ptr<bool> alive{ std::make_shared<bool>(true) };
-	std::unique_ptr<coro_t::pull_type> coro;
 };
 
 template <class Threadlike, class Mutex, bool IS_CORO>
@@ -139,11 +111,10 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 				delete workers[c];
 		}
 
-		ACTOR Future<Void> holdRefUntilStopped(Pool* p) {
+		Future<Void> holdRefUntilStopped(Pool* p) {
 			p->addref();
-			wait(p->allStopped.getResult());
+			co_await p->allStopped.getResult();
 			p->delref();
-			return Void();
 		}
 	};
 
@@ -202,14 +173,13 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 	Future<Void> m_stopOnError; // must be last, because its cancellation calls stop()!
 	Error error;
 
-	ACTOR Future<Void> stopOnError(WorkPool* w) {
+	Future<Void> stopOnError(WorkPool* w) {
 		try {
-			wait(w->getError());
+			co_await w->getError();
 			ASSERT(false);
 		} catch (Error& e) {
 			w->stop(e);
 		}
-		return Void();
 	}
 
 	void checkError() {
@@ -234,10 +204,10 @@ public:
 		pool->allStopped.add(w->stopped.getFuture());
 		startWorker(w);
 	}
-	ACTOR static void startWorker(Worker* w) {
+	static Future<Void> startWorker(Worker* w, Uncancellable = Uncancellable()) {
 		// We want to make sure that coroutines are always started after Net2::run() is called, so the main coroutine is
 		// initialized.
-		wait(delay(0, g_network->getCurrentTask()));
+		co_await delay(0, g_network->getCurrentTask());
 		w->start();
 	}
 	void post(PThreadAction action) override {
@@ -287,19 +257,44 @@ public:
 	void delref() override { ReferenceCounted<WorkPool>::delref(); }
 };
 
-typedef WorkPool<Coroutine, ThreadUnsafeSpinLock, true> CoroPool;
+using CoroPool = WorkPool<Coroutine, ThreadUnsafeSpinLock, true>;
+
+Future<Void> coroSwitcher(Future<Void> what, TaskPriority taskID, Coro* coro, Uncancellable = Uncancellable()) {
+	try {
+		// state double t = now();
+		co_await what;
+		// if (g_network->isSimulated() && g_simulator->getCurrentProcess()->rebooting && now()!=t)
+		//	TraceEvent("NonzeroWaitDuringReboot").detail("TaskID", taskID).detail("Elapsed", now()-t).backtrace("Flow");
+	} catch (Error&) {
+	}
+	co_await delay(0, taskID);
+	Coro_switchTo_(swapCoro(coro), coro);
+}
 
 void CoroThreadPool::waitFor(Future<Void> what) {
-	ASSERT(current_coro != nullptr);
+	ASSERT(current_coro != main_coro);
 	if (what.isReady())
 		return;
 	// double t = now();
-	current_coro->waitFor(what);
-	what.get(); // Throw if |what| is an error
+	coroSwitcher(what, g_network->getCurrentTask(), current_coro);
+	Coro_switchTo_(swapCoro(main_coro), main_coro);
+	// if (g_network->isSimulated() && g_simulator->getCurrentProcess()->rebooting && now()!=t)
+	//	TraceEvent("NonzeroWaitDuringReboot").detail("TaskID", currentTaskID).detail("Elapsed",
+	// now()-t).backtrace("Coro");
+	ASSERT(what.isReady());
 }
 
 // Right After INet2::run
-void CoroThreadPool::init() {}
+void CoroThreadPool::init() {
+	if (!current_coro) {
+		current_coro = main_coro = Coro_new();
+		if (main_coro == nullptr)
+			platform::outOfMemory();
+
+		Coro_initializeMainCoro(main_coro);
+		// printf("Main thread: %d bytes stack presumed available\n", Coro_bytesLeftOnStack(current_coro));
+	}
+}
 
 Reference<IThreadPool> CoroThreadPool::createThreadPool() {
 	return Reference<IThreadPool>(new CoroPool);

--- a/fdbserver/coroimpl/CoroFlowCoro.cpp
+++ b/fdbserver/coroimpl/CoroFlowCoro.cpp
@@ -174,7 +174,7 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 	Error error;
 	bool destroying{ false };
 	Promise<Void> stopRequested;
-	Future<Void> m_stopOnError; // Cancel before releasing pool; cancellation performs implicit shutdown.
+	Future<Void> m_stopOnError; // Destroy before the shutdown signal and pool.
 
 	Future<Void> stopOnError(WorkPool* w) {
 		try {
@@ -182,6 +182,10 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 			ASSERT(result.index() == 1);
 		} catch (Error& e) {
 			w->stop(e);
+			co_return;
+		}
+		if (w->destroying) {
+			w->stop(actor_cancelled());
 		}
 	}
 
@@ -194,7 +198,13 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 
 public:
 	WorkPool() : pool(new Pool) { m_stopOnError = stopOnError(this); }
-	~WorkPool() override { destroying = true; }
+	~WorkPool() override {
+		destroying = true;
+		// Run implicit stop inside the watcher's exception boundary, not this noexcept destructor.
+		if (stopRequested.canBeSet()) {
+			stopRequested.send(Void());
+		}
+	}
 
 	Future<Void> getError() const override { return pool->anyError.getResult(); }
 	void addThread(IThreadPoolReceiver* userData, const char*) override {
@@ -257,7 +267,7 @@ public:
 		for (int i = 0; i < idle.size(); i++)
 			idle[i]->unblock();
 
-		// Keep the cancellation fallback if synchronous cleanup throws; finish before stop waiters can release us.
+		// Keep implicit shutdown pending if synchronous cleanup throws; finish before stop waiters can release us.
 		if (stopRequested.canBeSet()) {
 			stopRequested.send(Void());
 		}

--- a/fdbserver/coroimpl/CoroFlowCoro.cpp
+++ b/fdbserver/coroimpl/CoroFlowCoro.cpp
@@ -20,6 +20,7 @@
 
 #include "fdbserver/CoroFlow.h"
 #include "flow/ActorCollection.h"
+#include "flow/CoroUtils.h"
 #include "Coro.h"
 #include "flow/TDMetric.h"
 #include "fdbrpc/simulator.h"
@@ -170,13 +171,15 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 	};
 
 	Reference<Pool> pool;
-	Future<Void> m_stopOnError; // must be last, because its cancellation calls stop()!
 	Error error;
+	bool destroying{ false };
+	Promise<Void> stopRequested;
+	Future<Void> m_stopOnError; // Cancel before releasing pool; cancellation performs implicit shutdown.
 
 	Future<Void> stopOnError(WorkPool* w) {
 		try {
-			co_await w->getError();
-			ASSERT(false);
+			auto result = co_await race(w->getError(), w->stopRequested.getFuture());
+			ASSERT(result.index() == 1);
 		} catch (Error& e) {
 			w->stop(e);
 		}
@@ -191,6 +194,7 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 
 public:
 	WorkPool() : pool(new Pool) { m_stopOnError = stopOnError(this); }
+	~WorkPool() override { destroying = true; }
 
 	Future<Void> getError() const override { return pool->anyError.getResult(); }
 	void addThread(IThreadPoolReceiver* userData, const char*) override {
@@ -224,6 +228,11 @@ public:
 			pool->queueLock.leave();
 	}
 	Future<Void> stop(Error const& e) override {
+		// User cancellation callbacks can release the last owner, except during implicit destruction itself.
+		Reference<WorkPool> keepAlive;
+		if (!destroying) {
+			keepAlive = Reference<WorkPool>::addRef(this);
+		}
 		if (error.code() == invalid_error_code) {
 			error = e;
 		}
@@ -248,6 +257,10 @@ public:
 		for (int i = 0; i < idle.size(); i++)
 			idle[i]->unblock();
 
+		// Keep the cancellation fallback if synchronous cleanup throws; finish before stop waiters can release us.
+		if (stopRequested.canBeSet()) {
+			stopRequested.send(Void());
+		}
 		pool->allStopped.add(Void());
 
 		return pool->allStopped.getResult();

--- a/fdbserver/workloads/UnitTests.cpp
+++ b/fdbserver/workloads/UnitTests.cpp
@@ -25,6 +25,7 @@ void forceLinkIndexedSetTests();
 void forceLinkDequeTests();
 void forceLinkFlowTests();
 void forceLinkCoroTests();
+void forceLinkCoroFlowTests();
 void forceLinkMemcpyTests();
 void forceLinkStreamCipherTests();
 void forceLinkSimExternalConnectionTests();
@@ -106,6 +107,7 @@ struct UnitTestWorkload : TestWorkload {
 		forceLinkDequeTests();
 		forceLinkFlowTests();
 		forceLinkCoroTests();
+		forceLinkCoroFlowTests();
 		forceLinkMemcpyTests();
 		forceLinkStreamCipherTests();
 		forceLinkSimExternalConnectionTests();


### PR DESCRIPTION
## Summary

Convert the Boost and libcoro CoroFlow implementations to regular `.cpp` files using standard C++ coroutines. Preserve the public thread-pool interface, task priorities, and stack-switch scheduling boundaries.

The mechanical conversion exposed a pool-lifecycle slowdown. Complete the error watcher through a private shutdown signal, retain the pool across cancellation callbacks that may release its last owner, and keep implicit cleanup inside the coroutine's exception boundary. Use detached coroutines only for discarded fire-and-forget scheduling results. Failed explicit cleanup retains its existing implicit-cleanup retry.

Add focused lifecycle/error tests and a production-linked `fdbserver_coroflow_bench` target.

## Validation

- All 11 `/fdbserver/CoroFlow/` tests pass on both backends in Net2 and Sim2. Across the original implementation and four incremental coroutine variants, all 440 test executions pass.
- SQLite-backed `CycleTest.toml` passes on both optimized backends with seed `20260818`, BUGGIFY, and fault injection enabled.
- Formatting and `git diff --check` pass.

## Performance

Compared with the actor implementation at the branch's [public base](https://github.com/apple/foundationdb/commit/368414496b3768aa2b4f09165bfd495dde781af9). Measured on Linux x86-64 with Clang 19.1.5, Release `-O3`, static libc++, LLD, and jemalloc; sanitizers and profiling disabled. The same `^coroflow_` benchmark harness was used for all variants in forward/reverse order on one pinned CPU, with nine repetitions per invocation and a one-second minimum for the main benchmarks.

| Backend | Operation | Original actors | Mechanical conversion | Optimized |
|---|---|---:|---:|---:|
| libcoro | Start/stop | 7.650 µs | 9.390 µs | 7.645 µs |
| libcoro | Suspended wait | 1.663 µs | 1.698 µs | 1.687 µs |
| Boost | Start/stop | 4.652 µs | 5.940 µs | 4.486 µs |
| Boost | Suspended wait | 262.9 ns | 246.9 ns | 239.2 ns |

Ready waits are effectively unchanged. The large start/stop regression is removed in this measurement, but the change is not performance-neutral everywhere: libcoro suspended waits remain 1.41% slower, and empty-pool create/drop costs approximately 153 ns more on libcoro and 247 ns more on Boost. These are focused microbenchmark results, not an end-to-end throughput or statistical-equivalence claim.
