### PR TITLE
always increment finishedQueries counter if incrementing allQueries

### DIFF
--- a/fdbrpc/CountedSectionTest.cpp
+++ b/fdbrpc/CountedSectionTest.cpp
@@ -1,0 +1,64 @@
+/*
+ * CountedSecitonTest.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include "fdbrpc/Stats.h"
+#include "flow/UnitTest.h"
+
+void forceLinkCountedSectionTests() {}
+
+struct TestCounters {
+	CounterCollection cc;
+	Counter start;
+	Counter end;
+
+	TestCounters() : cc("CountedSectionTest"), start("start", cc), end("end", cc) {}
+};
+
+Future<Void> doNothing(TestCounters* tc, Future<Void> f) {
+	CountedSection cs(tc->start, tc->end);
+	co_await f;
+}
+
+TEST_CASE("/fdbrpc/countedsection/uninterrupted") {
+	TestCounters tc;
+
+	Promise<Void> signal;
+	auto nothing = doNothing(&tc, signal.getFuture());
+	signal.send(Void());
+	co_await nothing;
+
+	ASSERT(tc.start.getValue() == 1);
+	ASSERT(tc.end.getValue() == 1);
+	co_return;
+}
+
+TEST_CASE("/fdbrpc/countedsection/interrupted") {
+	TestCounters tc;
+
+	{
+		Promise<Void> signal;
+		auto nothing = doNothing(&tc, signal.getFuture());
+	}
+
+	ASSERT(tc.start.getValue() == 1);
+	ASSERT(tc.end.getValue() == 1);
+	co_return;
+}

--- a/fdbrpc/include/fdbrpc/Stats.h
+++ b/fdbrpc/include/fdbrpc/Stats.h
@@ -163,6 +163,26 @@ struct Traceable<Counter> : std::true_type {
 	}
 };
 
+// Increments one counter at construction, and another at destruction;
+// intended to be used to mark the beginning and end of some scope, without
+// the possibility of forgetting to increment the exit counter on exceptions.
+class CountedSection final : public NonCopyable {
+public:
+	CountedSection() : end(nullptr) {}
+	CountedSection(Counter& start, Counter& end) : end(&end) { ++start; }
+	CountedSection& operator=(CountedSection&& other) {
+		std::swap(end, other.end);
+		return *this;
+	}
+	~CountedSection() {
+		if (end)
+			++*end;
+	}
+
+private:
+	Counter* end;
+};
+
 template <class F>
 struct SpecialCounter final : ICounter, FastAllocated<SpecialCounter<F>>, NonCopyable {
 	SpecialCounter(CounterCollection& collection, std::string const& name, F&& f) : name(name), f(f) {

--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -1189,83 +1189,6 @@ public:
 	Key sk;
 	Reference<AsyncVar<ServerDBInfo> const> db;
 	Database cx;
-	ActorCollection actors;
-
-	CoalescedKeyRangeMap<bool, int64_t, KeyBytesMetric<int64_t>> byteSampleClears;
-	AsyncVar<bool> byteSampleClearsTooLarge;
-	Future<Void> byteSampleRecovery;
-	Future<Void> durableInProgress;
-
-	AsyncMap<Key, bool> watches;
-	int64_t watchBytes;
-	int64_t numWatches;
-	AsyncVar<bool> noRecentUpdates;
-	double lastUpdate;
-
-	std::string folder;
-	std::string checkpointFolder;
-	std::string fetchedCheckpointFolder;
-	std::string bulkDumpFolder;
-	std::string bulkLoadFolder;
-
-	// defined only during splitMutations()/addMutation()
-	UpdateEagerReadInfo* updateEagerReads;
-
-	FlowLock durableVersionLock;
-	FlowLock fetchKeysParallelismLock;
-	int64_t fetchKeysBytesBudget;
-	AsyncVar<bool> fetchKeysBudgetUsed;
-	int64_t fetchKeysTotalCommitBytes;
-	std::vector<Promise<FetchInjectionInfo*>> readyFetchKeys;
-
-	ThroughputLimiter fetchKeysLimiter;
-
-	FlowLock serveFetchCheckpointParallelismLock;
-
-	std::unordered_map<UID, std::shared_ptr<MoveInShard>> moveInShards;
-
-	Reference<PriorityMultiLock> ssLock;
-	std::vector<int> readPriorityRanks;
-
-	Future<PriorityMultiLock::Lock> getReadLock(const Optional<ReadOptions>& options) {
-		int readType = (int)(options.present() ? options.get().type : ReadType::NORMAL);
-		readType = std::clamp<int>(readType, 0, readPriorityRanks.size() - 1);
-		return ssLock->lock(readPriorityRanks[readType]);
-	}
-
-	FlowLock serveAuditStorageParallelismLock;
-
-	FlowLock serveBulkDumpParallelismLock;
-
-	int64_t instanceID;
-
-	Promise<Void> otherError;
-	Promise<Void> coreStarted;
-	bool shuttingDown;
-
-	Promise<Void> registerInterfaceAcceptingRequests;
-	Future<Void> interfaceRegistered;
-
-	bool behind;
-	bool versionBehind;
-
-	bool debug_inApplyUpdate;
-	double debug_lastValidateTime;
-
-	int64_t lastBytesInputEBrake;
-	Version lastDurableVersionEBrake;
-
-	int maxQueryQueue;
-	int getAndResetMaxQueryQueueSize() {
-		int val = maxQueryQueue;
-		maxQueryQueue = 0;
-		return val;
-	}
-
-	TransactionTagCounter transactionTagCounter;
-	BusiestWriteTagContext busiestWriteTagContext;
-
-	Optional<LatencyBandConfig> latencyBandConfig;
 
 	struct Counters : CommonStorageCounters {
 
@@ -1421,6 +1344,84 @@ public:
 			specialCounter(cc, "KvstoreInlineKey", [self]() { return std::get<2>(self->storage.getSize()); });
 		}
 	} counters;
+
+	ActorCollection actors;
+
+	CoalescedKeyRangeMap<bool, int64_t, KeyBytesMetric<int64_t>> byteSampleClears;
+	AsyncVar<bool> byteSampleClearsTooLarge;
+	Future<Void> byteSampleRecovery;
+	Future<Void> durableInProgress;
+
+	AsyncMap<Key, bool> watches;
+	int64_t watchBytes;
+	int64_t numWatches;
+	AsyncVar<bool> noRecentUpdates;
+	double lastUpdate;
+
+	std::string folder;
+	std::string checkpointFolder;
+	std::string fetchedCheckpointFolder;
+	std::string bulkDumpFolder;
+	std::string bulkLoadFolder;
+
+	// defined only during splitMutations()/addMutation()
+	UpdateEagerReadInfo* updateEagerReads;
+
+	FlowLock durableVersionLock;
+	FlowLock fetchKeysParallelismLock;
+	int64_t fetchKeysBytesBudget;
+	AsyncVar<bool> fetchKeysBudgetUsed;
+	int64_t fetchKeysTotalCommitBytes;
+	std::vector<Promise<FetchInjectionInfo*>> readyFetchKeys;
+
+	ThroughputLimiter fetchKeysLimiter;
+
+	FlowLock serveFetchCheckpointParallelismLock;
+
+	std::unordered_map<UID, std::shared_ptr<MoveInShard>> moveInShards;
+
+	Reference<PriorityMultiLock> ssLock;
+	std::vector<int> readPriorityRanks;
+
+	Future<PriorityMultiLock::Lock> getReadLock(const Optional<ReadOptions>& options) {
+		int readType = (int)(options.present() ? options.get().type : ReadType::NORMAL);
+		readType = std::clamp<int>(readType, 0, readPriorityRanks.size() - 1);
+		return ssLock->lock(readPriorityRanks[readType]);
+	}
+
+	FlowLock serveAuditStorageParallelismLock;
+
+	FlowLock serveBulkDumpParallelismLock;
+
+	int64_t instanceID;
+
+	Promise<Void> otherError;
+	Promise<Void> coreStarted;
+	bool shuttingDown;
+
+	Promise<Void> registerInterfaceAcceptingRequests;
+	Future<Void> interfaceRegistered;
+
+	bool behind;
+	bool versionBehind;
+
+	bool debug_inApplyUpdate;
+	double debug_lastValidateTime;
+
+	int64_t lastBytesInputEBrake;
+	Version lastDurableVersionEBrake;
+
+	int maxQueryQueue;
+	int getAndResetMaxQueryQueueSize() {
+		int val = maxQueryQueue;
+		maxQueryQueue = 0;
+		return val;
+	}
+
+	TransactionTagCounter transactionTagCounter;
+	BusiestWriteTagContext busiestWriteTagContext;
+
+	Optional<LatencyBandConfig> latencyBandConfig;
 
 	// Bytes read from storage engine when a storage server starts.
 	int64_t bytesRestored = 0;
@@ -2134,12 +2135,12 @@ std::shared_ptr<MoveInShard> StorageServer::getMoveInShard(const UID& dataMoveId
 Future<Void> getValueQ(StorageServer* data, GetValueRequest req) {
 	int64_t resultSize = 0;
 	Span span("SS:getValue"_loc, req.spanContext);
+	CountedSection cs(data->counters.allQueries, data->counters.finishedQueries);
 	// Temporarily disabled -- this path is hit a lot
 	// getCurrentLineage()->modify(&TransactionLineage::txID) = req.spanContext.first();
 
 	try {
 		++data->counters.getValueQueries;
-		++data->counters.allQueries;
 		if (req.key.startsWith(systemKeys.begin)) {
 			++data->counters.systemKeyQueries;
 		}
@@ -2259,8 +2260,6 @@ Future<Void> getValueQ(StorageServer* data, GetValueRequest req) {
 	// Key size is not included in "BytesQueried", but still contributes to cost,
 	// so it must be accounted for here.
 	data->transactionTagCounter.addRequest(req.tags, req.key.size() + resultSize);
-
-	++data->counters.finishedQueries;
 
 	double duration = g_network->timer() - req.requestTime();
 	data->counters.readLatencySamples.sample(duration, ReadLatencySamples::READ, trackedReadType(req));
@@ -3364,8 +3363,8 @@ Future<Void> getKeyValuesQ(StorageServer* data, GetKeyValuesRequest req)
 
 	getCurrentLineage()->modify(&TransactionLineage::txID) = req.spanContext.traceID;
 
+	CountedSection cs(data->counters.allQueries, data->counters.finishedQueries);
 	++data->counters.getRangeQueries;
-	++data->counters.allQueries;
 	if (req.begin.getKey().startsWith(systemKeys.begin)) {
 		++data->counters.systemKeyQueries;
 		++data->counters.getRangeSystemKeyQueries;
@@ -3566,7 +3565,6 @@ Future<Void> getKeyValuesQ(StorageServer* data, GetKeyValuesRequest req)
 	}
 
 	data->transactionTagCounter.addRequest(req.tags, resultSize);
-	++data->counters.finishedQueries;
 
 	double duration = g_network->timer() - req.requestTime();
 	data->counters.readLatencySamples.sample(duration, ReadLatencySamples::READ, trackedReadType(req));
@@ -5552,8 +5550,8 @@ Future<Void> getMappedKeyValuesQ(StorageServer* data, GetMappedKeyValuesRequest 
 
 	getCurrentLineage()->modify(&TransactionLineage::txID) = req.spanContext.traceID;
 
-	++data->counters.getMappedRangeQueries;
-	++data->counters.allQueries;
+	CountedSection csAll(data->counters.allQueries, data->counters.finishedQueries);
+	CountedSection csRangeMapped(data->counters.getMappedRangeQueries, data->counters.finishedGetMappedRangeQueries);
 	if (req.begin.getKey().startsWith(systemKeys.begin)) {
 		++data->counters.systemKeyQueries;
 	}
@@ -5720,8 +5718,6 @@ Future<Void> getMappedKeyValuesQ(StorageServer* data, GetMappedKeyValuesRequest 
 	}
 
 	data->transactionTagCounter.addRequest(req.tags, resultSize);
-	++data->counters.finishedQueries;
-	++data->counters.finishedGetMappedRangeQueries;
 
 	double duration = g_network->timer() - req.requestTime();
 	data->counters.readLatencySamples.sample(duration, ReadLatencySamples::READ, trackedReadType(req));
@@ -5747,8 +5743,8 @@ Future<Void> getKeyValuesStreamQ(StorageServer* data, GetKeyValuesStreamRequest 
 	int64_t resultSize = 0;
 
 	req.reply.setByteLimit(SERVER_KNOBS->RANGESTREAM_LIMIT_BYTES);
+	CountedSection cs(data->counters.allQueries, data->counters.finishedQueries);
 	++data->counters.getRangeStreamQueries;
-	++data->counters.allQueries;
 	if (req.begin.getKey().startsWith(systemKeys.begin)) {
 		++data->counters.systemKeyQueries;
 	}
@@ -5942,7 +5938,6 @@ Future<Void> getKeyValuesStreamQ(StorageServer* data, GetKeyValuesStreamRequest 
 	}
 
 	data->transactionTagCounter.addRequest(req.tags, resultSize);
-	++data->counters.finishedQueries;
 }
 
 Future<Void> getKeyQ(StorageServer* data, GetKeyRequest req) {
@@ -5951,8 +5946,8 @@ Future<Void> getKeyQ(StorageServer* data, GetKeyRequest req) {
 
 	getCurrentLineage()->modify(&TransactionLineage::txID) = req.spanContext.traceID;
 
+	CountedSection cs(data->counters.allQueries, data->counters.finishedQueries);
 	++data->counters.getKeyQueries;
-	++data->counters.allQueries;
 	data->maxQueryQueue = std::max<int>(
 	    data->maxQueryQueue, data->counters.allQueries.getValue() - data->counters.finishedQueries.getValue());
 
@@ -6015,8 +6010,6 @@ Future<Void> getKeyQ(StorageServer* data, GetKeyRequest req) {
 	// key It would be more accurate to count all the read bytes, but it's not critical because this function is only
 	// used if read-your-writes is disabled
 	data->transactionTagCounter.addRequest(req.tags, resultSize);
-
-	++data->counters.finishedQueries;
 
 	double duration = g_network->timer() - req.requestTime();
 	data->counters.readLatencySamples.sample(duration, ReadLatencySamples::READ, trackedReadType(req));

--- a/fdbserver/workloads/UnitTests.cpp
+++ b/fdbserver/workloads/UnitTests.cpp
@@ -59,6 +59,7 @@ void forceLinkGrvProxyStarvationTests();
 // TODO akanksha: Remove once a production caller of rangePartitionedBackupWorker() is wired up;
 // this only exists to keep TEST_CASEs in RangePartitionedBackupWorker.cpp from being dead-stripped.
 void forceLinkRangePartitionedBackupWorkerTests();
+void forceLinkCountedSectionTests();
 
 struct UnitTestWorkload : TestWorkload {
 	static constexpr auto NAME = "UnitTests";
@@ -137,6 +138,7 @@ struct UnitTestWorkload : TestWorkload {
 		// TODO akanksha: Remove once a production caller of rangePartitionedBackupWorker() is wired up;
 		// this only exists to keep TEST_CASEs in RangePartitionedBackupWorker.cpp from being dead-stripped.
 		forceLinkRangePartitionedBackupWorkerTests();
+		forceLinkCountedSectionTests();
 
 #ifdef FLOW_GRPC_ENABLED
 		forceLinkGrpcTests();


### PR DESCRIPTION
Forward-port of #13786 to main. I've tested it locally; the buggy behavior it fixes is still observable in main, and is fixed by this change.