### PR TITLE
Fix range-lock identity and validate management API ranges

### DIFF
--- a/fdbclient/RangeLock.cpp
+++ b/fdbclient/RangeLock.cpp
@@ -26,6 +26,17 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/SystemData.h"
 #include "flow/Trace.h"
+#include "flow/UnitTest.h"
+
+namespace {
+
+void validateRangeLockRange(const KeyRangeRef& range) {
+	if (range.empty() || !normalKeys.contains(range)) {
+		throw range_lock_failed();
+	}
+}
+
+} // namespace
 
 // Persist a new owner if input ownerUniqueID is not existing; Update description if input ownerUniqueID exists
 Future<Void> registerRangeLockOwner(Database cx, RangeLockOwnerName ownerUniqueID, std::string description) {
@@ -140,9 +151,7 @@ AsyncResult<std::vector<RangeLockOwner>> getAllRangeLockOwners(Database cx) {
 // Not transactional
 Future<std::vector<std::pair<KeyRange, RangeLockState>>>
 findExclusiveReadLockOnRange(Database cx, KeyRange range, Optional<RangeLockOwnerName> ownerName) {
-	if (range.end > normalKeys.end) {
-		throw range_lock_failed();
-	}
+	validateRangeLockRange(range);
 	std::vector<std::pair<KeyRange, RangeLockState>> lockedRanges;
 	Key beginKey = range.begin;
 	Key endKey = range.end;
@@ -183,17 +192,9 @@ findExclusiveReadLockOnRange(Database cx, KeyRange range, Optional<RangeLockOwne
 
 namespace {
 
-// Validate the input range and owner.
-// If invalid, reject the request by throwing range_lock_failed error.
+// The range must already be validated. Reject an unregistered owner with range_lock_failed.
 // If the range has been locked, reject the request by throwing range_lock_reject error.
 Future<Void> prepareExclusiveRangeLockOperation(Transaction* tr, KeyRange range, RangeLockOwnerName ownerUniqueID) {
-	// Check input range
-	if (range.end > normalKeys.end) {
-		TraceEvent(SevDebug, "PrepareExclusiveRangeLockOperationFailed")
-		    .detail("Reason", "Range out of scope")
-		    .detail("Range", range);
-		throw range_lock_failed();
-	}
 	// Check owner
 	Optional<Value> ownerValue = co_await tr->get(rangeLockOwnerKeyFor(ownerUniqueID));
 	if (!ownerValue.present()) {
@@ -205,6 +206,7 @@ Future<Void> prepareExclusiveRangeLockOperation(Transaction* tr, KeyRange range,
 	}
 	RangeLockOwner owner = decodeRangeLockOwner(ownerValue.get());
 	ASSERT(owner.isValid());
+	const RangeLockState requestedLock(RangeLockType::ExclusiveReadLock, ownerUniqueID, range);
 	// Check lock state on the entire input range. Throw exception if the range has been locked by a different owner.
 	Key beginKey = range.begin;
 	Key endKey = range.end;
@@ -221,10 +223,8 @@ Future<Void> prepareExclusiveRangeLockOperation(Transaction* tr, KeyRange range,
 			}
 			RangeLockStateSet rangeLockStateSet = decodeRangeLockStateSet(res[i].value);
 			ASSERT(rangeLockStateSet.isValid());
-			auto lockSet = rangeLockStateSet.getLocks();
-			if (!lockSet.empty() && (!rangeLockStateSet.isLockedFor(RangeLockType::ExclusiveReadLock) ||
-			                         lockSet.find(RangeLockState(RangeLockType::ExclusiveReadLock, ownerUniqueID, range)
-			                                          .getLockUniqueString()) == lockSet.end())) {
+			if (!rangeLockStateSet.empty() &&
+			    (rangeLockStateSet.getLocks().size() != 1 || !rangeLockStateSet.containsLogicalLock(requestedLock))) {
 				TraceEvent(SevDebug, "PrepareExclusiveRangeLockOperationFailed")
 				    .detail("Reason", "Locked")
 				    .detail("NewLockType", RangeLockType::ExclusiveReadLock)
@@ -239,13 +239,6 @@ Future<Void> prepareExclusiveRangeLockOperation(Transaction* tr, KeyRange range,
 }
 
 Future<Void> prepareExclusiveRangeUnlockOperation(Transaction* tr, KeyRange range, RangeLockOwnerName ownerUniqueID) {
-	// Check input range
-	if (range.end > normalKeys.end) {
-		TraceEvent(SevDebug, "PrepareExclusiveRangeUnlockOperationFailed")
-		    .detail("Reason", "Range out of scope")
-		    .detail("Range", range);
-		throw range_lock_failed();
-	}
 	// Check owner
 	Optional<Value> ownerValue = co_await tr->get(rangeLockOwnerKeyFor(ownerUniqueID));
 	if (!ownerValue.present()) {
@@ -257,6 +250,7 @@ Future<Void> prepareExclusiveRangeUnlockOperation(Transaction* tr, KeyRange rang
 	}
 	RangeLockOwner owner = decodeRangeLockOwner(ownerValue.get());
 	ASSERT(owner.isValid());
+	const RangeLockState requestedLock(RangeLockType::ExclusiveReadLock, ownerUniqueID, range);
 
 	// Check lock state on the entire input range. Throw exception if the range has been locked by a different owner.
 	Key beginKey = range.begin;
@@ -274,10 +268,8 @@ Future<Void> prepareExclusiveRangeUnlockOperation(Transaction* tr, KeyRange rang
 			}
 			RangeLockStateSet rangeLockStateSet = decodeRangeLockStateSet(res[i].value);
 			ASSERT(rangeLockStateSet.isValid());
-			auto lockSet = rangeLockStateSet.getLocks();
-			if (!lockSet.empty() && (!rangeLockStateSet.isLockedFor(RangeLockType::ExclusiveReadLock) ||
-			                         lockSet.find(RangeLockState(RangeLockType::ExclusiveReadLock, ownerUniqueID, range)
-			                                          .getLockUniqueString()) == lockSet.end())) {
+			if (!rangeLockStateSet.empty() &&
+			    (rangeLockStateSet.getLocks().size() != 1 || !rangeLockStateSet.containsLogicalLock(requestedLock))) {
 				TraceEvent(SevDebug, "PrepareExclusiveRangeUnlockOperationFailed")
 				    .detail("Reason", "Has been locked by a different user or the same user with a different range")
 				    .detail("UnLockOwner", ownerUniqueID)
@@ -295,6 +287,7 @@ Future<Void> prepareExclusiveRangeUnlockOperation(Transaction* tr, KeyRange rang
 // Transactional. One transaction can call takeExclusiveReadLockOnRange at most for one time.
 // This is the limitation of the krmSetRangeCoalescing.
 Future<Void> takeExclusiveReadLockOnRange(Transaction* tr, KeyRange range, RangeLockOwnerName ownerUniqueID) {
+	validateRangeLockRange(range);
 	tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 	tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 	// Add conflict range
@@ -311,6 +304,7 @@ Future<Void> takeExclusiveReadLockOnRange(Transaction* tr, KeyRange range, Range
 // Transactional. One transaction can call releaseExclusiveReadLockOnRange at most for one time.
 // This is the limitation of the krmSetRangeCoalescing.
 Future<Void> releaseExclusiveReadLockOnRange(Transaction* tr, KeyRange range, RangeLockOwnerName ownerUniqueID) {
+	validateRangeLockRange(range);
 	tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 	tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 	co_await prepareExclusiveRangeUnlockOperation(tr, range, ownerUniqueID);
@@ -382,6 +376,7 @@ Future<Void> releaseExclusiveReadLockByUser(Database cx, RangeLockOwnerName owne
 
 // Transactional
 Future<Void> takeExclusiveReadLockOnRange(Database cx, KeyRange range, RangeLockOwnerName ownerUniqueID) {
+	validateRangeLockRange(range);
 	Transaction tr(cx);
 	while (true) {
 		Error err;
@@ -399,6 +394,7 @@ Future<Void> takeExclusiveReadLockOnRange(Database cx, KeyRange range, RangeLock
 
 // Transactional
 Future<Void> releaseExclusiveReadLockOnRange(Database cx, KeyRange range, RangeLockOwnerName ownerUniqueID) {
+	validateRangeLockRange(range);
 	Transaction tr(cx);
 	while (true) {
 		Error err;
@@ -412,4 +408,65 @@ Future<Void> releaseExclusiveReadLockOnRange(Database cx, KeyRange range, RangeL
 		}
 		co_await tr.onError(err);
 	}
+}
+
+TEST_CASE("/RangeLock/LogicalIdentity") {
+	const auto checkCollision = [](const RangeLockState& first, const RangeLockState& colliding) {
+		ASSERT(first != colliding);
+		ASSERT(first.getLockUniqueString() == colliding.getLockUniqueString());
+
+		RangeLockStateSet locks;
+		locks.insertIfNotExist(first);
+		const Value encoded = rangeLockStateSetValue(locks);
+		RangeLockStateSet decoded = decodeRangeLockStateSet(encoded);
+		ASSERT(decoded == locks);
+		ASSERT(decoded.containsLogicalLock(first));
+		ASSERT(!decoded.containsLogicalLock(colliding));
+		decoded.insertIfNotExist(first);
+		ASSERT(rangeLockStateSetValue(decoded) == encoded);
+
+		bool rejected = false;
+		try {
+			decoded.insertIfNotExist(colliding);
+		} catch (Error& e) {
+			ASSERT_EQ(e.code(), error_code_range_lock_failed);
+			rejected = true;
+		}
+		ASSERT(rejected);
+		decoded.remove(colliding);
+		ASSERT(decoded == locks);
+		decoded.remove(first);
+		ASSERT(decoded.empty());
+	};
+
+	checkCollision(
+	    RangeLockState(RangeLockType::ExclusiveReadLock, "A", KeyRangeRef("XExclusiveReadLock{ begin=a"_sr, "z"_sr)),
+	    RangeLockState(RangeLockType::ExclusiveReadLock, "AExclusiveReadLock{ begin=X", KeyRangeRef("a"_sr, "z"_sr)));
+	checkCollision(RangeLockState(RangeLockType::ExclusiveReadLock, "owner", KeyRangeRef("a"_sr, "b  end=c"_sr)),
+	               RangeLockState(RangeLockType::ExclusiveReadLock, "owner", KeyRangeRef("a  end=b"_sr, "c"_sr)));
+	co_return;
+}
+
+TEST_CASE("/RangeLock/InvalidRanges") {
+	const auto checkRejected = [](const auto& result) {
+		ASSERT(result.isReady());
+		ASSERT(result.isError());
+		ASSERT_EQ(result.getError().code(), error_code_range_lock_failed);
+	};
+	const std::vector<KeyRange> invalidRanges = {
+		KeyRangeRef(normalKeys.begin, normalKeys.begin), KeyRangeRef("a"_sr, "a"_sr),
+		KeyRangeRef(normalKeys.end, normalKeys.end),     KeyRangeRef(normalKeys.begin, allKeys.end),
+		KeyRangeRef(normalKeys.end, allKeys.end),
+	};
+	for (const auto& range : invalidRanges) {
+		// Invalid input must fail before either overload accesses a transaction or database.
+		checkRejected(takeExclusiveReadLockOnRange(static_cast<Transaction*>(nullptr), range, "owner"));
+		checkRejected(releaseExclusiveReadLockOnRange(static_cast<Transaction*>(nullptr), range, "owner"));
+		checkRejected(takeExclusiveReadLockOnRange(Database(), range, "owner"));
+		checkRejected(releaseExclusiveReadLockOnRange(Database(), range, "owner"));
+		checkRejected(findExclusiveReadLockOnRange(Database(), range));
+	}
+	validateRangeLockRange(normalKeys);
+	validateRangeLockRange(KeyRangeRef("a"_sr, normalKeys.end));
+	co_return;
 }

--- a/fdbclient/include/fdbclient/RangeLock.h
+++ b/fdbclient/include/fdbclient/RangeLock.h
@@ -121,7 +121,8 @@ public:
 		return lockType == r.lockType && ownerUniqueId == r.ownerUniqueId && range == r.range;
 	}
 
-	// TODO: use lockId
+	// This legacy map key is persisted and can collide. Compare the lock fields for identity;
+	// changing this encoding requires migrating existing range-lock metadata.
 	RangeLockUniqueString getLockUniqueString() const {
 		return ownerUniqueId + rangeLockTypeString(lockType) + range.toString();
 	}
@@ -172,6 +173,15 @@ public:
 
 	const std::map<RangeLockUniqueString, RangeLockState>& getLocks() const { return locks; }
 
+	bool containsLogicalLock(const RangeLockState& inputLock) const {
+		for (const auto& [name, lock] : locks) {
+			if (lock == inputLock) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	bool operator==(RangeLockStateSet const& r) const {
 		auto rLocks = r.getLocks();
 		if (locks.size() != rLocks.size()) {
@@ -191,18 +201,25 @@ public:
 
 	void insertIfNotExist(const RangeLockState& inputLock) {
 		ASSERT(inputLock.isValid());
-		if (inputLock.isLockedFor(RangeLockType::ExclusiveReadLock) && !locks.empty() &&
-		    locks.find(inputLock.getLockUniqueString()) == locks.end()) {
+		if (containsLogicalLock(inputLock)) {
+			return;
+		}
+		if (inputLock.isLockedFor(RangeLockType::ExclusiveReadLock) && !locks.empty()) {
 			throw range_lock_failed();
 		}
-		locks.insert({ inputLock.getLockUniqueString(), inputLock });
-		return;
+		if (!locks.insert({ inputLock.getLockUniqueString(), inputLock }).second) {
+			throw range_lock_failed();
+		}
 	}
 
 	void remove(const RangeLockState& inputLock) {
 		ASSERT(inputLock.isValid());
-		locks.erase(inputLock.getLockUniqueString());
-		return;
+		for (auto it = locks.begin(); it != locks.end(); ++it) {
+			if (it->second == inputLock) {
+				locks.erase(it);
+				return;
+			}
+		}
 	}
 
 	bool isLockedFor(RangeLockType lockType) const {
@@ -237,17 +254,17 @@ AsyncResult<std::vector<RangeLockOwner>> getAllRangeLockOwners(Database cx);
 // Get a rangeLock owner by ownerUniqueID.
 Future<Optional<RangeLockOwner>> getRangeLockOwner(Database cx, RangeLockOwnerName ownerUniqueID);
 
-// Block write traffic to a user range (the input range must be within normalKeys).
+// Block write traffic to a non-empty user range within normalKeys; otherwise throw range_lock_failed.
 // One transaction can call takeExclusiveReadLockOnRange at most one time.
 Future<Void> takeExclusiveReadLockOnRange(Transaction* tr, KeyRange range, RangeLockOwnerName ownerUniqueID);
 Future<Void> takeExclusiveReadLockOnRange(Database cx, KeyRange range, RangeLockOwnerName ownerUniqueID);
 
-// Unblock a user range (the input range must be within normalKeys).
+// Unblock a non-empty user range within normalKeys; otherwise throw range_lock_failed.
 // One transaction can call releaseExclusiveReadLockOnRange at most one time.
 Future<Void> releaseExclusiveReadLockOnRange(Transaction* tr, KeyRange range, RangeLockOwnerName ownerUniqueID);
 Future<Void> releaseExclusiveReadLockOnRange(Database cx, KeyRange range, RangeLockOwnerName ownerUniqueID);
 
-// Get locked ranges within the input range (the input range must be within normalKeys).
+// Get locked ranges within a non-empty range in normalKeys; otherwise throw range_lock_failed.
 Future<std::vector<std::pair<KeyRange, RangeLockState>>> findExclusiveReadLockOnRange(
     Database cx,
     KeyRange range,

--- a/fdbserver/workloads/RangeLock.cpp
+++ b/fdbserver/workloads/RangeLock.cpp
@@ -148,17 +148,21 @@ struct RangeLocking : TestWorkload {
 		}
 	}
 
-	Future<Void> expectClearRejected(Database cx, KeyRange range) {
+	Future<Void> expectOperationRejected(Future<Void> operation, int expectedError) {
 		bool rejected = false;
 		try {
-			co_await clearRange(cx, range);
+			co_await operation;
 		} catch (Error& e) {
-			if (e.code() != error_code_transaction_rejected_range_locked) {
+			if (e.code() != expectedError) {
 				throw;
 			}
 			rejected = true;
 		}
 		ASSERT(rejected);
+	}
+
+	Future<Void> expectClearRejected(Database cx, KeyRange range) {
+		return expectOperationRejected(clearRange(cx, range), error_code_transaction_rejected_range_locked);
 	}
 
 	Future<Void> testNormalKeyspaceBoundary(Database cx) {
@@ -189,6 +193,41 @@ struct RangeLocking : TestWorkload {
 		lockedValue = co_await getKey(cx, lockedKey);
 		ASSERT(!lockedValue.present());
 		TraceEvent("RangeLockNormalKeyspaceBoundaryPassed");
+	}
+
+	Future<Void> testLogicalIdentity(Database cx) {
+		const RangeLockOwnerName owner = "RangeLockIdentityA";
+		const RangeLockOwnerName collidingOwner = owner + "ExclusiveReadLock{ begin=X";
+		const KeyRange range = KeyRangeRef("XExclusiveReadLock{ begin=a"_sr, "z"_sr);
+		const KeyRange collidingRange = KeyRangeRef("a"_sr, "z"_sr);
+		const RangeLockState original(RangeLockType::ExclusiveReadLock, owner, range);
+		const RangeLockState colliding(RangeLockType::ExclusiveReadLock, collidingOwner, collidingRange);
+		const Key protectedKey = "m"_sr;
+		const Value value = "preserved"_sr;
+		ASSERT(original != colliding);
+		ASSERT(original.getLockUniqueString() == colliding.getLockUniqueString());
+		co_await registerRangeLockOwner(cx, owner, owner);
+		co_await registerRangeLockOwner(cx, collidingOwner, collidingOwner);
+		co_await setKey(cx, protectedKey, value);
+		co_await takeExclusiveReadLockOnRange(cx, range, owner);
+
+		co_await expectOperationRejected(takeExclusiveReadLockOnRange(cx, collidingRange, collidingOwner),
+		                                 error_code_range_lock_reject);
+		auto locks = co_await findExclusiveReadLockOnRange(cx, normalKeys);
+		ASSERT(locks.size() == 1 && locks[0].first == range && locks[0].second == original);
+		co_await expectOperationRejected(releaseExclusiveReadLockOnRange(cx, collidingRange, collidingOwner),
+		                                 error_code_range_unlock_reject);
+		locks = co_await findExclusiveReadLockOnRange(cx, normalKeys);
+		ASSERT(locks.size() == 1 && locks[0].first == range && locks[0].second == original);
+		co_await expectClearRejected(cx, collidingRange);
+		const Optional<Value> protectedValue = co_await getKey(cx, protectedKey);
+		ASSERT(protectedValue.present() && protectedValue.get() == value);
+
+		co_await releaseExclusiveReadLockOnRange(cx, range, owner);
+		co_await clearKey(cx, protectedKey);
+		co_await removeRangeLockOwner(cx, owner);
+		co_await removeRangeLockOwner(cx, collidingOwner);
+		TraceEvent("RangeLockLogicalIdentityPassed");
 	}
 
 	std::string getLockRangesString(const std::vector<std::pair<KeyRange, RangeLockState>>& locks) {
@@ -660,6 +699,7 @@ struct RangeLocking : TestWorkload {
 			co_return;
 		}
 		co_await testNormalKeyspaceBoundary(cx);
+		co_await testLogicalIdentity(cx);
 		co_await complexTest(this, cx);
 		co_await testUnlockByUser(this, cx);
 	}


### PR DESCRIPTION
## Summary

Range-lock metadata uses a printable string as its persisted map key. Different
owners and ranges can produce the same string, allowing a competing management
operation to mistake another owner's lock for its own.

Use the existing structured lock equality for membership, insertion, removal,
and acquire/release validation. Preserve the persisted map keys and serialized
layout. Also reject empty or out-of-normal-keyspace ranges before accessing a
transaction, preventing invalid KRM updates from reaching the commit proxy.

Add client unit coverage for identity collisions, serialization compatibility,
and invalid ranges. Extend `RangeLocking` with a crafted collision that checks
the real acquire/release errors and proves the original lock still protects
its data.

This is a small follow-up to #13921. It does not change owner lifecycles,
BulkLoad, feature activation, or recovery behavior.

## Validation

- Both `/RangeLock/` client unit tests passed in normal and simulated modes.
- `tests/fast/RangeLocking.toml` passed with seed `20260820` and buggify disabled,
  including the new API-level collision regression.

The executables were freshly linked and run directly. The build wrapper
returned a nonzero status after linking, with zero compiler failures.
