### PR TITLE
Add Python bindings for native CDC

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -126,6 +126,20 @@ if(NOT OPEN_FOR_IDE AND NOT USE_SANITIZER)
     DISABLE_LOG_DUMP
   )
 
+  add_fdbclient_test(
+    NAME python_native_cdc_tests
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tests/native_cdc_tests.py
+            --cluster-file @CLUSTER_FILE@ --verbose
+  )
+  set_property(TEST python_native_cdc_tests APPEND PROPERTY ENVIRONMENT
+    "FDB_KNOB_enable_native_cdc=true")
+
+  add_fdbclient_test(
+    NAME python_native_cdc_legacy_api_tests
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tests/native_cdc_tests.py
+            --cluster-file @CLUSTER_FILE@ --api-version 740 --verbose
+  )
+
   # FIXME Windows support
   set(PYPKG_TEST_DIR "${CMAKE_BINARY_DIR}/pypkg-test-venv")
   set(PYPKG_TEST_PY3 "${PYPKG_TEST_DIR}/bin/python3")

--- a/bindings/python/fdb/__init__.py
+++ b/bindings/python/fdb/__init__.py
@@ -109,6 +109,13 @@ def api_version(ver):
         "transactional",
         "options",
         "StreamingMode",
+        "CdcMutationType",
+        "CdcCursor",
+        "CdcStreamInfo",
+        "CdcMutation",
+        "CdcVersionedMutations",
+        "CdcConsumeResult",
+        "CdcConsumer",
     )
 
     _add_symbols(fdb.impl, list)

--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -23,9 +23,11 @@
 import atexit
 import ctypes
 import ctypes.util
+import enum
 import functools
 import inspect
 import multiprocessing
+import operator
 import os
 import platform
 import struct
@@ -33,6 +35,7 @@ import sys
 import threading
 import traceback
 import weakref
+from typing import NamedTuple, Tuple
 
 import fdb
 from fdb.tuple import int2byte
@@ -42,6 +45,7 @@ from fdb import fdboptions as _opts
 
 _network_thread = None
 _network_thread_reentrant_lock = threading.RLock()
+_cdc_c_api_initialized = False
 
 _open_file = open
 
@@ -891,6 +895,81 @@ class FutureStringArray(Future):
         return list(strings[0 : count.value])
 
 
+class FutureCdcStreamInfoArray(Future):
+    def wait(self):
+        self.block_until_ready()
+        streams = ctypes.POINTER(CdcStreamInfoStruct)()
+        count = ctypes.c_int()
+        self.capi.fdb_future_get_cdc_stream_info_array(
+            self.fpointer, ctypes.byref(streams), ctypes.byref(count)
+        )
+        return [
+            CdcStreamInfo(
+                ctypes.string_at(stream.name.key, stream.name.key_length),
+                stream.stream_id,
+                ctypes.string_at(
+                    stream.key_range.begin_key, stream.key_range.begin_key_length
+                ),
+                ctypes.string_at(
+                    stream.key_range.end_key, stream.key_range.end_key_length
+                ),
+                stream.min_version,
+            )
+            for stream in streams[: count.value]
+        ]
+
+
+class FutureCdcConsumer(Future):
+    def __init__(self, fpointer):
+        super().__init__(fpointer)
+        self._consumer = None
+        self._lock = threading.Lock()
+
+    def wait(self):
+        self.block_until_ready()
+        with self._lock:
+            if self._consumer is None:
+                consumer = CdcConsumer()
+                self.capi.fdb_future_get_cdc_consumer(
+                    self.fpointer, ctypes.byref(consumer._pointer)
+                )
+                # Each C getter call transfers a reference. Keep one Python
+                # owner even when callbacks or callers retrieve the result again.
+                self._consumer = consumer
+            return self._consumer
+
+
+class FutureCdcConsumeResult(Future):
+    def wait(self):
+        self.block_until_ready()
+        groups = ctypes.POINTER(CdcVersionedMutationsStruct)()
+        count = ctypes.c_int()
+        last_consumed_version = ctypes.c_int64()
+        self.capi.fdb_future_get_cdc_versioned_mutations(
+            self.fpointer,
+            ctypes.byref(groups),
+            ctypes.byref(count),
+            ctypes.byref(last_consumed_version),
+        )
+        return CdcConsumeResult(
+            tuple(
+                CdcVersionedMutations(
+                    group.version,
+                    tuple(
+                        CdcMutation(
+                            mutation.type,
+                            ctypes.string_at(mutation.param1, mutation.param1_length),
+                            ctypes.string_at(mutation.param2, mutation.param2_length),
+                        )
+                        for mutation in group.mutations[: group.mutation_count]
+                    ),
+                )
+                for group in groups[: count.value]
+            ),
+            last_consumed_version.value,
+        )
+
+
 class replaceable_property(object):
     def __get__(self, obj, cls=None):
         return self.method(obj)
@@ -1342,8 +1421,199 @@ class Database(_TransactionCreator):
     def get_client_status(self):
         return Key(self.capi.fdb_database_get_client_status(self.dpointer))
 
