### PR TITLE
Backup: log the bulkdump timeout that was actually used

### DIFF
--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -3687,7 +3687,7 @@ struct BulkDumpTaskFunc : BackupTaskFuncBase {
 					TraceEvent(SevWarn, "BulkDumpTaskTimeout")
 					    .detail("BackupUID", config.getUid())
 					    .detail("BulkDumpJobId", bulkDumpJob.getJobId())
-					    .detail("TimeoutDuration", 300.0);
+					    .detail("TimeoutDuration", CLIENT_KNOBS->BULKDUMP_JOB_TIMEOUT);
 					Params.timeoutOccurred().set(task, true);
 				}
 


### PR DESCRIPTION
`BulkDumpTaskTimeout` reported a hardcoded `300.0` while the wait itself used
`CLIENT_KNOBS->BULKDUMP_JOB_TIMEOUT`, whose default is 24 hours and which the `BackupS3Blob` restore tests
override to 1200 or 5400. The event therefore named a duration no caller had asked for.

This costs real debugging time. Diagnosing a backup whose bulkdump snapshot was skipped, the trace points at
a 300 second timeout that does not exist; if you instead trust the knob default, you are left trying to
reconcile 24 hours against a simulation run that lasted 1281 seconds. The actual answer was a 1200 second
override in the test's own TOML, and the event was the one place that should have said so.

Trace detail only, no behaviour change.
