### PR TITLE
Fix a use-after-free in S3Client copyUpFile() when it is cancelled

### DIFF
--- a/fdbclient/S3Client.actor.cpp
+++ b/fdbclient/S3Client.actor.cpp
@@ -214,7 +214,7 @@ ACTOR static Future<Void> copyUpFile(Reference<S3BlobStoreEndpoint> endpoint,
 	state std::string uploadID;
 	state std::vector<Future<PartState>> uploadFutures;
 	state std::vector<PartState> parts;
-	state std::vector<std::string> partDatas;
+	state std::vector<std::shared_ptr<std::string>> partDatas;
 	state int64_t size = fileSize(filepath);
 
 	try {
@@ -248,10 +248,10 @@ ACTOR static Future<Void> copyUpFile(Reference<S3BlobStoreEndpoint> endpoint,
 			state int64_t partSize = std::min(config.partSizeBytes, size - offset);
 
 			// Store part data in our vector to keep it alive
-			partDatas.emplace_back();
-			partDatas.back().resize(partSize);
+			partDatas.push_back(std::make_shared<std::string>(partSize, '\0'));
 
-			int bytesRead = wait(file->read(&partDatas.back()[0], partSize, offset));
+			int bytesRead =
+			    wait(uncancellable(holdWhile(partDatas.back(), file->read(&(*partDatas.back())[0], partSize, offset))));
 			if (bytesRead != partSize) {
 				TraceEvent(SevError, "S3ClientCopyUpFileReadError")
 				    .detail("Expected", partSize)
@@ -261,7 +261,7 @@ ACTOR static Future<Void> copyUpFile(Reference<S3BlobStoreEndpoint> endpoint,
 				throw io_error();
 			}
 
-			std::string md5 = HTTP::computeMD5Sum(partDatas.back());
+			std::string md5 = HTTP::computeMD5Sum(*partDatas.back());
 			state PartState part;
 			part.partNumber = partNumber;
 			part.offset = offset;
@@ -270,7 +270,7 @@ ACTOR static Future<Void> copyUpFile(Reference<S3BlobStoreEndpoint> endpoint,
 			parts.push_back(part);
 
 			uploadFutures.push_back(
-			    uploadPart(endpoint, bucket, objectName, uploadID, part, partDatas.back(), config.retryDelayMs));
+			    uploadPart(endpoint, bucket, objectName, uploadID, part, *partDatas.back(), config.retryDelayMs));
 
 			offset += partSize;
 			partNumber++;


### PR DESCRIPTION
Problem: copyUpFile() handed file->read() a raw pointer into a state vector that lives in the actor frame, so cancelling it mid-read freed the buffer while the read could still be writing to it. IAsyncFile.h says dropping a pending read on cancel is up to the implementation, so we can't count on it stopping by itself.

Solution: hold each part's buffer in a shared_ptr and wrap the read in uncancellable(holdWhile(...)). This is the same pattern already used in calculateFileChecksum() in this file (from https://github.com/apple/foundationdb/pull/13871, now also on release-7.4). So overall, copyUpFile() stays cancellable, it just no longer owns the memory the read is writing to.

I found this during a 7.4 audit while checking whether the upload-part path was fully cancellation-safe after #13871 fixed the checksum side. It's not portable from upstream main, because main only fixed this incidentally as part of a much larger unrelated rework, so this is a 7.4 only fix.

Testing: 
- general 100K: baseline 99999/100000, fix 100000/100000 (zero severity-40 events on the fix side)
- BulkDumping 10K: baseline 10000/10000, fix 10000/10000