### PR TITLE
Move proxy load metric decoding into `fdbclient`

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -64,6 +64,7 @@
 #include "fdbclient/CommitProxyInterface.h"
 #include "fdbclient/MonitorLeader.h"
 #include "fdbclient/MutationList.h"
+#include "fdbclient/ProxyLoadBalanceMetrics.h"
 #include "fdbclient/ReadYourWrites.h"
 #include "fdbclient/SpecialKeySpace.h"
 #include "fdbclient/StorageServerInterface.h"
@@ -89,6 +90,7 @@
 #include "flow/genericactors.h"
 #include "flow/Knobs.h"
 #include "flow/Platform.h"
+#include "flow/ScopeExit.h"
 #include "flow/SystemMonitor.h"
 #include "flow/TLSConfig.h"
 #include "fdbclient/Tracing.h"
@@ -297,7 +299,7 @@ void DatabaseContext::setOption(FDBDatabaseOptions::Option option, Optional<Stri
 			if (clientInfo->get().commitProxies.size())
 				commitProxies = makeReference<CommitProxyInfo>(clientInfo->get().commitProxies);
 			if (clientInfo->get().grvProxies.size())
-				grvProxies = makeReference<GrvProxyInfo>(clientInfo->get().grvProxies, BalanceOnRequests::True);
+				grvProxies = makeReference<GrvProxyInfo>(clientInfo->get().grvProxies);
 			server_interf.clear();
 			locationCache.insert(allKeys, Reference<LocationInfo>());
 			break;
@@ -313,7 +315,7 @@ void DatabaseContext::setOption(FDBDatabaseOptions::Option option, Optional<Stri
 			if (clientInfo->get().commitProxies.size())
 				commitProxies = makeReference<CommitProxyInfo>(clientInfo->get().commitProxies);
 			if (clientInfo->get().grvProxies.size())
-				grvProxies = makeReference<GrvProxyInfo>(clientInfo->get().grvProxies, BalanceOnRequests::True);
+				grvProxies = makeReference<GrvProxyInfo>(clientInfo->get().grvProxies);
 			server_interf.clear();
 			locationCache.insert(allKeys, Reference<LocationInfo>());
 			break;
@@ -938,13 +940,79 @@ void DatabaseContext::updateProxies() {
 		commitProxyProvisional = clientInfo->get().commitProxies[0].provisional;
 	}
 	if (clientInfo->get().grvProxies.size()) {
-		grvProxies = makeReference<GrvProxyInfo>(clientInfo->get().grvProxies, BalanceOnRequests::True);
+		grvProxies = makeReference<GrvProxyInfo>(clientInfo->get().grvProxies);
 		grvProxyProvisional = clientInfo->get().grvProxies[0].provisional;
 	}
 	if (clientInfo->get().commitProxies.size() && clientInfo->get().grvProxies.size()) {
 		ASSERT(commitProxyProvisional == grvProxyProvisional);
 		proxyProvisional = commitProxyProvisional;
 	}
+}
+
+TEST_CASE("/fdbclient/NativeAPI/proxyLoadBalanceMetrics") {
+	FlowKnobs knobs(Randomize::False, IsSimulated::False);
+	knobs.BASIC_LOAD_BALANCE_COMPUTE_PRECISION = 10000;
+	knobs.BASIC_LOAD_BALANCE_MIN_REQUESTS = 20;
+	knobs.BASIC_LOAD_BALANCE_MIN_CPU = 0.05;
+	knobs.BASIC_LOAD_BALANCE_MAX_CHANGE = 0.10;
+	knobs.BASIC_LOAD_BALANCE_MAX_PROB = 2.0;
+	const FlowKnobs* previousKnobs = FLOW_KNOBS;
+	ScopeExit restoreKnobs([previousKnobs]() { FLOW_KNOBS = previousKnobs; });
+	FLOW_KNOBS = &knobs;
+
+	// Keep this synchronous so the model updaters are cancelled before the global knobs are restored.
+	auto grv = makeReference<GrvProxyInfo>(std::vector<GrvProxyInterface>(2));
+	auto cpu = makeReference<CommitProxyInfo>(std::vector<CommitProxyInterface>(2));
+	auto update = [](const auto& model, int first, int second) {
+		model->updateRecent(0, first);
+		model->updateRecent(1, second);
+		model->updateProbabilities();
+	};
+	auto checkSelections = [](const auto& model, double firstProbability) {
+		for (int i = 0; i < 1024; ++i) {
+			// Match DeterministicRandom::random01 without reseeding or consuming an extra draw.
+			double next = deterministicRandom()->peek() / double(std::numeric_limits<uint64_t>::max());
+			int chosen = model->getBest();
+			// Ignore normalization roundoff at the expected selection boundary.
+			if (std::abs(next - firstProbability) > 1e-12) {
+				ASSERT_EQ(chosen, next <= firstProbability ? 0 : 1);
+			}
+		}
+	};
+
+	const int precision = knobs.BASIC_LOAD_BALANCE_COMPUTE_PRECISION;
+	ASSERT_EQ(ProxyGrvMetric::decode(-1), 0);
+	ASSERT_EQ(ProxyCpuMetric::decode(-1), -1);
+	ASSERT_EQ(ProxyGrvMetric::decode(precision - 1), 0);
+	ASSERT_EQ(ProxyCpuMetric::decode(precision - 1), precision - 1);
+	ASSERT_EQ(ProxyGrvMetric::decode(precision), 1);
+	ASSERT_EQ(ProxyCpuMetric::decode(precision), 0);
+
+	update(grv, 80 * precision + 1000, 20 * precision + 9000);
+	update(cpu, 80 * precision + 1000, 20 * precision + 9000);
+	checkSelections(grv, 0.47);
+	checkSelections(cpu, 0.54);
+
+	update(grv, 19 * precision + 9000, 20 * precision + 1000);
+	update(cpu, 80 * precision + 999, 20 * precision);
+	checkSelections(grv, 0.47);
+	checkSelections(cpu, 0.54);
+
+	update(grv, 40 * precision, 0);
+	update(cpu, 1000, 0);
+	checkSelections(grv, 0.47 - 0.05);
+	checkSelections(cpu, 0.54 - 0.05);
+
+	grv->updateRecent(0, 31000);
+	grv->updateRecent(1, 19000);
+	cpu->updateRecent(0, 31000);
+	cpu->updateRecent(1, 19000);
+	knobs.BASIC_LOAD_BALANCE_COMPUTE_PRECISION = 1000;
+	grv->updateProbabilities();
+	cpu->updateProbabilities();
+	checkSelections(grv, 0.42 + (0.5 - 31.0 / 50.0) * 0.10);
+	checkSelections(cpu, 0.54 - 0.05);
+	return Void();
 }
 
 Reference<CommitProxyInfo> DatabaseContext::getCommitProxies(UseProvisionalProxies useProvisionalProxies) {

--- a/fdbclient/include/fdbclient/DatabaseContext.h
+++ b/fdbclient/include/fdbclient/DatabaseContext.h
@@ -37,6 +37,7 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/KeyRangeMap.h"
 #include "fdbclient/CommitProxyInterface.h"
+#include "fdbclient/ProxyLoadBalanceMetrics.h"
 #include "fdbclient/SpecialKeySpace.h"
 #include "fdbclient/VersionVector.h"
 #include "fdbrpc/QueueModel.h"
@@ -72,8 +73,8 @@ struct LocationInfo : MultiInterface<ReferencedInterface<StorageServerInterface>
 	Reference<Locations> locations() { return Reference<Locations>::addRef(this); }
 };
 
-using CommitProxyInfo = ModelInterface<CommitProxyInterface>;
-using GrvProxyInfo = ModelInterface<GrvProxyInterface>;
+using CommitProxyInfo = ModelInterface<CommitProxyInterface, ProxyCpuMetric>;
+using GrvProxyInfo = ModelInterface<GrvProxyInterface, ProxyGrvMetric>;
 
 class ClientTagThrottleData : NonCopyable {
 private:

--- a/fdbclient/include/fdbclient/ProxyLoadBalanceMetrics.h
+++ b/fdbclient/include/fdbclient/ProxyLoadBalanceMetrics.h
@@ -1,0 +1,54 @@
+/*
+ * ProxyLoadBalanceMetrics.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBCLIENT_PROXYLOADBALANCEMETRICS_H
+#define FDBCLIENT_PROXYLOADBALANCEMETRICS_H
+#pragma once
+
+#include "flow/Knobs.h"
+
+#include <cstddef>
+
+// Packed proxy feedback uses the quotient for recent transaction rate and the remainder for CPU busyness.
+// Preserve signed values and carries at the precision boundary.
+class ProxyCpuMetric {
+public:
+	static int decode(int processBusyTime) {
+		return processBusyTime % FLOW_KNOBS->BASIC_LOAD_BALANCE_COMPUTE_PRECISION;
+	}
+
+	static double minimumTotal(std::size_t alternativeCount) {
+		return FLOW_KNOBS->BASIC_LOAD_BALANCE_COMPUTE_PRECISION * FLOW_KNOBS->BASIC_LOAD_BALANCE_MIN_CPU *
+		       alternativeCount;
+	}
+};
+
+class ProxyGrvMetric {
+public:
+	static int decode(int processBusyTime) {
+		return processBusyTime / FLOW_KNOBS->BASIC_LOAD_BALANCE_COMPUTE_PRECISION;
+	}
+
+	static double minimumTotal(std::size_t alternativeCount) {
+		return FLOW_KNOBS->BASIC_LOAD_BALANCE_MIN_REQUESTS * alternativeCount;
+	}
+};
+
+#endif

--- a/fdbrpc/include/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/include/fdbrpc/LoadBalance.actor.h
@@ -652,8 +652,8 @@ Optional<BasicLoadBalancedReply> getBasicLoadBalancedReply(const void*);
 // If |alternativeChosen| is not null, then atMostOnce must be True, and if the returned future completes successfully
 // then *alternativeChosen will be the alternative to which the message was sent. *alternativeChosen must outlive the
 // returned future.
-ACTOR template <class Interface, class Request, class Multi, bool P>
-Future<REPLY_TYPE(Request)> basicLoadBalance(Reference<ModelInterface<Multi>> alternatives,
+ACTOR template <class Interface, class Request, class Multi, bool P, class Metric>
+Future<REPLY_TYPE(Request)> basicLoadBalance(Reference<ModelInterface<Multi, Metric>> alternatives,
                                              RequestStream<Request, P> Interface::* channel,
                                              Request request = Request(),
                                              TaskPriority taskID = TaskPriority::DefaultPromiseEndpoint,

--- a/fdbrpc/include/fdbrpc/MultiInterface.h
+++ b/fdbrpc/include/fdbrpc/MultiInterface.h
@@ -91,16 +91,12 @@ struct AlternativeInfo {
 	bool operator==(double const& r) const { return cumulativeProbability == r; }
 };
 
-FDB_BOOLEAN_PARAM(BalanceOnRequests);
-
-template <class T>
-class ModelInterface : public ReferenceCounted<ModelInterface<T>> {
+// Metric supplies static int decode(int) and static double minimumTotal(std::size_t).
+// Decoding at each update allows the policy to consult its current configuration.
+template <class T, class Metric>
+class ModelInterface : public ReferenceCounted<ModelInterface<T, Metric>> {
 public:
-	// If balanceOnRequests is true, the client will load balance based on the number of GRVs released by each proxy
-	// If balanceOnRequests is false, the client will load balance based on the CPU usage of each proxy
-	// Only requests which take from the GRV budget on the proxy should set balanceOnRequests to true
-	explicit ModelInterface(const std::vector<T>& v, BalanceOnRequests balanceOnRequests = BalanceOnRequests::False)
-	  : balanceOnRequests(balanceOnRequests) {
+	explicit ModelInterface(const std::vector<T>& v) {
 		for (int i = 0; i < v.size(); i++) {
 			alternatives.push_back(AlternativeInfo(v[i], 1.0 / v.size(), (i + 1.0) / v.size()));
 		}
@@ -126,24 +122,20 @@ public:
 	void updateProbabilities() {
 		double totalBusy = 0;
 		for (auto& it : alternatives) {
-			int busyMetric = balanceOnRequests ? it.processBusyTime / FLOW_KNOBS->BASIC_LOAD_BALANCE_COMPUTE_PRECISION
-			                                   : it.processBusyTime % FLOW_KNOBS->BASIC_LOAD_BALANCE_COMPUTE_PRECISION;
+			int busyMetric = Metric::decode(it.processBusyTime);
 			totalBusy += busyMetric;
 			if (now() - it.lastUpdate > FLOW_KNOBS->BASIC_LOAD_BALANCE_UPDATE_RATE / 2.0) {
 				return;
 			}
 		}
 
-		if ((balanceOnRequests && totalBusy < FLOW_KNOBS->BASIC_LOAD_BALANCE_MIN_REQUESTS * alternatives.size()) ||
-		    (!balanceOnRequests && totalBusy < FLOW_KNOBS->BASIC_LOAD_BALANCE_COMPUTE_PRECISION *
-		                                           FLOW_KNOBS->BASIC_LOAD_BALANCE_MIN_CPU * alternatives.size())) {
+		if (totalBusy < Metric::minimumTotal(alternatives.size())) {
 			return;
 		}
 
 		double totalProbability = 0;
 		for (auto& it : alternatives) {
-			int busyMetric = balanceOnRequests ? it.processBusyTime / FLOW_KNOBS->BASIC_LOAD_BALANCE_COMPUTE_PRECISION
-			                                   : it.processBusyTime % FLOW_KNOBS->BASIC_LOAD_BALANCE_COMPUTE_PRECISION;
+			int busyMetric = Metric::decode(it.processBusyTime);
 			it.probability +=
 			    (1.0 / alternatives.size() - (busyMetric / totalBusy)) * FLOW_KNOBS->BASIC_LOAD_BALANCE_MAX_CHANGE;
 			it.probability =
@@ -179,7 +171,6 @@ public:
 private:
 	std::vector<AlternativeInfo<T>> alternatives;
 	Future<Void> updater;
-	bool balanceOnRequests;
 };
 
 template <class T>
@@ -255,8 +246,8 @@ template <class Ar, class T>
 void load(Ar& ar, Reference<MultiInterface<T>>&) {
 	ASSERT(false);
 } //< required for Future<T>
-template <class Ar, class T>
-void load(Ar& ar, Reference<ModelInterface<T>>&) {
+template <class Ar, class T, class Metric>
+void load(Ar& ar, Reference<ModelInterface<T, Metric>>&) {
 	ASSERT(false);
 } //< required for Future<T>
 


### PR DESCRIPTION
## Summary

Follow up on #13180 by moving FoundationDB's GRV transaction-rate versus CPU interpretation of proxy load feedback out of `fdbrpc`.

- Require an explicit metric policy on `ModelInterface` and preserve it through `basicLoadBalance`.
- Define CPU and GRV metric policies in `fdbclient`, selected by `CommitProxyInfo` and `GrvProxyInfo`. Decode the packed value and read the minimum-load thresholds at probability-update time, as before.
- Keep the serialized `processBusyTime` field, server encoding, knob names/defaults, probability calculation, stale-sample behavior, retry logic, and production random draws unchanged.
- Add one behavioral test using the real proxy aliases. It checks weighted selection, minimum-load boundaries, signed/carry decoding, and live precision changes.

## Validation

- `fdbrpc_test`, `fdbclient_test`, and `fdbserver` compiled and linked with Clang, Release, and `USE_WERROR=ON`.
- Nine focused unit-test passes: the new proxy-metric test, existing load-balance hook tests, and TSS comparison coverage in normal and simulated modes, plus the new test through the full server unit-test runner.
- Standalone `fdbrpclinktest` built, linked, and exited successfully.
- Unchanged `tests/fast/CycleTest.toml` passed both `Clogged` and `Unclogged` with seed `424242`, BUGGIFY off, and fault injection on. Its trace confirmed GRV traffic and contained no severity-40 events.
