### PR TITLE
Fix range-lock checks at the normal-keyspace boundary

### DIFF
--- a/fdbserver/commitproxy/ProxyCommitData.h
+++ b/fdbserver/commitproxy/ProxyCommitData.h
@@ -438,10 +438,11 @@ public:
 
 	bool isLocked(const KeyRange& range) const {
 		ASSERT(pProxyCommitData != nullptr && pProxyCommitData->rangeLockEnabled());
-		if (range.end >= normalKeys.end) {
+		const KeyRangeRef normalRange = range & normalKeys;
+		if (normalRange.empty()) {
 			return false;
 		}
-		for (auto lockRange : coreMap.intersectingRanges(range)) {
+		for (auto lockRange : coreMap.intersectingRanges(normalRange)) {
 			if (lockRange.value().isValid() && lockRange.value().isLockedFor(RangeLockType::ExclusiveReadLock)) {
 				return true;
 			}

--- a/fdbserver/workloads/RangeLock.cpp
+++ b/fdbserver/workloads/RangeLock.cpp
@@ -148,6 +148,49 @@ struct RangeLocking : TestWorkload {
 		}
 	}
 
+	Future<Void> expectClearRejected(Database cx, KeyRange range) {
+		bool rejected = false;
+		try {
+			co_await clearRange(cx, range);
+		} catch (Error& e) {
+			if (e.code() != error_code_transaction_rejected_range_locked) {
+				throw;
+			}
+			rejected = true;
+		}
+		ASSERT(rejected);
+	}
+
+	Future<Void> testNormalKeyspaceBoundary(Database cx) {
+		const Key lockedKey = "rangeLockBoundary/c"_sr;
+		const Key outsideKey = "rangeLockBoundary/z"_sr;
+		const Value value = "preserved"_sr;
+		const KeyRange middleRange = KeyRangeRef("rangeLockBoundary/b"_sr, "rangeLockBoundary/d"_sr);
+		const KeyRange suffixRange = KeyRangeRef(middleRange.begin, normalKeys.end);
+		co_await setKey(cx, lockedKey, value);
+		co_await setKey(cx, outsideKey, value);
+		co_await takeExclusiveReadLockOnRange(cx, middleRange, rangeLockOwnerName);
+		co_await expectClearRejected(cx, suffixRange);
+		co_await expectClearRejected(cx, normalKeys);
+		co_await clearRange(cx, KeyRangeRef(middleRange.end, normalKeys.end));
+		Optional<Value> lockedValue = co_await getKey(cx, lockedKey);
+		Optional<Value> outsideValue = co_await getKey(cx, outsideKey);
+		ASSERT(lockedValue.present() && lockedValue.get() == value);
+		ASSERT(!outsideValue.present());
+		co_await releaseExclusiveReadLockOnRange(cx, middleRange, rangeLockOwnerName);
+
+		co_await takeExclusiveReadLockOnRange(cx, suffixRange, rangeLockOwnerName);
+		co_await expectClearRejected(cx, suffixRange);
+		co_await releaseExclusiveReadLockOnRange(cx, suffixRange, rangeLockOwnerName);
+		co_await takeExclusiveReadLockOnRange(cx, normalKeys, rangeLockOwnerName);
+		co_await expectClearRejected(cx, normalKeys);
+		co_await releaseExclusiveReadLockOnRange(cx, normalKeys, rangeLockOwnerName);
+		co_await clearRange(cx, normalKeys);
+		lockedValue = co_await getKey(cx, lockedKey);
+		ASSERT(!lockedValue.present());
+		TraceEvent("RangeLockNormalKeyspaceBoundaryPassed");
+	}
+
 	std::string getLockRangesString(const std::vector<std::pair<KeyRange, RangeLockState>>& locks) {
 		std::string res = "";
 		int count = 0;
@@ -603,12 +646,20 @@ struct RangeLocking : TestWorkload {
 				                           candidates[i]));
 			}
 		}
+		// The isolation assertions intentionally leave other owners locked.
+		// Release those locks before the harness clears the normal keyspace.
+		for (const auto& candidate : candidates) {
+			co_await releaseExclusiveReadLockByUser(cx, candidate);
+		}
+		const auto remainingLocks = co_await findExclusiveReadLockOnRange(cx, normalKeys);
+		ASSERT(remainingLocks.empty());
 	}
 
 	Future<Void> start(Database const& cx) override {
 		if (clientId != 0) {
 			co_return;
 		}
+		co_await testNormalKeyspaceBoundary(cx);
 		co_await complexTest(this, cx);
 		co_await testUnlockByUser(this, cx);
 	}


### PR DESCRIPTION
## Summary

`RangeLock::isLocked` skipped any mutation range ending at or beyond
`normalKeys.end`. A legal clear ending at `\xff`, including a clear of the
entire normal keyspace, could therefore bypass an overlapping range lock.

Check the mutation's intersection with `normalKeys` instead. Extend the
existing `RangeLocking` simulation to cover suffix and full-keyspace clears,
non-overlapping clears, boundary-ending locks, and successful clears after
unlocking. Release the workload's remaining test-owned locks after its
isolation assertions so its final database cleanup can succeed.

This is the independent boundary fix from #13914. It does not change feature
activation, persisted metadata, lock ownership APIs, or recovery behavior.

## Validation

- Commit-proxy unit tests passed in normal and simulated modes.
- `tests/fast/RangeLocking.toml` passed, including the new boundary regression.
- `tests/fast/RangeLockCycle.toml` passed.

Both simulations used seed `20260820` with buggify disabled. The executables
were freshly linked and run directly; the build wrapper returned a nonzero
status after linking, with zero compiler failures.