+    def register_cdc_stream(self, name, begin_key, end_key):
+        """Register a named CDC range and return a future containing its stream ID."""
+        _require_cdc_api_version()
+        name = keyToBytes(name)
+        begin_key = keyToBytes(begin_key)
+        end_key = keyToBytes(end_key)
+        return FutureUInt64(
+            self.capi.fdb_database_register_cdc_stream(
+                self.dpointer,
+                name,
+                len(name),
+                begin_key,
+                len(begin_key),
+                end_key,
+                len(end_key),
+            )
+        )
+
+    def remove_cdc_stream(self, name):
+        """Remove a stream and relinquish its unread history; return a void future."""
+        _require_cdc_api_version()
+        name = keyToBytes(name)
+        return FutureVoid(
+            self.capi.fdb_database_remove_cdc_stream(self.dpointer, name, len(name))
+        )
+
+    def list_cdc_streams(self):
+        """Return a future containing a list of CdcStreamInfo records."""
+        _require_cdc_api_version()
+        return FutureCdcStreamInfoArray(
+            self.capi.fdb_database_list_cdc_streams(self.dpointer)
+        )
+
+    def create_cdc_consumer(self, name):
+        """Return a future containing a consumer for an existing stream name."""
+        _require_cdc_api_version()
+        name = keyToBytes(name)
+        return FutureCdcConsumer(
+            self.capi.fdb_database_create_cdc_consumer(self.dpointer, name, len(name))
+        )
+
+    def resume_cdc_consumer(self, cursor):
+        """Return a consumer future from a durably checkpointed CdcCursor.
+
+        The native client validates the stream and position on consume or
+        acknowledge, not when constructing the handle.
+        """
+        _require_cdc_api_version()
+        stream_id = operator.index(cursor.stream_id)
+        version = operator.index(cursor.last_consumed_version)
+        if not 0 <= stream_id < 2**64:
+            raise ValueError("stream_id must fit in an unsigned 64-bit integer")
+        if not -(2**63) <= version < 2**63:
+            raise ValueError(
+                "last_consumed_version must fit in a signed 64-bit integer"
+            )
+        return FutureCdcConsumer(
+            self.capi.fdb_database_resume_cdc_consumer(
+                self.dpointer, stream_id, version
+            )
+        )
+
 
 fill_operations()
