### PR TITLE
Turn DD global admission control off by default

### DIFF
--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -278,13 +278,16 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( MERGE_RELOCATION_PARALLELISM_PER_TEAM,                   6 ); if (randomize && buggify() ) MERGE_RELOCATION_PARALLELISM_PER_TEAM = 1;
 	init( DD_QUEUE_MAX_KEY_SERVERS,                              100 ); // Do not buggify
 	init( DD_REBALANCE_PARALLELISM,                               50 );
-	// Hard cap on total relocations DD tracks (queued + in-flight). 1000 corresponds to a 500-server
-	// cluster with two concurrent shard moves per storage server.  We have observed large clusters doing
-	// 25-30GB in flight, or closer to 100 shards at a time, so this has plenty of margin of safety
-	// built in.  For simulation, we don't really know how many servers there are, but 10 seems like a good
-	// guess (thus 20 moves).  Do not buggify this too small: testing under artificial scarcity results in
-	// uninteresting degenerate cases.
-	init( DD_MAX_PIPELINE_MOVES,                                1000 ); if( randomize && buggify() ) DD_MAX_PIPELINE_MOVES = 20;
+	// Global admission control for DD relocations is OFF by default. The default limit is set high
+	// enough that pipelineSize() can never reach it, so pipelineFull never becomes true and the
+	// relocation gate in pipelineGateActor() never holds anything back. To turn the feature on, set
+	// this to a real cap: 1000 corresponds to a 500-server cluster with two concurrent shard moves
+	// per storage server. We have observed large clusters doing 25-30GB in flight, or closer to 100
+	// shards at a time, so 1000 would have plenty of margin of safety built in. Simulation still
+	// exercises the gate via the buggify value below. For simulation, we don't really know how many
+	// servers there are, but 10 seems like a good guess (thus 20 moves). Do not buggify this too
+	// small: testing under artificial scarcity results in uninteresting degenerate cases.
+	init( DD_MAX_PIPELINE_MOVES, std::numeric_limits<int>::max() ); if( randomize && buggify() ) DD_MAX_PIPELINE_MOVES = 20;
 	init( DD_REBALANCE_RESET_AMOUNT,                              30 );
 	init( INFLIGHT_PENALTY_HEALTHY,                              1.0 );
 	init( INFLIGHT_PENALTY_UNHEALTHY,                          500.0 );


### PR DESCRIPTION
As title.

Simulation testing:
- `DDPipelineSaturation`: 1000/1000, `20260820-043420-praza-dd-admission-control--4b6fdfb3b21f970b`
- general correctness: 10000/10000, `20260820-043459-praza-dd-admission-control--448eb8a7d3fb36d0`
