### PR TITLE
bindings/python: install python "build" pkg only if missing

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -136,8 +136,7 @@ if(NOT OPEN_FOR_IDE AND NOT USE_SANITIZER)
       if ! [ -f '${package_file}' ]; then
         exit 66
       fi
-      $<TARGET_FILE:Python3::Interpreter> -m venv ${PYPKG_TEST_DIR}
-      ${PYPKG_TEST_PY3} -m ensurepip   # probably not needed, but for consistency
+      ${Python3_EXECUTABLE} -m venv ${PYPKG_TEST_DIR}
       ${PYPKG_TEST_PY3} -m pip install '${package_file}'
       ${PYPKG_TEST_PY3} -c 'import fdb'
       ${PYPKG_TEST_PY3} -m pip install '${wheel_package_file}'

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -87,11 +87,28 @@ set(wheel_package_file ${CMAKE_BINARY_DIR}/packages/${wheel_file_name})
 # Build both source distribution and wheel
 # Note: foundationdb is a pure Python package (uses ctypes), so wheel is py3-none-any
 set(PYPKG_VENV_DIR "${CMAKE_BINARY_DIR}/pypkg-venv")
-set(PYPKG_PY3      "${PYPKG_VENV_DIR}/bin/python3")
+set(PYPKG_PY3       ${Python3_EXECUTABLE})
+execute_process(
+  COMMAND         ${PYPKG_PY3} -m build --version
+  RESULT_VARIABLE PY_BUILD_STATUS
+  OUTPUT_VARIABLE PY_BUILD_OUTPUT
+  ERROR_VARIABLE  PY_BUILD_OUTPUT
+)
+if(PY_BUILD_STATUS EQUAL 0)
+  message(STATUS "Found python ${PY_BUILD_OUTPUT}")
+else()
+  message(STATUS "Setting up python pkg build virtual environment")
+  execute_process(COMMAND ${Python3_EXECUTABLE} -m venv ${PYPKG_VENV_DIR} COMMAND_ERROR_IS_FATAL ANY)
+  find_program(
+    VENV_Python3_EXECUTABLE
+    NAMES python3 python3.exe python.exe
+    PATHS ${PYPKG_VENV_DIR}/Scripts ${PYPKG_VENV_DIR}/bin
+    REQUIRED NO_DEFAULT_PATH NO_CACHE
+    DOC "Checking Python3 executable in virtual environment")
+  set(PYPKG_PY3 ${VENV_Python3_EXECUTABLE})
+  execute_process(COMMAND "${PYPKG_PY3}" -m pip install build COMMAND_ERROR_IS_FATAL ANY)
+endif()
 add_custom_command(OUTPUT ${package_file} ${wheel_package_file}
-  COMMAND $<TARGET_FILE:Python3::Interpreter> -m venv "${PYPKG_VENV_DIR}"
-  COMMAND ${PYPKG_PY3} -m ensurepip
-  COMMAND ${PYPKG_PY3} -m pip install --upgrade build
   COMMAND ${PYPKG_PY3} -m build --sdist --wheel
   COMMAND ${CMAKE_COMMAND} -E copy dist/${setup_file_name} ${package_file}
   COMMAND ${CMAKE_COMMAND} -E copy dist/${wheel_file_name} ${wheel_package_file}

--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -615,11 +615,9 @@ endif()
 set(test_venv_cmd "")
 string(APPEND test_venv_cmd "${Python3_EXECUTABLE} -m venv ${test_venv_dir} ")
 string(APPEND test_venv_cmd "&& ${test_venv_activate} ")
-string(APPEND test_venv_cmd "&& pip install --upgrade pip ")
-string(APPEND test_venv_cmd "&& pip install -r ${CMAKE_SOURCE_DIR}/tests/TestRunner/requirements.txt")
-string(APPEND test_venv_cmd "&& pip install -e ${CMAKE_SOURCE_DIR}/tests/TestRunner ")
-# NOTE: At this stage we are in the virtual environment and Python3_EXECUTABLE is not available anymore
-string(APPEND test_venv_cmd "&& (cd ${CMAKE_BINARY_DIR}/bindings/python && python3 -m pip install .) ")
+string(APPEND test_venv_cmd "&& pip install --retries 9 -r ${CMAKE_SOURCE_DIR}/tests/TestRunner/requirements.txt ")
+string(APPEND test_venv_cmd "&& pip install ${CMAKE_SOURCE_DIR}/tests/TestRunner ")
+string(APPEND test_venv_cmd "&& pip install ${CMAKE_BINARY_DIR}/bindings/python ")
 add_test(
   NAME test_venv_setup
   COMMAND bash -c ${test_venv_cmd}

--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -18,11 +18,10 @@ if(NOT Sphinx_FOUND)
   execute_process(COMMAND "${Python3_EXECUTABLE}" -m venv ${SPHINX_VENV_DIR})
   find_program(
     VENV_Python3_EXECUTABLE
-    NAMES python3 python3.exe
-    PATHS ${SPHINX_VENV_DIR}/Scripts ${SPHINX_VENV_DIR}/bin REQUIRED
-    NO_DEFAULT_PATH NO_CACHE
+    NAMES python3 python3.exe python.exe
+    PATHS ${SPHINX_VENV_DIR}/Scripts ${SPHINX_VENV_DIR}/bin
+    REQUIRED NO_DEFAULT_PATH NO_CACHE
     DOC "Checking Python3 executable in virtual environment")
-  execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m ensurepip COMMAND_ERROR_IS_FATAL ANY)
   execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m pip install -r "${SPHINX_DOCUMENT_DIR}/requirements.txt" COMMAND_ERROR_IS_FATAL ANY)
   # find_package(Sphinx) only works with default search order, so use find_program()
   find_program(

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -43,11 +43,8 @@ if(NOT Jinja2_FOUND)
     VENV_Python3_EXECUTABLE
     NAMES python3 python3.exe python.exe
     PATHS ${PROTOCOL_VERSION_VENV_DIR}/Scripts ${PROTOCOL_VERSION_VENV_DIR}/bin
-          REQUIRED
-    NO_DEFAULT_PATH NO_CACHE
+    REQUIRED NO_DEFAULT_PATH NO_CACHE
     DOC "Checking Python3 executable in virtual environment")
-  execute_process(COMMAND "${VENV_Python3_EXECUTABLE}" -m ensurepip
-                          COMMAND_ERROR_IS_FATAL ANY)
   execute_process(
     COMMAND
       "${VENV_Python3_EXECUTABLE}" -m pip install -r


### PR DESCRIPTION
to reduce requests to PyPI during CI builds

... also, add pip install retries to `test_venv_setup`, also to try to deal with occasional PyPI 502 responses.