+
+
+class CdcMutationType(enum.IntEnum):
+    """Known raw CDC mutation codes; a reply may also contain unknown codes."""
+
+    SET_VALUE = 0
+    CLEAR_RANGE = 1
+    ADD = 2
+    AND = 6
+    OR = 7
+    XOR = 8
+    APPEND_IF_FITS = 9
+    MAX = 12
+    MIN = 13
+    SET_VERSIONSTAMPED_KEY = 14
+    SET_VERSIONSTAMPED_VALUE = 15
+    BYTE_MIN = 16
+    BYTE_MAX = 17
+    MIN_V2 = 18
+    AND_V2 = 19
+    COMPARE_AND_CLEAR = 20
+
+
+class CdcCursor(NamedTuple):
+    """A stream's stable ID and delivered position, suitable for checkpointing."""
+
+    stream_id: int
+    last_consumed_version: int
+
+
+class CdcStreamInfo(NamedTuple):
+    """A registered stream and its durable minimum required version."""
+
+    name: bytes
+    stream_id: int
+    begin_key: bytes
+    end_key: bytes
+    min_version: int
+
+
+class CdcMutation(NamedTuple):
+    """One raw mutation with Python-owned parameter bytes."""
+
+    type: int
+    param1: bytes
+    param2: bytes
+
+
+class CdcVersionedMutations(NamedTuple):
+    """A complete group of mutations sharing one commit version."""
+
+    version: int
+    mutations: Tuple[CdcMutation, ...]
+
+
+class CdcConsumeResult(NamedTuple):
+    """Copied mutation groups and the delivered watermark, even for empty replies."""
+
+    mutations: Tuple[CdcVersionedMutations, ...]
+    last_consumed_version: int
+
+
+class CdcConsumer(_FDBBase):
+    """An owned native CDC consumer handle.
+
+    Only one consume or acknowledge operation may be outstanding per handle.
+    Acknowledgements affect the whole stream, which must have only one active
+    logical consumer. Closing a handle does not acknowledge or remove its stream.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._pointer = ctypes.c_void_p()
+
+    def __del__(self):
+        if getattr(self, "_pointer", None):
+            self.close()
+
+    def _check_open(self):
+        if not self._pointer:
+            raise ValueError("CDC consumer is closed")
+
+    def close(self):
+        """Release this handle without acknowledging or removing the stream."""
+        with self._lock:
+            if self._pointer:
+                pointer = self._pointer
+                self._pointer = None
+                self.capi.fdb_cdc_consumer_destroy(pointer)
+
+    def __enter__(self):
+        with self._lock:
+            self._check_open()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def consume(self):
+        """Long-poll for complete commit groups; return a CdcConsumeResult future.
+
+        Consumption advances the delivered cursor, not durable retention. Do not
+        consume again until the previous reply has been durably processed.
+        """
+        with self._lock:
+            self._check_open()
+            return FutureCdcConsumeResult(
+                self.capi.fdb_cdc_consumer_consume(self._pointer)
+            )
+
+    def acknowledge(self):
+        """Durably acknowledge the current delivered position; return a void future.
+
+        Call only after durably processing every mutation through that position.
+        """
+        with self._lock:
+            self._check_open()
+            return FutureVoid(self.capi.fdb_cdc_consumer_acknowledge(self._pointer))
+
+    def get_position(self):
+        """Return the current CdcCursor; this does not acknowledge the position."""
+        with self._lock:
+            self._check_open()
+            stream_id = ctypes.c_uint64()
+            version = ctypes.c_int64()
+            self.capi.fdb_cdc_consumer_get_position(
+                self._pointer, ctypes.byref(stream_id), ctypes.byref(version)
+            )
+            return CdcCursor(stream_id.value, version.value)
 
 
 class Cluster(_FDBBase):
@@ -1436,6 +1706,46 @@ class KeyValueStruct(ctypes.Structure):
 class KeyStruct(ctypes.Structure):
     _fields_ = [("key", ctypes.POINTER(ctypes.c_byte)), ("key_length", ctypes.c_int)]
     _pack_ = 4
+
+
+class KeyRangeStruct(ctypes.Structure):
+    _pack_ = 4
+    _fields_ = [
+        ("begin_key", ctypes.POINTER(ctypes.c_byte)),
+        ("begin_key_length", ctypes.c_int),
+        ("end_key", ctypes.POINTER(ctypes.c_byte)),
+        ("end_key_length", ctypes.c_int),
+    ]
+
+
+class CdcStreamInfoStruct(ctypes.Structure):
+    _pack_ = 4
+    _fields_ = [
+        ("name", KeyStruct),
+        ("stream_id", ctypes.c_uint64),
+        ("key_range", KeyRangeStruct),
+        ("min_version", ctypes.c_int64),
+    ]
+
+
+class CdcMutationStruct(ctypes.Structure):
+    _pack_ = 4
+    _fields_ = [
+        ("type", ctypes.c_uint8),
+        ("param1", ctypes.POINTER(ctypes.c_byte)),
+        ("param1_length", ctypes.c_int),
+        ("param2", ctypes.POINTER(ctypes.c_byte)),
+        ("param2_length", ctypes.c_int),
+    ]
+
+
+class CdcVersionedMutationsStruct(ctypes.Structure):
+    _pack_ = 4
+    _fields_ = [
+        ("version", ctypes.c_int64),
+        ("mutations", ctypes.POINTER(CdcMutationStruct)),
+        ("mutation_count", ctypes.c_int),
+    ]
 
 
 class KeyValue(object):
@@ -1556,6 +1866,16 @@ def optionalParamToBytes(v):
     else:
         v = paramToBytes(v)
         return (v, len(v))
+
+
+def _require_cdc_api_version():
+    global _cdc_c_api_initialized
+    if fdb.get_api_version() < 800:
+        raise RuntimeError("Native CDC requires API version 800 or later")
+    with _network_thread_reentrant_lock:
+        if not _cdc_c_api_initialized:
+            _init_cdc_c_api()
+            _cdc_c_api_initialized = True
 
 
 _FDBBase.capi = _capi
@@ -1908,6 +2228,89 @@ def init_c_api():
 
     _capi.fdb_transaction_reset.argtypes = [ctypes.c_void_p]
     _capi.fdb_transaction_reset.restype = None
+
+
+def _init_cdc_c_api():
+    # Older libraries may support API 800 without these experimental symbols.
+    # Resolve the whole surface before using it, and leave non-CDC users alone.
+    signatures = (
+        (
+            "fdb_future_get_cdc_stream_info_array",
+            [
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.POINTER(CdcStreamInfoStruct)),
+                ctypes.POINTER(ctypes.c_int),
+            ],
+            ctypes.c_int,
+        ),
+        (
+            "fdb_future_get_cdc_consumer",
+            [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)],
+            ctypes.c_int,
+        ),
+        (
+            "fdb_future_get_cdc_versioned_mutations",
+            [
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.POINTER(CdcVersionedMutationsStruct)),
+                ctypes.POINTER(ctypes.c_int),
+                ctypes.POINTER(ctypes.c_int64),
+            ],
+            ctypes.c_int,
+        ),
+        (
+            "fdb_database_register_cdc_stream",
+            [
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_int,
+                ctypes.c_void_p,
+                ctypes.c_int,
+                ctypes.c_void_p,
+                ctypes.c_int,
+            ],
+            ctypes.c_void_p,
+        ),
+        (
+            "fdb_database_remove_cdc_stream",
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int],
+            ctypes.c_void_p,
+        ),
+        ("fdb_database_list_cdc_streams", [ctypes.c_void_p], ctypes.c_void_p),
+        (
+            "fdb_database_create_cdc_consumer",
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int],
+            ctypes.c_void_p,
+        ),
+        (
+            "fdb_database_resume_cdc_consumer",
+            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_int64],
+            ctypes.c_void_p,
+        ),
+        ("fdb_cdc_consumer_destroy", [ctypes.c_void_p], None),
+        ("fdb_cdc_consumer_consume", [ctypes.c_void_p], ctypes.c_void_p),
+        ("fdb_cdc_consumer_acknowledge", [ctypes.c_void_p], ctypes.c_void_p),
+        (
+            "fdb_cdc_consumer_get_position",
+            [
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_uint64),
+                ctypes.POINTER(ctypes.c_int64),
+            ],
+            ctypes.c_int,
+        ),
+    )
+    try:
+        functions = [getattr(_capi, name) for name, _, _ in signatures]
+    except AttributeError as error:
+        raise RuntimeError(
+            "The loaded FoundationDB C library does not support native CDC"
+        ) from error
+    for function, (_, argtypes, restype) in zip(functions, signatures):
+        function.argtypes = argtypes
+        function.restype = restype
+        if restype is ctypes.c_int:
+            function.errcheck = check_error_code
 
 
 if hasattr(ctypes.pythonapi, "Py_IncRef"):

--- a/bindings/python/tests/native_cdc_tests.py
+++ b/bindings/python/tests/native_cdc_tests.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+#
+# native_cdc_tests.py
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import ctypes
+import gc
+import threading
+import time
+import unittest
+import uuid
+from unittest import mock
+
+import fdb
+
+
+def wait(future, timeout=30):
+    ready = threading.Event()
+    future.on_ready(lambda _: ready.set())
+    if not ready.wait(timeout):
+        future.cancel()
+        raise AssertionError(
+            "CDC operation did not complete within {} seconds".format(timeout)
+        )
+    return future.wait()
+
+
+class CdcDecodingTests(unittest.TestCase):
+    def test_packed_c_layout(self):
+        impl = fdb.impl
+        pointer_size = ctypes.sizeof(ctypes.c_void_p)
+        layouts = (
+            (impl.KeyRangeStruct, 2 * pointer_size + 8),
+            (impl.CdcStreamInfoStruct, 3 * pointer_size + 28),
+            (impl.CdcMutationStruct, 2 * pointer_size + 12),
+            (impl.CdcVersionedMutationsStruct, pointer_size + 12),
+        )
+        for structure, size in layouts:
+            with self.subTest(structure=structure.__name__):
+                self.assertEqual(structure._pack_, 4)
+                self.assertEqual(ctypes.sizeof(structure), size)
+        self.assertEqual(impl.CdcMutationStruct.param1.offset, 4)
+        self.assertEqual(impl.CdcStreamInfoStruct.stream_id.offset, pointer_size + 4)
+
+    def test_unknown_mutation_type_and_copied_bytes(self):
+        impl = fdb.impl
+        key = ctypes.create_string_buffer(b"key\x00\xff")
+        value = ctypes.create_string_buffer(b"\x00value\xff")
+        mutations = (impl.CdcMutationStruct * 2)(
+            impl.CdcMutationStruct(
+                255,
+                ctypes.cast(key, ctypes.POINTER(ctypes.c_byte)),
+                len(key) - 1,
+                ctypes.cast(value, ctypes.POINTER(ctypes.c_byte)),
+                len(value) - 1,
+            ),
+            impl.CdcMutationStruct(fdb.CdcMutationType.SET_VALUE, None, 0, None, 0),
+        )
+        groups = (impl.CdcVersionedMutationsStruct * 2)(
+            impl.CdcVersionedMutationsStruct(100, mutations, 2),
+            impl.CdcVersionedMutationsStruct(101, None, 0),
+        )
+
+        def get_result(pointer, out_groups, out_count, out_version):
+            ctypes.cast(
+                out_groups,
+                ctypes.POINTER(ctypes.POINTER(impl.CdcVersionedMutationsStruct)),
+            )[0] = groups
+            ctypes.cast(out_count, ctypes.POINTER(ctypes.c_int))[0] = len(groups)
+            ctypes.cast(out_version, ctypes.POINTER(ctypes.c_int64))[0] = 150
+
+        future = impl.FutureCdcConsumeResult(1)
+        future.capi = mock.Mock()
+        future.capi.fdb_future_is_ready.return_value = 1
+        future.capi.fdb_future_get_cdc_versioned_mutations.side_effect = get_result
+        result = future.wait()
+        ctypes.memset(key, 0, len(key))
+        ctypes.memset(value, 0, len(value))
+        mutations[0].type = 0
+        groups[0].version = 0
+        del future
+        gc.collect()
+
+        self.assertEqual(
+            result,
+            fdb.CdcConsumeResult(
+                (
+                    fdb.CdcVersionedMutations(
+                        100,
+                        (
+                            fdb.CdcMutation(255, b"key\x00\xff", b"\x00value\xff"),
+                            fdb.CdcMutation(fdb.CdcMutationType.SET_VALUE, b"", b""),
+                        ),
+                    ),
+                    fdb.CdcVersionedMutations(101, ()),
+                ),
+                150,
+            ),
+        )
+        self.assertIs(type(result.mutations[0].mutations[0].type), int)
+        with self.assertRaises(AttributeError):
+            result.last_consumed_version = 0
+
+    def test_empty_reply_preserves_progress(self):
+        def get_result(pointer, out_groups, out_count, out_version):
+            ctypes.cast(out_count, ctypes.POINTER(ctypes.c_int))[0] = 0
+            ctypes.cast(out_version, ctypes.POINTER(ctypes.c_int64))[0] = 2**63 - 1
+
+        future = fdb.impl.FutureCdcConsumeResult(1)
+        future.capi = mock.Mock()
+        future.capi.fdb_future_is_ready.return_value = 1
+        future.capi.fdb_future_get_cdc_versioned_mutations.side_effect = get_result
+        self.assertEqual(future.wait(), fdb.CdcConsumeResult((), 2**63 - 1))
+
+
+class NativeCdcTests(unittest.TestCase):
+    def setUp(self):
+        self.prefix = b"python-cdc/" + uuid.uuid4().bytes + b"\x00/"
+        self.name = self.prefix + b"stream\x00\xff"
+        self.begin = self.prefix + b"range/"
+        self.end = self.prefix + b"range0"
+        self.addCleanup(self.db.clear_range, self.prefix, self.prefix + b"\xff")
+
+    def register(self):
+        stream_id = wait(self.db.register_cdc_stream(self.name, self.begin, self.end))
+        self.addCleanup(lambda: wait(self.db.remove_cdc_stream(self.name)))
+        return stream_id
+
+    def stream_info(self):
+        future = self.db.list_cdc_streams()
+        streams = wait(future)
+        self.assertEqual(future.wait(), streams)
+        future._release_memory()
+        del future
+        gc.collect()
+        return next(stream for stream in streams if stream.name == self.name)
+
+    def commit(self, write):
+        tr = self.db.create_transaction()
+        tr.options.set_timeout(30000)
+        while True:
+            try:
+                write(tr)
+                wait(tr.commit())
+                return tr.get_committed_version()
+            except fdb.FDBError as error:
+                wait(tr.on_error(error))
+
+    def consume_through(self, consumer, version):
+        groups = {}
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            future = consumer.consume()
+            result = wait(future)
+            self.assertEqual(future.wait(), result)
+            future._release_memory()
+            del future
+            gc.collect()
+            self.assertEqual(
+                consumer.get_position().last_consumed_version,
+                result.last_consumed_version,
+            )
+            self.assertIsInstance(result.mutations, tuple)
+            for group in result.mutations:
+                self.assertIsInstance(group.mutations, tuple)
+                if group.version in groups:
+                    self.assertEqual(groups[group.version], group.mutations)
+                groups[group.version] = group.mutations
+            if result.last_consumed_version >= version:
+                return groups
+        self.fail("CDC did not deliver the committed version within 60 seconds")
+
+    def assert_closed(self, consumer):
+        consumer.close()
+        consumer.close()
+        for operation in (
+            consumer.consume,
+            consumer.acknowledge,
+            consumer.get_position,
+        ):
+            with self.subTest(operation=operation.__name__):
+                with self.assertRaises(ValueError):
+                    operation()
+
+    def test_stream_lifecycle_and_result_ownership(self):
+        stream_id = self.register()
+        self.assertGreater(stream_id, 0)
+        self.assertEqual(
+            wait(self.db.register_cdc_stream(self.name, self.begin, self.end)),
+            stream_id,
+        )
+        info = self.stream_info()
+        self.assertEqual(
+            (info.name, info.stream_id, info.begin_key, info.end_key),
+            (self.name, stream_id, self.begin, self.end),
+        )
+        self.assertGreaterEqual(info.min_version, 0)
+        with self.assertRaises(AttributeError):
+            info.name = b"different"
+
+        create_future = self.db.create_cdc_consumer(self.name)
+        consumer = wait(create_future)
+        self.addCleanup(consumer.close)
+        self.assertIs(create_future.wait(), consumer)
+        self.assertIs(create_future.result(), consumer)
+        self.assertIsNone(create_future.exception())
+        create_future._release_memory()
+        del create_future
+        gc.collect()
+        self.assertEqual(consumer.get_position(), fdb.CdcCursor(stream_id, -1))
+
+        first_key = self.begin + b"first\x00\xff"
+        second_key = self.begin + b"second"
+        empty_key = self.begin + b"empty"
+        first_value = b"\x00first\xffvalue\x00"
+        second_value = b"second-value"
+
+        def write_sets(tr):
+            tr[first_key] = first_value
+            tr[second_key] = second_value
+            tr[self.prefix + b"outside"] = b"not in the stream"
+
+        set_version = self.commit(write_sets)
+        empty_version = self.commit(lambda tr: tr.set(empty_key, b""))
+        groups = self.consume_through(consumer, empty_version)
+        self.assertCountEqual(
+            groups[set_version],
+            (
+                fdb.CdcMutation(fdb.CdcMutationType.SET_VALUE, first_key, first_value),
+                fdb.CdcMutation(
+                    fdb.CdcMutationType.SET_VALUE, second_key, second_value
+                ),
+            ),
+        )
+        self.assertEqual(
+            groups[empty_version],
+            (fdb.CdcMutation(fdb.CdcMutationType.SET_VALUE, empty_key, b""),),
+        )
+        cursor = consumer.get_position()
+        self.assert_closed(consumer)
+        self.assertEqual(self.stream_info().min_version, info.min_version)
+
+        resume_future = self.db.resume_cdc_consumer(cursor)
+        resumed = wait(resume_future)
+        self.addCleanup(resumed.close)
+        self.assertIs(resume_future.wait(), resumed)
+        del resume_future
+        gc.collect()
+        with resumed:
+            self.assertEqual(resumed.get_position(), cursor)
+            # A resumed handle has no local delivery proof. Its acknowledgement
+            # must be at or behind a fresh database read version.
+            deadline = time.monotonic() + 30
+            while True:
+                remaining = deadline - time.monotonic()
+                self.assertGreater(remaining, 0, "Read version did not reach cursor")
+                tr = self.db.create_transaction()
+                read_version = wait(
+                    tr.get_read_version(),
+                    timeout=max(0, deadline - time.monotonic()),
+                )
+                if read_version >= cursor.last_consumed_version:
+                    break
+                time.sleep(min(0.01, max(0, deadline - time.monotonic())))
+            # Reconcile the durable checkpoint, then reissue the acknowledgement.
+            for _ in range(2):
+                self.assertIsNone(wait(resumed.acknowledge()))
+                self.assertEqual(
+                    self.stream_info().min_version,
+                    cursor.last_consumed_version + 1,
+                )
+            clear_end = first_key + b"\x00"
+            counter_key = self.begin + b"counter"
+            operand = b"\x01\x00\x00\x00"
+
+            def write_raw_mutations(tr):
+                tr.clear_range(first_key, clear_end)
+                tr.add(counter_key, operand)
+
+            raw_version = self.commit(write_raw_mutations)
+            groups = self.consume_through(resumed, raw_version)
+            self.assertCountEqual(
+                groups[raw_version],
+                (
+                    fdb.CdcMutation(
+                        fdb.CdcMutationType.CLEAR_RANGE, first_key, clear_end
+                    ),
+                    fdb.CdcMutation(fdb.CdcMutationType.ADD, counter_key, operand),
+                ),
+            )
+            self.assertIsNone(wait(resumed.acknowledge()))
+        self.assert_closed(resumed)
+
+        self.assertIsNone(wait(self.db.remove_cdc_stream(self.name)))
+        self.assertIsNone(wait(self.db.remove_cdc_stream(self.name)))
+        self.assertNotIn(
+            self.name, [stream.name for stream in wait(self.db.list_cdc_streams())]
+        )
+
+    def test_native_errors_propagate(self):
+        with self.assertRaises(fdb.FDBError):
+            wait(self.db.create_cdc_consumer(self.name))
+        self.register()
+        with self.assertRaises(fdb.FDBError):
+            wait(self.db.register_cdc_stream(self.name, self.begin, self.end + b"\x00"))
+        self.assertEqual(self.stream_info().end_key, self.end)
+
+    def test_missing_cdc_symbols_preserves_normal_database_use(self):
+        impl = fdb.impl
+        capi = impl._capi
+
+        class WithoutCdcSymbols:
+            def __getattr__(self, name):
+                if "_cdc_" in name:
+                    raise AttributeError(name)
+                return getattr(capi, name)
+
+        with mock.patch.object(impl, "_capi", WithoutCdcSymbols()):
+            with mock.patch.object(impl, "_cdc_c_api_initialized", False):
+                impl.init_c_api()
+                with self.assertRaisesRegex(
+                    RuntimeError, "does not support native CDC"
+                ):
+                    self.db.list_cdc_streams()
+                self.assertFalse(impl._cdc_c_api_initialized)
+                key = self.prefix + b"compatibility"
+                self.db[key] = b"ordinary value"
+                self.assertEqual(self.db[key], b"ordinary value")
+
+    def test_cursor_integer_boundaries(self):
+        for cursor in (
+            fdb.CdcCursor(0, -(2**63)),
+            fdb.CdcCursor(2**64 - 1, 2**63 - 1),
+        ):
+            with self.subTest(cursor=cursor):
+                with wait(self.db.resume_cdc_consumer(cursor)) as consumer:
+                    self.assertEqual(consumer.get_position(), cursor)
+        for cursor in (
+            fdb.CdcCursor(-1, -1),
+            fdb.CdcCursor(2**64, -1),
+            fdb.CdcCursor(1, -(2**63) - 1),
+            fdb.CdcCursor(1, 2**63),
+        ):
+            with self.subTest(cursor=cursor):
+                with self.assertRaises(ValueError):
+                    self.db.resume_cdc_consumer(cursor)
+        for cursor in (fdb.CdcCursor(1.5, -1), fdb.CdcCursor(1, "0")):
+            with self.subTest(cursor=cursor):
+                with self.assertRaises(TypeError):
+                    self.db.resume_cdc_consumer(cursor)
+
+
+class LegacyApiTests(unittest.TestCase):
+    def test_normal_database_use_and_cdc_version_gate(self):
+        key = b"python-cdc-legacy/" + uuid.uuid4().bytes
+        self.addCleanup(self.db.clear, key)
+        self.db[key] = b"normal database operations still work"
+        self.assertEqual(self.db[key], b"normal database operations still work")
+        operations = (
+            lambda: self.db.register_cdc_stream(b"legacy", b"a", b"z"),
+            lambda: self.db.remove_cdc_stream(b"legacy"),
+            lambda: self.db.list_cdc_streams(),
+            lambda: self.db.create_cdc_consumer(b"legacy"),
+            lambda: self.db.resume_cdc_consumer(fdb.CdcCursor(1, -1)),
+        )
+        for operation in operations:
+            with self.assertRaisesRegex(RuntimeError, "requires API version 800"):
+                operation()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Native CDC Python binding tests")
+    parser.add_argument("--cluster-file", "-C", required=True)
+    parser.add_argument("--api-version", type=int, default=fdb.LATEST_API_VERSION)
+    parser.add_argument("--verbose", "-V", action="store_true")
+    args = parser.parse_args()
+    fdb.api_version(args.api_version)
+    db = fdb.open(args.cluster_file)
+    db.options.set_transaction_timeout(30000)
+    NativeCdcTests.db = db
+    LegacyApiTests.db = db
+    classes = (
+        (CdcDecodingTests, NativeCdcTests)
+        if args.api_version >= 800
+        else (LegacyApiTests,)
+    )
+    suite = unittest.TestSuite(
+        unittest.defaultTestLoader.loadTestsFromTestCase(cls) for cls in classes
+    )
+    result = unittest.TextTestRunner(verbosity=2 if args.verbose else 1).run(suite)
+    raise SystemExit(0 if result.wasSuccessful() else 1)

--- a/design/cdc.md
+++ b/design/cdc.md
@@ -11,11 +11,11 @@ or transaction-system recovery.
 
 ## Background
 
-This design describes the native C++ interface, its C binding, and its server
-implementation. The feature is disabled by default behind `ENABLE_NATIVE_CDC`;
+This design describes the native C++ interface, its C and Python bindings, and
+its server implementation. The feature is disabled by default behind `ENABLE_NATIVE_CDC`;
 the native CDC workloads explicitly enable it, and simulation may randomly
-enable it. The client interface is exposed through the native C++ API and C
-binding; it does not expose an external protocol compatibility guarantee.
+enable it. The client interface is exposed through the native C++ API and C and
+Python bindings; it does not expose an external protocol compatibility guarantee.
 
 The implementation uses the following terms:
 
@@ -85,7 +85,7 @@ The current implementation does not attempt to provide:
   range requires removing and registering a stream.
 * Throughput-aware assignment of streams across CDC proxies.
 * Throughput-aware movement of streams between CDC tags.
-* Language-specific bindings beyond the C API.
+* Language-specific bindings beyond the C and Python APIs.
 
 ## Client interface
 
@@ -95,7 +95,8 @@ value types and the thread-safe surface shared with language bindings are in
 roles are in the private `fdbclient/NativeCdcInternal.h`; cursor and wire
 request types are in `fdbclient/CDCProxyInterface.h`. The public C binding is
 declared in `bindings/c/foundationdb/fdb_c.h` and documented in
-`documentation/sphinx/source/api-c.rst`.
+`documentation/sphinx/source/api-c.rst`. The Python binding is documented in
+`documentation/sphinx/source/api-python.rst`.
 `CDCStreamId` is a `uint64_t` typedef. CDC tag IDs are 16-bit, so one
 configured tag pool can contain at most 65,536 distinct tags.
 
@@ -773,8 +774,8 @@ policy simple.
   response to load. A future implementation can use versioned tag history to
   make such changes without losing the ability to read earlier tagged data.
 * The CDC client surface does not yet provide language-specific bindings beyond
-  the C API, administrative tooling, or a higher-level consumer checkpoint
-  abstraction.
+  the C and Python APIs, administrative tooling, or a higher-level consumer
+  checkpoint abstraction.
 
 These improvements must preserve the acknowledgement and retired-pop
 invariants above. In particular, moving a stream between tags cannot forget an

--- a/documentation/sphinx/source/api-python.rst
+++ b/documentation/sphinx/source/api-python.rst
@@ -519,10 +519,15 @@ Stream management
     a checkpointed :class:`CdcCursor`. The cursor contains no process-local
     state. Stream existence and cursor validity are checked when consuming
     or acknowledging, not by this method. Resume only from a durably processed
-    checkpoint. Before the first consume, reissue :meth:`CdcConsumer.acknowledge`
-    and wait for it to complete to reconcile a possibly interrupted
-    acknowledgement. Unacknowledged mutations may be redelivered after CDC
-    proxy replacement, so processing must tolerate replay.
+    checkpoint. Before the first consume, wait until a fresh database read
+    version reaches ``cursor.last_consumed_version``, then reissue
+    :meth:`CdcConsumer.acknowledge` and wait for it to complete to reconcile a
+    possibly interrupted acknowledgement. A resumed handle lacks the original
+    handle's delivery proof, so an unacknowledged cursor ahead of that read
+    version is rejected with ``client_invalid_operation`` even if it was
+    previously delivered. Bound the read-version wait rather than retrying all
+    invalid-operation errors. Unacknowledged mutations may be redelivered after
+    CDC proxy replacement, so processing must tolerate replay.
 
 Result types
 ------------
@@ -623,6 +628,8 @@ and must tolerate replay without repeating non-idempotent side effects. It
 must also handle an empty reply. If it raises, the loop does not acknowledge
 the reply::
 
+    import time
+
     import fdb
 
     fdb.api_version(800)
@@ -637,13 +644,24 @@ the reply::
 
     with consumer_future.wait() as consumer:
         if saved_cursor is not None:
+            deadline = time.monotonic() + 30
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("CDC checkpoint is ahead of the read version")
+                tr = db.create_transaction()
+                tr.options.set_read_lock_aware()
+                tr.options.set_timeout(max(1, int(remaining * 1000)))
+                if tr.get_read_version().wait() >= saved_cursor.last_consumed_version:
+                    break
+                time.sleep(min(0.01, max(0, deadline - time.monotonic())))
             consumer.acknowledge().wait()
         while True:
             reply = consumer.consume().wait()
             apply_and_checkpoint(reply.mutations, consumer.get_position())
             consumer.acknowledge().wait()
 
-The acknowledgement immediately after resume closes the crash gap between
+The acknowledgement after the read-version wait closes the crash gap between
 persisting the checkpoint and completing its acknowledgement; reissuing an
 already durable acknowledgement is safe. This requires a cursor whose
 mutations are known to have been durably processed. Never invent a cursor or

--- a/documentation/sphinx/source/api-python.rst
+++ b/documentation/sphinx/source/api-python.rst
@@ -455,7 +455,200 @@ Database options
 .. method:: Database.options.set_snapshot_ryw_disable()
 
     |option-db-snapshot-ryw-disable-blurb|
-    
+
+.. _api-python-cdc:
+
+Native change data capture (CDC)
+================================
+
+CDC provides durable, named streams of committed mutations for a non-empty,
+half-open user-key range. Select API version 800 or later with
+:func:`api_version` before using this interface. New stream registration also
+requires the cluster's ``ENABLE_NATIVE_CDC`` admission knob. Existing streams
+can still be listed or removed while admission is disabled; consumer creation,
+resume, consumption, and acknowledgement also remain available. Repeating an
+existing same-name, same-range registration remains idempotent.
+
+Unlike the synchronous database key-value methods, the CDC database methods
+and the consumer's ``consume()`` and ``acknowledge()`` methods return
+:ref:`futures <api-python-future>`. Use their usual ``wait()``, ``on_ready()``,
+or ``result()`` interfaces to observe completion and errors. These operations
+are not methods on :class:`Transaction`, and cannot be made atomic with
+application writes by using :func:`transactional`.
+
+.. warning::
+
+    A stream has one shared acknowledgement frontier, not one per handle.
+    Use only one active logical consumer per stream. Each handle permits only
+    one outstanding ``consume()`` or ``acknowledge()`` operation at a time.
+    Acknowledge only after every mutation through the delivered position and
+    the corresponding application checkpoint are durable. Neither consuming
+    nor closing a handle acknowledges automatically. An abandoned stream can
+    retain unread log history indefinitely until acknowledged or removed.
+
+Stream management
+-----------------
+
+.. method:: Database.register_cdc_stream(name, begin_key, end_key)
+
+    Registers the byte-string ``name`` for ``[begin_key, end_key)`` in normal
+    user key space. The name and range must be non-empty. Repeating the same
+    name and range is idempotent; reusing a name with another range fails.
+    Returns a future whose value is the unsigned 64-bit stream ID as a Python
+    ``int``. Register long-lived streams rather than a stream per request.
+
+.. method:: Database.remove_cdc_stream(name)
+
+    Removes the byte-string stream name and relinquishes its unread history.
+    Removing a missing name succeeds. Returns a future whose value is
+    ``None``. Removal is terminal for existing consumers; registering the
+    same name again does not redirect their cursors to the new stream.
+
+.. method:: Database.list_cdc_streams()
+
+    Returns a future whose value is a list of :class:`CdcStreamInfo` records.
+
+.. method:: Database.create_cdc_consumer(name)
+
+    Returns a future whose value is a :class:`CdcConsumer` for the existing
+    byte-string stream name at its initial position.
+
+.. method:: Database.resume_cdc_consumer(cursor)
+
+    Returns a future whose value is a :class:`CdcConsumer` constructed from
+    a checkpointed :class:`CdcCursor`. The cursor contains no process-local
+    state. Stream existence and cursor validity are checked when consuming
+    or acknowledging, not by this method. Resume only from a durably processed
+    checkpoint. Before the first consume, reissue :meth:`CdcConsumer.acknowledge`
+    and wait for it to complete to reconcile a possibly interrupted
+    acknowledgement. Unacknowledged mutations may be redelivered after CDC
+    proxy replacement, so processing must tolerate replay.
+
+Result types
+------------
+
+The following records are immutable tuples with named fields. Returned names,
+keys, and mutation parameters are Python-owned ``bytes``, copied from the
+native result. They remain valid after the future or consumer is released.
+
+.. class:: CdcCursor(stream_id, last_consumed_version)
+
+    A stable unsigned 64-bit stream ID and the signed 64-bit version through
+    which mutations have been delivered. Both fields are Python ``int``
+    values. A delivered cursor is not proof of processing or acknowledgement.
+
+.. class:: CdcStreamInfo(name, stream_id, begin_key, end_key, min_version)
+
+    A stream's byte-string name, integer ID, half-open registered key range,
+    and durable minimum required version. ``min_version`` is a retention
+    frontier, not a snapshot version for the registered key range.
+
+.. class:: CdcMutation(type, param1, param2)
+
+    One raw mutation. ``type`` is an integer, including for unrecognized
+    mutation types; ``param1`` and ``param2`` are byte strings. For
+    ``SET_VALUE`` they are the key and value; for ``CLEAR_RANGE`` they are
+    the begin and end keys, clipped to the registered range; for atomic
+    mutations they are the key and operand. CDC returns raw mutation
+    operations, not a materialized post-mutation value for every key.
+
+.. class:: CdcMutationType
+
+    An ``enum.IntEnum`` of known raw mutation type values, matching the C API
+    constants without the ``FDB_CDC_MUTATION_TYPE_`` prefix: ``SET_VALUE``,
+    ``CLEAR_RANGE``, ``ADD``, ``AND``, ``OR``, ``XOR``, ``APPEND_IF_FITS``,
+    ``MAX``, ``MIN``, ``SET_VERSIONSTAMPED_KEY``, ``SET_VERSIONSTAMPED_VALUE``,
+    ``BYTE_MIN``, ``BYTE_MAX``, ``MIN_V2``, ``AND_V2``, and ``COMPARE_AND_CLEAR``.
+    These constants are not exhaustive. Compare ``mutation.type`` to known
+    constants, but handle unknown integers without assuming that constructing
+    ``CdcMutationType(mutation.type)`` will succeed.
+
+.. class:: CdcVersionedMutations(version, mutations)
+
+    One complete commit-version group, with an integer ``version`` and a
+    tuple of :class:`CdcMutation` records. Preserve this grouping when
+    processing a reply.
+
+.. class:: CdcConsumeResult(mutations, last_consumed_version)
+
+    ``mutations`` is a tuple of :class:`CdcVersionedMutations` groups;
+    ``last_consumed_version`` is the integer delivered cursor after the reply.
+    The cursor may advance across commit-version gaps with no returned
+    mutations. Even an empty reply can advance the cursor; do not infer it
+    from the last mutation group or skip checkpointing and acknowledgement
+    solely because ``mutations`` is empty.
+
+Consumer lifecycle
+------------------
+
+.. class:: CdcConsumer
+
+    An owned native consumer handle, obtained from a database create or resume
+    future. It remains valid independently of that future. Use it as a
+    context manager or call :meth:`CdcConsumer.close` when finished.
+
+.. method:: CdcConsumer.consume()
+
+    Long-polls for the next delivered position and complete commit-version
+    groups. Returns a future whose value is :class:`CdcConsumeResult`.
+    Successful consumption advances the in-memory position, but does not
+    release durable retention. Finish processing a reply before consuming
+    again if that reply may need to be retried. Following proxy replacement,
+    the client may rewind to its last successful durable acknowledgement and
+    redeliver unacknowledged mutations.
+
+.. method:: CdcConsumer.acknowledge()
+
+    Durably acknowledges the handle's current delivered position, allowing
+    history through that position to be released. Returns a future whose
+    value is ``None``. Wait for it before starting another consume or
+    acknowledgement. This is not atomic with writes to a downstream system
+    or an application checkpoint.
+
+.. method:: CdcConsumer.get_position()
+
+    Returns the current :class:`CdcCursor` synchronously.
+
+.. method:: CdcConsumer.close()
+
+    Releases the local handle. Repeated calls are harmless. It does not
+    acknowledge the delivered position or remove the stream. Exiting the
+    consumer's context manager calls this method, including on exceptions.
+
+For example, the following loop supports both an initial start and a restart.
+The application-supplied ``load_checkpoint`` returns a durable
+:class:`CdcCursor`, or ``None`` on the first start. ``apply_and_checkpoint``
+must durably apply complete version groups and record the cursor consistently,
+and must tolerate replay without repeating non-idempotent side effects. It
+must also handle an empty reply. If it raises, the loop does not acknowledge
+the reply::
+
+    import fdb
+
+    fdb.api_version(800)
+    db = fdb.open()
+    db.register_cdc_stream(b"orders", b"order/", b"order0").wait()
+
+    saved_cursor = load_checkpoint()
+    if saved_cursor is None:
+        consumer_future = db.create_cdc_consumer(b"orders")
+    else:
+        consumer_future = db.resume_cdc_consumer(saved_cursor)
+
+    with consumer_future.wait() as consumer:
+        if saved_cursor is not None:
+            consumer.acknowledge().wait()
+        while True:
+            reply = consumer.consume().wait()
+            apply_and_checkpoint(reply.mutations, consumer.get_position())
+            consumer.acknowledge().wait()
+
+The acknowledgement immediately after resume closes the crash gap between
+persisting the checkpoint and completing its acknowledgement; reissuing an
+already durable acknowledgement is safe. This requires a cursor whose
+mutations are known to have been durably processed. Never invent a cursor or
+advance a checkpoint or acknowledgement beyond that position.
+
 Transactional decoration
 ========================
 


### PR DESCRIPTION
## Summary

- Expose native CDC stream registration, listing, removal, consumer creation and resumption through the Python database API.
- Support multi-range streams with `register_cdc_stream(name, ranges=[(begin, end), ...])`, while retaining the single-range `register_cdc_stream(name, begin, end)` form. Listed streams expose their canonical union as immutable, Python-owned `CdcKeyRange` records.
- Add future-based consumption and explicit acknowledgement, immutable mutation/cursor records, and owned consumer handles with deterministic cleanup.
- Load CDC symbols only on first use so ordinary database operations still work with client libraries that do not expose CDC.
- Document retention, replay, and checkpoint/acknowledgement recovery semantics without changing the native protocol or server behavior.

## Validation

- `python_native_cdc_tests`: passed all 8 tests, including canonical range unions, binary result ownership, gap filtering, clipped clears, acknowledgement/resume, and single-range compatibility.
- `python_native_cdc_legacy_api_tests`: passed with API version 740.
- Existing `python_unit_tests`: passed.
- Black 22.8.0 and Flake8 5.0.4: passed.
- Sphinx dummy build with warnings treated as errors: passed.

## Compatibility

CDC requires API version 800 or later, the multi-range native CDC implementation, and cluster admission for new streams. Earlier experimental single-range CDC binaries have an incompatible ABI; drain and remove their streams and finish retired cleanup before upgrading all CDC-capable clients and servers.

Closing a consumer neither acknowledges mutations nor removes its stream. All registered ranges share one cursor and acknowledgement frontier. Results own their bytes independently of native futures, and unknown raw mutation codes remain available to callers. Single-range stream metadata retains `begin_key` and `end_key` properties; multi-range callers use `ranges`.
