### PR TITLE
Convert `DDTeamCollection` to standard coroutines

### DIFF
--- a/fdbserver/datadistributor/DDTeamCollection.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.cpp
@@ -1,5 +1,5 @@
 /*
- * DDTeamCollection.actor.cpp
+ * DDTeamCollection.cpp
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -36,7 +36,6 @@
 #include "flow/TxnCounters.h"
 
 #include "flow/CoroUtils.h"
-#include "flow/actorcompiler.h" // This must be the last #include.
 
 namespace {
 
@@ -1409,27 +1408,29 @@ public:
 		}
 	}
 
-	ACTOR static Future<Void> storageServerTracker(
+	static Future<Void> storageServerTracker(
 	    DDTeamCollection* self,
 	    TCServerInfo* server, // This actor is owned by this TCServerInfo, point to server_info[id]
 	    Promise<Void> errorOut,
 	    Version addedVersion,
 	    const DDEnabledState* ddEnabledState,
 	    bool isTss) {
-		state Future<Void> failureTracker;
-		state ServerStatus status(server->getLastKnownInterface().locality);
-		state bool lastIsUnhealthy = false;
-		state Future<Void> metricsTracker = server->serverMetricsPolling(self->db);
+		Future<Void> failureTracker;
+		ServerStatus status(server->getLastKnownInterface().locality);
+		bool lastIsUnhealthy = false;
+		Future<Void> metricsTracker = server->serverMetricsPolling(self->db);
 
-		state Future<std::pair<StorageServerInterface, ProcessClass>> interfaceChanged = server->onInterfaceChanged;
-		state bool hasWrongDC = !self->isCorrectDC(*server);
-		state bool hasInvalidLocality =
+		Future<std::pair<StorageServerInterface, ProcessClass>> interfaceChanged = server->onInterfaceChanged;
+		bool hasWrongDC = !self->isCorrectDC(*server);
+		bool hasInvalidLocality =
 		    !self->isValidLocality(self->configuration.storagePolicy, server->getLastKnownInterface().locality);
-		state int targetTeamNumPerServer =
+		int targetTeamNumPerServer =
 		    (SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER * (self->configuration.storageTeamSize + 1)) / 2;
-		state Future<Void> storageMetadataTracker = self->updateStorageMetadata(server);
+		Future<Void> storageMetadataTracker = self->updateStorageMetadata(server);
+		std::vector<Future<Void>> otherChanges;
+		Error err;
 		try {
-			loop {
+			while (true) {
 				{
 					bool versionLagUndesired =
 					    !self->disableFailingLaggingServers.get() && server->ssVersionTooFarBehind.get();
@@ -1450,7 +1451,7 @@ public:
 				// If there is any other server on this exact NetworkAddress, this server is undesired and will
 				// eventually be eliminated. This samAddress checking must be redo whenever the server's state (e.g.,
 				// storeType, dcLocation, interface) is changed.
-				state std::vector<Future<Void>> otherChanges;
+				otherChanges = std::vector<Future<Void>>();
 				std::vector<Promise<Void>> wakeUpTrackers;
 				for (const auto& i : self->server_and_tss_info) {
 					if (i.second.getPtr() != server &&
@@ -1606,9 +1607,9 @@ public:
 						TraceEvent(SevWarn, "FailedServerRemoveKeys", self->distributorId)
 						    .detail("Server", server->getId())
 						    .detail("Excluded", worstAddr.toString());
-						wait(delay(0.0)); // Do not throw an error while still inside trackExcludedServers
+						co_await delay(0.0); // Do not throw an error while still inside trackExcludedServers
 						while (!ddEnabledState->isEnabled()) {
-							wait(delay(1.0));
+							co_await delay(1.0);
 						}
 						if (self->removeFailedServer.canBeSet()) {
 							self->removeFailedServer.send(server->getId());
@@ -1631,191 +1632,195 @@ public:
 				}
 				lastIsUnhealthy = status.isUnhealthy();
 
-				state bool recordTeamCollectionInfo = false;
-				choose {
-					when(wait(failureTracker || server->onTSSPairRemoved || server->killTss.getFuture())) {
-						// The server is failed AND all data has been removed from it, so permanently remove it.
-						TraceEvent("StatusMapChange", self->distributorId)
-						    .detail("ServerID", server->getId())
-						    .detail("Status", "Removing");
+				bool recordTeamCollectionInfo = false;
+				auto serverRemoved = failureTracker || server->onTSSPairRemoved || server->killTss.getFuture();
+				// Do not start the quorum when an earlier branch is already ready.
+				Future<Void> otherChange = serverRemoved.isReady() || interfaceChanged.isReady() || otherChanges.empty()
+				                               ? Future<Void>(Never())
+				                               : quorum(otherChanges, 1);
+				auto res = co_await race(std::move(serverRemoved),
+				                         interfaceChanged,
+				                         std::move(otherChange),
+				                         server->wrongStoreTypeToRemove.onChange(),
+				                         server->wakeUpTracker.getFuture(),
+				                         storageMetadataTracker,
+				                         server->ssVersionTooFarBehind.onChange(),
+				                         self->disableFailingLaggingServers.onChange(),
+				                         server->longStorageQueue.onChange());
+				if (res.index() == 0) {
+					// The server is failed AND all data has been removed from it, so permanently remove it.
+					TraceEvent("StatusMapChange", self->distributorId)
+					    .detail("ServerID", server->getId())
+					    .detail("Status", "Removing");
 
-						if (server->updated.canBeSet()) {
-							server->updated.send(Void());
-						}
-
-						// Remove server from FF/serverList
-						storageMetadataTracker.cancel();
-						wait(self->db->removeStorageServer(
-						    server->getId(), server->getLastKnownInterface().tssPairID, self->lock, ddEnabledState));
-
-						TraceEvent("StatusMapChange", self->distributorId)
-						    .detail("ServerID", server->getId())
-						    .detail("Status", "Removed");
-						// Sets removeSignal (alerting dataDistributionTeamCollection to remove the storage server from
-						// its own data structures)
-						server->removed.send(Void());
-						if (isTss) {
-							self->removedTSS.send(server->getId());
-						} else {
-							self->removedServers.send(server->getId());
-						}
-						return Void();
+					if (server->updated.canBeSet()) {
+						server->updated.send(Void());
 					}
-					when(std::pair<StorageServerInterface, ProcessClass> newInterface = wait(interfaceChanged)) {
-						auto const& lastKnownInterface = server->getLastKnownInterface();
-						bool restartRecruiting = newInterface.first.waitFailure.getEndpoint().getPrimaryAddress() !=
-						                         lastKnownInterface.waitFailure.getEndpoint().getPrimaryAddress();
-						bool localityChanged = lastKnownInterface.locality != newInterface.first.locality;
-						bool zoneLocalityChanged =
-						    lastKnownInterface.locality.zoneId().get() != newInterface.first.locality.zoneId().get();
-						TraceEvent("StorageServerInterfaceChanged", self->distributorId)
-						    .detail("ServerID", server->getId())
-						    .detail("NewWaitFailureToken", newInterface.first.waitFailure.getEndpoint().token)
-						    .detail("OldWaitFailureToken", lastKnownInterface.waitFailure.getEndpoint().token)
-						    .detail("LocalityChanged", localityChanged)
-						    .detail("ZoneLocalityChanged", zoneLocalityChanged);
 
-						server->updateLastKnown(newInterface.first, newInterface.second);
-						if (localityChanged && !isTss) {
-							CODE_PROBE(true, "Server locality changed");
+					// Remove server from FF/serverList
+					storageMetadataTracker.cancel();
+					co_await self->db->removeStorageServer(
+					    server->getId(), server->getLastKnownInterface().tssPairID, self->lock, ddEnabledState);
 
-							// Machine teams are keyed by zone ID, so zone locality changes require updating
-							// machine-team membership for this server.
-							if (zoneLocalityChanged) {
-								// First handle the impact on the server's old zone-keyed machine.
-								Reference<TCMachineInfo> machine = server->machine;
-								ASSERT_GE(machine->serversOnMachine.size(), 1);
-								if (machine->serversOnMachine.size() == 1) {
-									// When this is the last server on the zone-keyed machine,
-									// remove the machine and related machine teams.
-									self->removeMachine(machine);
-									server->machine = Reference<TCMachineInfo>();
-								} else {
-									// Remove the server from the zone-keyed machine. The representative locality
-									// entry is left stale until machineLocalityMap is rebuilt.
-									int serverIndex = -1;
-									for (int i = 0; i < machine->serversOnMachine.size(); ++i) {
-										if (machine->serversOnMachine[i].getPtr() == server) {
-											// NOTE: now the machine's locality is wrong. Need update it whenever uses
-											// it.
-											serverIndex = i;
-											machine->serversOnMachine[i] = machine->serversOnMachine.back();
-											machine->serversOnMachine.pop_back();
-											break; // Invariant: server only appear on the machine once
-										}
+					TraceEvent("StatusMapChange", self->distributorId)
+					    .detail("ServerID", server->getId())
+					    .detail("Status", "Removed");
+					// Sets removeSignal (alerting dataDistributionTeamCollection to remove the storage server from
+					// its own data structures)
+					server->removed.send(Void());
+					if (isTss) {
+						self->removedTSS.send(server->getId());
+					} else {
+						self->removedServers.send(server->getId());
+					}
+					co_return;
+				} else if (res.index() == 1) {
+					auto newInterface = std::get<1>(std::move(res));
+					auto const& lastKnownInterface = server->getLastKnownInterface();
+					bool restartRecruiting = newInterface.first.waitFailure.getEndpoint().getPrimaryAddress() !=
+					                         lastKnownInterface.waitFailure.getEndpoint().getPrimaryAddress();
+					bool localityChanged = lastKnownInterface.locality != newInterface.first.locality;
+					bool zoneLocalityChanged =
+					    lastKnownInterface.locality.zoneId().get() != newInterface.first.locality.zoneId().get();
+					TraceEvent("StorageServerInterfaceChanged", self->distributorId)
+					    .detail("ServerID", server->getId())
+					    .detail("NewWaitFailureToken", newInterface.first.waitFailure.getEndpoint().token)
+					    .detail("OldWaitFailureToken", lastKnownInterface.waitFailure.getEndpoint().token)
+					    .detail("LocalityChanged", localityChanged)
+					    .detail("ZoneLocalityChanged", zoneLocalityChanged);
+
+					server->updateLastKnown(newInterface.first, newInterface.second);
+					if (localityChanged && !isTss) {
+						CODE_PROBE(true, "Server locality changed");
+
+						// Machine teams are keyed by zone ID, so zone locality changes require updating
+						// machine-team membership for this server.
+						if (zoneLocalityChanged) {
+							// First handle the impact on the server's old zone-keyed machine.
+							Reference<TCMachineInfo> machine = server->machine;
+							ASSERT_GE(machine->serversOnMachine.size(), 1);
+							if (machine->serversOnMachine.size() == 1) {
+								// When this is the last server on the zone-keyed machine,
+								// remove the machine and related machine teams.
+								self->removeMachine(machine);
+								server->machine = Reference<TCMachineInfo>();
+							} else {
+								// Remove the server from the zone-keyed machine. The representative locality
+								// entry is left stale until machineLocalityMap is rebuilt.
+								int serverIndex = -1;
+								for (int i = 0; i < machine->serversOnMachine.size(); ++i) {
+									if (machine->serversOnMachine[i].getPtr() == server) {
+										// NOTE: now the machine's locality is wrong. Need update it whenever uses
+										// it.
+										serverIndex = i;
+										machine->serversOnMachine[i] = machine->serversOnMachine.back();
+										machine->serversOnMachine.pop_back();
+										break; // Invariant: server only appear on the machine once
 									}
-									ASSERT(serverIndex != -1);
-									// NOTE: we do not update the machine's locality map even when
-									// its representative server is changed.
 								}
-
-								// Next handle the destination zone-keyed machine. Create it if necessary;
-								// otherwise add the server and update its machine reference.
-								Reference<TCMachineInfo> destMachine =
-								    self->checkAndCreateMachine(self->server_info[server->getId()]);
-								ASSERT(destMachine.isValid());
+								ASSERT(serverIndex != -1);
+								// NOTE: we do not update the machine's locality map even when
+								// its representative server is changed.
 							}
 
-							// Ensure the server's server team belong to a machine team, and
-							// Get the newBadTeams due to the locality change
-							std::vector<Reference<TCTeamInfo>> newBadTeams;
-							for (auto& serverTeam : server->getTeams()) {
-								if (!self->satisfiesPolicy(serverTeam->getServers())) {
-									newBadTeams.push_back(serverTeam);
-									continue;
-								}
-								if (zoneLocalityChanged) {
-									Reference<TCMachineTeamInfo> machineTeam =
-									    self->checkAndCreateMachineTeam(serverTeam);
-									ASSERT(machineTeam.isValid());
-									serverTeam->machineTeam = machineTeam;
-								}
-							}
+							// Next handle the destination zone-keyed machine. Create it if necessary;
+							// otherwise add the server and update its machine reference.
+							Reference<TCMachineInfo> destMachine =
+							    self->checkAndCreateMachine(self->server_info[server->getId()]);
+							ASSERT(destMachine.isValid());
+						}
 
-							server->updateInDesiredDC(self->includedDCs);
-							self->resetLocalitySet();
+						// Ensure the server's server team belong to a machine team, and
+						// Get the newBadTeams due to the locality change
+						std::vector<Reference<TCTeamInfo>> newBadTeams;
+						for (auto& serverTeam : server->getTeams()) {
+							if (!self->satisfiesPolicy(serverTeam->getServers())) {
+								newBadTeams.push_back(serverTeam);
+								continue;
+							}
+							if (zoneLocalityChanged) {
+								Reference<TCMachineTeamInfo> machineTeam = self->checkAndCreateMachineTeam(serverTeam);
+								ASSERT(machineTeam.isValid());
+								serverTeam->machineTeam = machineTeam;
+							}
+						}
 
-							bool addedNewBadTeam = false;
-							for (auto it : newBadTeams) {
-								if (self->removeTeam(it)) {
-									self->addTeam(it->getServers(), IsInitialTeam::True);
-									addedNewBadTeam = true;
-								}
+						server->updateInDesiredDC(self->includedDCs);
+						self->resetLocalitySet();
+
+						bool addedNewBadTeam = false;
+						for (auto it : newBadTeams) {
+							if (self->removeTeam(it)) {
+								self->addTeam(it->getServers(), IsInitialTeam::True);
+								addedNewBadTeam = true;
 							}
-							if (addedNewBadTeam && self->badTeamRemover.isReady()) {
-								// TODO: Improve simulation testing to test locality changes. Until then, we
-								// realistically don't expect this code probe to be hit.
-								CODE_PROBE(true, "Server locality change created bad teams", probe::decoration::rare);
-								self->doBuildTeams = true;
-								self->badTeamRemover = removeBadTeams(self);
-								self->addActor.send(self->badTeamRemover);
-								// The team number changes, so we need to update the team number info
-								// self->traceTeamCollectionInfo();
-								recordTeamCollectionInfo = true;
-							}
-							// The locality change of the server will invalid the server's old teams,
-							// so we need to rebuild teams for the server
+						}
+						if (addedNewBadTeam && self->badTeamRemover.isReady()) {
+							// TODO: Improve simulation testing to test locality changes. Until then, we
+							// realistically don't expect this code probe to be hit.
+							CODE_PROBE(true, "Server locality change created bad teams", probe::decoration::rare);
 							self->doBuildTeams = true;
+							self->badTeamRemover = removeBadTeams(self);
+							self->addActor.send(self->badTeamRemover);
+							// The team number changes, so we need to update the team number info
+							// self->traceTeamCollectionInfo();
+							recordTeamCollectionInfo = true;
 						}
+						// The locality change of the server will invalid the server's old teams,
+						// so we need to rebuild teams for the server
+						self->doBuildTeams = true;
+					}
 
-						interfaceChanged = server->onInterfaceChanged;
-						// Old failureTracker for the old interface will be actorCancelled since the handler of the old
-						// actor now points to the new failure monitor actor.
-						status = ServerStatus(IsFailed(status.isFailed),
-						                      IsUndesired(status.isUndesired),
-						                      IsWiggling(status.isWiggling),
-						                      server->getLastKnownInterface().locality);
+					interfaceChanged = server->onInterfaceChanged;
+					// Old failureTracker for the old interface will be actorCancelled since the handler of the old
+					// actor now points to the new failure monitor actor.
+					status = ServerStatus(IsFailed(status.isFailed),
+					                      IsUndesired(status.isUndesired),
+					                      IsWiggling(status.isWiggling),
+					                      server->getLastKnownInterface().locality);
 
-						// self->traceTeamCollectionInfo();
-						recordTeamCollectionInfo = true;
-						// Restart the storeTracker for the new interface. This will cancel the previous
-						// keyValueStoreTypeTracker
-						storageMetadataTracker = self->updateStorageMetadata(server);
-						hasWrongDC = !self->isCorrectDC(*server);
-						hasInvalidLocality = !self->isValidLocality(self->configuration.storagePolicy,
-						                                            server->getLastKnownInterface().locality);
-						self->restartTeamBuilder.trigger();
+					// self->traceTeamCollectionInfo();
+					recordTeamCollectionInfo = true;
+					// Restart the storeTracker for the new interface. This will cancel the previous
+					// keyValueStoreTypeTracker
+					storageMetadataTracker = self->updateStorageMetadata(server);
+					hasWrongDC = !self->isCorrectDC(*server);
+					hasInvalidLocality = !self->isValidLocality(self->configuration.storagePolicy,
+					                                            server->getLastKnownInterface().locality);
+					self->restartTeamBuilder.trigger();
 
-						if (restartRecruiting)
-							self->restartRecruiting.trigger();
-					}
-					when(wait(otherChanges.empty() ? Never() : quorum(otherChanges, 1))) {
-						TraceEvent("SameAddressChangedStatus", self->distributorId).detail("ServerID", server->getId());
-					}
-					when(wait(server->wrongStoreTypeToRemove.onChange())) {
-						TraceEvent("UndesiredStorageServerTriggered", self->distributorId)
-						    .detail("Server", server->getId())
-						    .detail("StoreType", server->getStoreType())
-						    .detail("ConfigStoreType", self->configuration.storageServerStoreType)
-						    .detail("WrongStoreTypeRemoved", server->wrongStoreTypeToRemove.get());
-					}
-					when(wait(server->wakeUpTracker.getFuture())) {
-						server->wakeUpTracker = Promise<Void>();
-					}
-					when(wait(storageMetadataTracker)) {}
-					when(wait(server->ssVersionTooFarBehind.onChange())) {}
-					when(wait(self->disableFailingLaggingServers.onChange())) {}
-					when(wait(server->longStorageQueue.onChange())) {
-						int64_t threshold = calculateTeamStorageQueueThreshold(self->teams);
-						// threshold represents the queue length of majority teams
-						// team queue length is defined as the max queue size among all SSes of the team
-						if (server->longStorageQueue.get() < threshold) {
-							TraceEvent(SevInfo, "TriggerStorageQueueRebalanceIgnored", self->distributorId)
-							    .detail("SSID", server->getId());
-						} else {
-							TraceEvent(SevInfo, "TriggerStorageQueueRebalance", self->distributorId)
-							    .detail("SSID", server->getId());
-							std::vector<ShardsAffectedByTeamFailure::Team> teams;
-							for (const auto& team : server->getTeams()) {
-								std::vector<UID> servers;
-								for (const auto& server : team->getServers()) {
-									servers.push_back(server->getId());
-								}
-								teams.push_back(ShardsAffectedByTeamFailure::Team(servers, self->primary));
+					if (restartRecruiting)
+						self->restartRecruiting.trigger();
+				} else if (res.index() == 2) {
+					TraceEvent("SameAddressChangedStatus", self->distributorId).detail("ServerID", server->getId());
+				} else if (res.index() == 3) {
+					TraceEvent("UndesiredStorageServerTriggered", self->distributorId)
+					    .detail("Server", server->getId())
+					    .detail("StoreType", server->getStoreType())
+					    .detail("ConfigStoreType", self->configuration.storageServerStoreType)
+					    .detail("WrongStoreTypeRemoved", server->wrongStoreTypeToRemove.get());
+				} else if (res.index() == 4) {
+					server->wakeUpTracker = Promise<Void>();
+				} else if (res.index() == 8) {
+					int64_t threshold = calculateTeamStorageQueueThreshold(self->teams);
+					// threshold represents the queue length of majority teams
+					// team queue length is defined as the max queue size among all SSes of the team
+					if (server->longStorageQueue.get() < threshold) {
+						TraceEvent(SevInfo, "TriggerStorageQueueRebalanceIgnored", self->distributorId)
+						    .detail("SSID", server->getId());
+					} else {
+						TraceEvent(SevInfo, "TriggerStorageQueueRebalance", self->distributorId)
+						    .detail("SSID", server->getId());
+						std::vector<ShardsAffectedByTeamFailure::Team> teams;
+						for (const auto& team : server->getTeams()) {
+							std::vector<UID> servers;
+							for (const auto& server : team->getServers()) {
+								servers.push_back(server->getId());
 							}
-							self->triggerStorageQueueRebalance.send(
-							    RebalanceStorageQueueRequest(server->getId(), teams, self->primary));
+							teams.push_back(ShardsAffectedByTeamFailure::Team(servers, self->primary));
 						}
+						self->triggerStorageQueueRebalance.send(
+						    RebalanceStorageQueueRequest(server->getId(), teams, self->primary));
 					}
 				}
 
@@ -1824,18 +1829,18 @@ public:
 				}
 			}
 		} catch (Error& e) {
-			state Error err = e;
-			TraceEvent("StorageServerTrackerCancelled", self->distributorId)
-			    .errorUnsuppressed(e)
-			    .suppressFor(1.0)
-			    .detail("Primary", self->primary)
-			    .detail("Server", server->getId());
-			if (e.code() != error_code_actor_cancelled && errorOut.canBeSet()) {
-				errorOut.sendError(e);
-				wait(delay(0)); // Check for cancellation, since errorOut.sendError(e) could delete self
-			}
-			throw err;
+			err = e;
 		}
+		TraceEvent("StorageServerTrackerCancelled", self->distributorId)
+		    .errorUnsuppressed(err)
+		    .suppressFor(1.0)
+		    .detail("Primary", self->primary)
+		    .detail("Server", server->getId());
+		if (err.code() != error_code_actor_cancelled && errorOut.canBeSet()) {
+			errorOut.sendError(err);
+			co_await delay(0); // Check for cancellation, since errorOut.sendError(err) could delete self
+		}
+		throw err;
 	}
 
 	static Future<Void> removeWrongStoreType(DDTeamCollection* self) {
@@ -2489,20 +2494,20 @@ public:
 		}
 	}
 
-	ACTOR static Future<Void> perpetualStorageWiggler(DDTeamCollection* self,
-	                                                  AsyncVar<bool>* stopSignal,
-	                                                  PromiseStream<Void> finishStorageWiggleSignal) {
-		state StorageWiggleData wiggleState;
-		state KeyBackedObjectMap<UID, StorageWiggleValue, decltype(IncludeVersion())> metadataMap =
+	static Future<Void> perpetualStorageWiggler(DDTeamCollection* self,
+	                                            AsyncVar<bool>* stopSignal,
+	                                            PromiseStream<Void> finishStorageWiggleSignal) {
+		StorageWiggleData wiggleState;
+		KeyBackedObjectMap<UID, StorageWiggleValue, decltype(IncludeVersion())> metadataMap =
 		    wiggleState.wigglingStorageServer(PrimaryRegion(self->primary));
 
-		state Future<StorageWiggleValue> nextFuture = Never();
-		state Future<Void> moveFinishFuture = Never();
-		state int extraTeamCount = 0;
-		state Future<Void> ddQueueCheck = clusterHealthCheckForPerpetualWiggle(self, &extraTeamCount);
-		state FutureStream<StorageWiggleValue> nextStream = self->nextWiggleInfo.getFuture();
+		Future<StorageWiggleValue> nextFuture = Never();
+		Future<Void> moveFinishFuture = Never();
+		int extraTeamCount = 0;
+		Future<Void> ddQueueCheck = clusterHealthCheckForPerpetualWiggle(self, &extraTeamCount);
+		FutureStream<StorageWiggleValue> nextStream = self->nextWiggleInfo.getFuture();
 
-		wait(readStorageWiggleMap(self));
+		co_await readStorageWiggleMap(self);
 
 		if (!self->wigglingId.present()) {
 			// skip to the next valid ID
@@ -2510,11 +2515,11 @@ public:
 			finishStorageWiggleSignal.send(Void());
 		}
 
-		loop {
-			state Future<Void> pauseChanged = self->pauseWiggle->onChange();
-			state Future<Void> stopChanged = stopSignal->onChange();
+		while (true) {
+			Future<Void> pauseChanged = self->pauseWiggle->onChange();
+			Future<Void> stopChanged = stopSignal->onChange();
 			if (self->wigglingId.present()) {
-				state UID id = self->wigglingId.get();
+				UID id = self->wigglingId.get();
 				if (self->pauseWiggle->get()) {
 					CODE_PROBE(true, "paused because cluster is unhealthy");
 					moveFinishFuture = Never();
@@ -2530,53 +2535,52 @@ public:
 					    .detail("ExtraHealthyTeamCount", extraTeamCount)
 					    .detail("HealthyTeamCount", self->healthyTeamCount);
 				} else {
-					choose {
-						when(wait(self->waitUntilHealthy())) {
-							CODE_PROBE(true, "start wiggling");
-							wait(self->storageWiggler->startWiggle());
-							auto fv = self->excludeStorageServersForWiggle(id);
-							moveFinishFuture = fv;
-							self->storageWiggler->setWiggleState(StorageWiggler::RUN);
-							TraceEvent("PerpetualStorageWiggleStart", self->distributorId)
-							    .detail("Primary", self->primary)
-							    .detail("ServerId", id)
-							    .detail("ExtraHealthyTeamCount", extraTeamCount)
-							    .detail("HealthyTeamCount", self->healthyTeamCount);
-						}
-						when(wait(pauseChanged)) {
-							continue;
-						}
+					auto res = co_await race(self->waitUntilHealthy(), pauseChanged);
+					if (res.index() == 1) {
+						continue;
 					}
+					CODE_PROBE(true, "start wiggling");
+					co_await self->storageWiggler->startWiggle();
+					moveFinishFuture = self->excludeStorageServersForWiggle(id);
+					self->storageWiggler->setWiggleState(StorageWiggler::RUN);
+					TraceEvent("PerpetualStorageWiggleStart", self->distributorId)
+					    .detail("Primary", self->primary)
+					    .detail("ServerId", id)
+					    .detail("ExtraHealthyTeamCount", extraTeamCount)
+					    .detail("HealthyTeamCount", self->healthyTeamCount);
 				}
 			}
 
-			choose {
-				when(StorageWiggleValue value = wait(nextFuture)) {
-					ASSERT(!self->wigglingId.present()); // the previous wiggle must be finished
-					nextFuture = Never();
-					self->wigglingId = value.id;
-					// random delay
-					wait(delayJittered(5.0, TaskPriority::DataDistributionLow));
-				}
-				when(wait(moveFinishFuture)) {
-					ASSERT(self->wigglingId.present());
-					self->waitUntilRecruited.set(true);
-					self->restartTeamBuilder.trigger();
+			// Do not start the signal wait if a higher-priority branch is already ready.
+			auto res = co_await race(nextFuture,
+			                         moveFinishFuture,
+			                         nextFuture.isReady() || moveFinishFuture.isReady()
+			                             ? Future<Void>(Never())
+			                             : ddQueueCheck || pauseChanged || stopChanged);
+			if (res.index() == 0) {
+				StorageWiggleValue value = std::get<0>(res);
+				ASSERT(!self->wigglingId.present()); // the previous wiggle must be finished
+				nextFuture = Never();
+				self->wigglingId = value.id;
+				// random delay
+				co_await delayJittered(5.0, TaskPriority::DataDistributionLow);
+			} else if (res.index() == 1) {
+				ASSERT(self->wigglingId.present());
+				self->waitUntilRecruited.set(true);
+				self->restartTeamBuilder.trigger();
 
-					moveFinishFuture = Never();
-					self->includeStorageServersForWiggle();
-					TraceEvent("PerpetualStorageWiggleFinish", self->distributorId)
-					    .detail("Primary", self->primary)
-					    .detail("ServerId", self->wigglingId.get());
+				moveFinishFuture = Never();
+				self->includeStorageServersForWiggle();
+				TraceEvent("PerpetualStorageWiggleFinish", self->distributorId)
+				    .detail("Primary", self->primary)
+				    .detail("ServerId", self->wigglingId.get());
 
-					wait(self->eraseStorageWiggleMap(&metadataMap, self->wigglingId.get()) &&
-					     self->storageWiggler->finishWiggle());
-					self->wigglingId.reset();
-					nextFuture = waitAndForward(nextStream);
-					finishStorageWiggleSignal.send(Void());
-					extraTeamCount = std::max(0, extraTeamCount - 1);
-				}
-				when(wait(ddQueueCheck || pauseChanged || stopChanged)) {}
+				co_await (self->eraseStorageWiggleMap(&metadataMap, self->wigglingId.get()) &&
+				          self->storageWiggler->finishWiggle());
+				self->wigglingId.reset();
+				nextFuture = waitAndForward(nextStream);
+				finishStorageWiggleSignal.send(Void());
+				extraTeamCount = std::max(0, extraTeamCount - 1);
 			}
 
 			if (stopSignal->get()) {
@@ -2591,8 +2595,6 @@ public:
 			    .detail("ServerId", self->wigglingId.get());
 			self->wigglingId.reset();
 		}
-
-		return Void();
 	}
 
 	// This coroutine sets a watch to monitor the value change of `perpetualStorageWiggleKey` which is controlled by
@@ -3035,32 +3037,27 @@ public:
 		self->restartRecruiting.trigger();
 	}
 
-	ACTOR static Future<Void> storageRecruiter(
-	    DDTeamCollection* self,
-	    Reference<IAsyncListener<RequestStream<RecruitStorageRequest>>> recruitStorage,
-	    DDEnabledState const* ddEnabledState) {
-		state Future<RecruitStorageReply> fCandidateWorker;
-		state RecruitStorageRequest lastRequest;
-		state bool hasHealthyTeam;
-		state std::map<AddressExclusion, int> numSSPerAddr;
-		state std::map<AddressExclusion, int> numSSIgnoredPerAddr;
+	static Future<Void> storageRecruiter(DDTeamCollection* self,
+	                                     Reference<IAsyncListener<RequestStream<RecruitStorageRequest>>> recruitStorage,
+	                                     DDEnabledState const* ddEnabledState) {
+		Future<RecruitStorageReply> fCandidateWorker;
+		RecruitStorageRequest lastRequest;
 
 		// tss-specific recruitment state
-		state int32_t targetTSSInDC = 0;
-		state int32_t tssToRecruit = 0;
-		state int inProgressTSSCount = 0;
-		state PromiseStream<Future<Void>> addTSSInProgress;
-		state Future<Void> inProgressTSS =
+		int32_t tssToRecruit = 0;
+		int inProgressTSSCount = 0;
+		PromiseStream<Future<Void>> addTSSInProgress;
+		Future<Void> inProgressTSS =
 		    actorCollection(addTSSInProgress.getFuture(), &inProgressTSSCount, nullptr, nullptr, nullptr);
-		state Reference<TSSPairState> tssState = makeReference<TSSPairState>();
-		state Future<Void> checkTss = self->initialFailureReactionDelay;
-		state bool pendingTSSCheck = false;
+		Reference<TSSPairState> tssState = makeReference<TSSPairState>();
+		Future<Void> checkTss = self->initialFailureReactionDelay;
+		bool pendingTSSCheck = false;
 
 		TraceEvent(SevDebug, "TSS_RecruitUpdated", self->distributorId).detail("Count", tssToRecruit);
 
-		loop {
+		while (true) {
 			try {
-				targetTSSInDC = self->getTargetTSSInDC();
+				int32_t targetTSSInDC = self->getTargetTSSInDC();
 				int newTssToRecruit = targetTSSInDC - self->tss_info_by_pair.size() - inProgressTSSCount;
 				// FIXME: Should log this if the recruit count stays the same but the other numbers update?
 				if (newTssToRecruit != tssToRecruit) {
@@ -3080,90 +3077,99 @@ public:
 						checkTss = self->initialFailureReactionDelay;
 					}
 				}
-				numSSPerAddr.clear();
-				numSSIgnoredPerAddr.clear();
-				hasHealthyTeam = (self->healthyTeamCount != 0);
-				RecruitStorageRequest rsr;
-				std::set<AddressExclusion> exclusions;
-				// Exclude existing servers running SS from being recruited again.
-				for (auto s = self->server_and_tss_info.begin(); s != self->server_and_tss_info.end(); ++s) {
-					auto serverStatus = self->server_status.get(s->second->getLastKnownInterface().id());
-					auto addr = s->second->getLastKnownInterface().stableAddress();
-					AddressExclusion addrExcl(addr.ip, addr.port);
-					if (serverStatus.excludeOnRecruit()) {
-						TraceEvent(SevDebug, "DDRecruitExcl1")
-						    .detail("Primary", self->primary)
-						    .detail("Excluding", s->second->getLastKnownInterface().address());
-						exclusions.insert(addrExcl);
-						numSSPerAddr[addrExcl]++; // increase from 0
-					} else {
-						numSSIgnoredPerAddr[addrExcl]++;
+				std::map<AddressExclusion, int> numSSPerAddr;
+				bool hasHealthyTeam = (self->healthyTeamCount != 0);
+				{
+					std::map<AddressExclusion, int> numSSIgnoredPerAddr;
+					RecruitStorageRequest rsr;
+					std::set<AddressExclusion> exclusions;
+					// Exclude existing servers running SS from being recruited again.
+					for (auto s = self->server_and_tss_info.begin(); s != self->server_and_tss_info.end(); ++s) {
+						auto serverStatus = self->server_status.get(s->second->getLastKnownInterface().id());
+						auto addr = s->second->getLastKnownInterface().stableAddress();
+						AddressExclusion addrExcl(addr.ip, addr.port);
+						if (serverStatus.excludeOnRecruit()) {
+							TraceEvent(SevDebug, "DDRecruitExcl1")
+							    .detail("Primary", self->primary)
+							    .detail("Excluding", s->second->getLastKnownInterface().address());
+							exclusions.insert(addrExcl);
+							numSSPerAddr[addrExcl]++; // increase from 0
+						} else {
+							numSSIgnoredPerAddr[addrExcl]++;
+						}
+					}
+					for (auto addr : self->recruitingLocalities) {
+						exclusions.insert(AddressExclusion(addr.ip, addr.port));
+					}
+
+					auto excl = self->excludedServers.getKeys();
+					for (const auto& s : excl) {
+						if (self->excludedServers.get(s) != DDTeamCollection::Status::NONE) {
+							TraceEvent(SevDebug, "DDRecruitExcl2")
+							    .detail("Primary", self->primary)
+							    .detail("Excluding", s.toString());
+							exclusions.insert(s);
+						}
+					}
+
+					// Exclude workers that have invalid locality
+					for (auto& addr : self->invalidLocalityAddr) {
+						TraceEvent(SevDebug, "DDRecruitExclInvalidAddr").detail("Excluding", addr.toString());
+						exclusions.insert(addr);
+					}
+
+					for (auto& it : numSSIgnoredPerAddr) {
+						if (it.second > 2) {
+							// In this case, we know initialize storage will skip recruiting this host due to too many
+							// storages already on the process. Exclude it from the request to the CC to try to find a
+							// better fit, especially in the critical recruitment case. This is temporary while storages
+							// are in this state. Either these failed storages will eventually have data moved away,
+							// which will trigger restartRecruiting again, or the host will become healthy again, in
+							// which case we won't need to recruit on it and it would be counted with Excl1.
+							exclusions.insert(it.first);
+							TraceEvent(SevDebug, "DDRecruitExcl3")
+							    .detail("Primary", self->primary)
+							    .detail("Excluding", it.first.toString())
+							    .detail("IgnoredCount", it.second);
+						}
+					}
+
+					rsr.criticalRecruitment = !hasHealthyTeam;
+					for (auto it : exclusions) {
+						rsr.excludeAddresses.push_back(it);
+					}
+
+					rsr.includeDCs = self->includedDCs;
+
+					TraceEvent(rsr.criticalRecruitment ? SevWarn : SevInfo, "DDRecruiting")
+					    .detail("Primary", self->primary)
+					    .detail("State", "Sending request to CC")
+					    .detail("Exclusions", rsr.excludeAddresses.size())
+					    .detail("Critical", rsr.criticalRecruitment)
+					    .detail("IncludedDCsSize", rsr.includeDCs.size());
+
+					if (rsr.criticalRecruitment) {
+						TraceEvent(SevWarn, "DDRecruitingEmergency", self->distributorId)
+						    .detail("Primary", self->primary);
+					}
+
+					if (!fCandidateWorker.isValid() || fCandidateWorker.isReady() ||
+					    rsr.excludeAddresses != lastRequest.excludeAddresses ||
+					    rsr.criticalRecruitment != lastRequest.criticalRecruitment) {
+						lastRequest = rsr;
+						fCandidateWorker =
+						    brokenPromiseToNever(recruitStorage->get().getReply(rsr, TaskPriority::DataDistribution));
 					}
 				}
-				for (auto addr : self->recruitingLocalities) {
-					exclusions.insert(AddressExclusion(addr.ip, addr.port));
-				}
 
-				auto excl = self->excludedServers.getKeys();
-				for (const auto& s : excl) {
-					if (self->excludedServers.get(s) != DDTeamCollection::Status::NONE) {
-						TraceEvent(SevDebug, "DDRecruitExcl2")
-						    .detail("Primary", self->primary)
-						    .detail("Excluding", s.toString());
-						exclusions.insert(s);
-					}
-				}
-
-				// Exclude workers that have invalid locality
-				for (auto& addr : self->invalidLocalityAddr) {
-					TraceEvent(SevDebug, "DDRecruitExclInvalidAddr").detail("Excluding", addr.toString());
-					exclusions.insert(addr);
-				}
-
-				for (auto& it : numSSIgnoredPerAddr) {
-					if (it.second > 2) {
-						// In this case, we know initialize storage will skip recruiting this host due to too many
-						// storages already on the process. Exclude it from the request to the CC to try to find a
-						// better fit, especially in the critical recruitment case. This is temporary while storages are
-						// in this state. Either these failed storages will eventually have data moved away, which will
-						// trigger restartRecruiting again, or the host will become healthy again, in which case we
-						// won't need to recruit on it and it would be counted with Excl1.
-						exclusions.insert(it.first);
-						TraceEvent(SevDebug, "DDRecruitExcl3")
-						    .detail("Primary", self->primary)
-						    .detail("Excluding", it.first.toString())
-						    .detail("IgnoredCount", it.second);
-					}
-				}
-
-				rsr.criticalRecruitment = !hasHealthyTeam;
-				for (auto it : exclusions) {
-					rsr.excludeAddresses.push_back(it);
-				}
-
-				rsr.includeDCs = self->includedDCs;
-
-				TraceEvent(rsr.criticalRecruitment ? SevWarn : SevInfo, "DDRecruiting")
-				    .detail("Primary", self->primary)
-				    .detail("State", "Sending request to CC")
-				    .detail("Exclusions", rsr.excludeAddresses.size())
-				    .detail("Critical", rsr.criticalRecruitment)
-				    .detail("IncludedDCsSize", rsr.includeDCs.size());
-
-				if (rsr.criticalRecruitment) {
-					TraceEvent(SevWarn, "DDRecruitingEmergency", self->distributorId).detail("Primary", self->primary);
-				}
-
-				if (!fCandidateWorker.isValid() || fCandidateWorker.isReady() ||
-				    rsr.excludeAddresses != lastRequest.excludeAddresses ||
-				    rsr.criticalRecruitment != lastRequest.criticalRecruitment) {
-					lastRequest = rsr;
-					fCandidateWorker =
-					    brokenPromiseToNever(recruitStorage->get().getReply(rsr, TaskPriority::DataDistribution));
-				}
-
-				choose {
-					when(RecruitStorageReply candidateWorker = wait(fCandidateWorker)) {
+				{
+					auto res = co_await race(fCandidateWorker,
+					                         recruitStorage->onChange(),
+					                         self->zeroHealthyTeams->onChange(),
+					                         checkTss,
+					                         self->restartRecruiting.onTrigger());
+					if (res.index() == 0) {
+						RecruitStorageReply candidateWorker = std::get<0>(std::move(res));
 						// Note that this call may be blocked in CC when there are no more storage process matching
 						// the criteria in RecruitStorageRequest.
 						AddressExclusion candidateSSAddr(candidateWorker.worker.stableAddress().ip,
@@ -3212,17 +3218,14 @@ public:
 								    self, candidateWorker, ddEnabledState, false, makeReference<TSSPairState>()));
 							}
 						}
-					}
-					when(wait(recruitStorage->onChange())) {
+					} else if (res.index() == 1) {
 						fCandidateWorker = Future<RecruitStorageReply>();
-					}
-					when(wait(self->zeroHealthyTeams->onChange())) {
+					} else if (res.index() == 2) {
 						if (!pendingTSSCheck && self->zeroHealthyTeams->get() &&
 						    (self->isTssRecruiting || self->tss_info_by_pair.size() > 0)) {
 							checkTss = self->initialFailureReactionDelay;
 						}
-					}
-					when(wait(checkTss)) {
+					} else if (res.index() == 3) {
 						bool cancelTss = self->isTssRecruiting && (tssToRecruit < 0 || self->zeroHealthyTeams->get());
 						// Can't kill more tss' than we have. Kill 1 if zero healthy teams, otherwise kill enough to get
 						// back to the desired amount
@@ -3261,7 +3264,7 @@ public:
 										Promise<Void> shutdown = self->shutdown;
 										killPromise.send(Void());
 										if (!shutdown.canBeSet()) {
-											return Void(); // "self" got destroyed, so return.
+											co_return; // "self" got destroyed, so return.
 										}
 									}
 								}
@@ -3284,9 +3287,8 @@ public:
 							}
 						}
 					}
-					when(wait(self->restartRecruiting.onTrigger())) {}
 				}
-				wait(delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY, TaskPriority::DataDistribution));
+				co_await delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY, TaskPriority::DataDistribution);
 			} catch (Error& e) {
 				if (e.code() != error_code_timed_out) {
 					throw;
@@ -3481,100 +3483,109 @@ public:
 		}
 	}
 
-	ACTOR static Future<Void> updateStorageMetadata(DDTeamCollection* self, TCServerInfo* server) {
-		state TxnCounters* counters = updateStorageMetadataCounters();
-		state KeyBackedObjectMap<UID, StorageMetadataType, decltype(IncludeVersion())> metadataMap(
-		    serverMetadataKeys.begin, IncludeVersion());
-		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(self->dbContext());
+	static Future<Void> updateStorageMetadata(DDTeamCollection* self, TCServerInfo* server) {
+		{
+			TxnCounters* counters = updateStorageMetadataCounters();
+			KeyBackedObjectMap<UID, StorageMetadataType, decltype(IncludeVersion())> metadataMap(
+			    serverMetadataKeys.begin, IncludeVersion());
+			Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(self->dbContext());
 
-		state bool isTss = server->getLastKnownInterface().isTss();
-		// Update server's storeType, especially when it was created
-		wait(server->updateStoreType());
-		if (server->getStoreType() == KeyValueStoreType::SSD_SHARDED_ROCKSDB &&
-		    !SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
-			TraceEvent(SevError, "PhysicalShardNotEnabledForShardedRocks", self->getDistributorId())
-			    .detail("StorageServer", server->getId());
-			throw internal_error();
-		}
-		state StorageMetadataType data(
-		    StorageMetadataType::currentTime(),
-		    server->getStoreType(),
-		    !(server->isCorrectStoreType(isTss ? self->configuration.testingStorageServerStoreType
-		                                       : (self->configuration.perpetualStoreType.isValid()
-		                                              ? self->configuration.perpetualStoreType
-		                                              : self->configuration.storageServerStoreType))));
+			bool isTss = server->getLastKnownInterface().isTss();
+			// Update server's storeType, especially when it was created
+			co_await server->updateStoreType();
+			if (server->getStoreType() == KeyValueStoreType::SSD_SHARDED_ROCKSDB &&
+			    !SERVER_KNOBS->SHARD_ENCODE_LOCATION_METADATA) {
+				TraceEvent(SevError, "PhysicalShardNotEnabledForShardedRocks", self->getDistributorId())
+				    .detail("StorageServer", server->getId());
+				throw internal_error();
+			}
+			StorageMetadataType data(
+			    StorageMetadataType::currentTime(),
+			    server->getStoreType(),
+			    !(server->isCorrectStoreType(isTss ? self->configuration.testingStorageServerStoreType
+			                                       : (self->configuration.perpetualStoreType.isValid()
+			                                              ? self->configuration.perpetualStoreType
+			                                              : self->configuration.storageServerStoreType))));
 
-		// read storage metadata
-		loop {
-			counters->started->increment(1);
-			try {
-				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-				Optional<Value> serverInterfaceValue = wait(tr->get(serverListKeyFor(server->getId())));
-				// The storage server is removed
-				if (!serverInterfaceValue.present()) {
-					TraceEvent("UpdateStorageMetadataNoOp", self->getDistributorId())
-					    .detail("Server", server->getId())
-					    .detail("IsTss", isTss)
-					    .detail("Reason", "Absent server list item");
-					return Never();
+			bool metadataUpdated{ false };
+			// read storage metadata
+			while (true) {
+				counters->started->increment(1);
+				Error err;
+				try {
+					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+					Optional<Value> serverInterfaceValue = co_await tr->get(serverListKeyFor(server->getId()));
+					// The storage server is removed
+					if (!serverInterfaceValue.present()) {
+						TraceEvent("UpdateStorageMetadataNoOp", self->getDistributorId())
+						    .detail("Server", server->getId())
+						    .detail("IsTss", isTss)
+						    .detail("Reason", "Absent server list item");
+						break;
+					}
+					Optional<StorageMetadataType> metadata = co_await metadataMap.get(tr, server->getId());
+					// NOTE: in upgrade testing, there may not be any metadata
+					// TODO: change to ASSERT(metadata.present()) in a release version only supports upgrade from 71.3
+					if (metadata.present()) {
+						data.createdTime = metadata.get().createdTime;
+					}
+					metadataMap.set(tr, server->getId(), data);
+					tr->set(serverMetadataChangeKey, deterministicRandom()->randomUniqueID().toString());
+					co_await tr->commit();
+					counters->committed->increment(1);
+					metadataUpdated = true;
+					break;
+				} catch (Error& e) {
+					counters->aborted->increment(1);
+					err = e;
 				}
-				Optional<StorageMetadataType> metadata = wait(metadataMap.get(tr, server->getId()));
-				// NOTE: in upgrade testing, there may not be any metadata
-				// TODO: change to ASSERT(metadata.present()) in a release version only supports upgrade from 71.3
-				if (metadata.present()) {
-					data.createdTime = metadata.get().createdTime;
+				co_await tr->onError(err);
+			}
+			if (metadataUpdated) {
+				// printf("------ updated metadata %s\n", server->getId().toString().c_str());
+				TraceEvent("UpdateStorageMetadata", self->getDistributorId())
+				    .detail("Server", server->getId())
+				    .detail("IsTss", isTss);
+
+				// wrong store type handler
+				if (!isTss) {
+					if (!(server->isCorrectStoreType(self->configuration.storageServerStoreType) ||
+					      server->isCorrectStoreType(self->configuration.perpetualStoreType)) &&
+					    self->wrongStoreTypeRemover.isReady()) {
+						self->wrongStoreTypeRemover = removeWrongStoreType(self);
+						self->addActor.send(self->wrongStoreTypeRemover);
+					}
+					// add server to wiggler
+					if (self->storageWiggler->contains(server->getId())) {
+						self->storageWiggler->updateMetadata(server->getId(), data);
+					} else {
+						self->storageWiggler->addServer(server->getId(), data);
+					}
 				}
-				metadataMap.set(tr, server->getId(), data);
-				tr->set(serverMetadataChangeKey, deterministicRandom()->randomUniqueID().toString());
-				wait(tr->commit());
-				counters->committed->increment(1);
-				break;
-			} catch (Error& e) {
-				counters->aborted->increment(1);
-				wait(tr->onError(e));
-			}
-		}
-		// printf("------ updated metadata %s\n", server->getId().toString().c_str());
-		TraceEvent("UpdateStorageMetadata", self->getDistributorId())
-		    .detail("Server", server->getId())
-		    .detail("IsTss", isTss);
-
-		// wrong store type handler
-		if (!isTss) {
-			if (!(server->isCorrectStoreType(self->configuration.storageServerStoreType) ||
-			      server->isCorrectStoreType(self->configuration.perpetualStoreType)) &&
-			    self->wrongStoreTypeRemover.isReady()) {
-				self->wrongStoreTypeRemover = removeWrongStoreType(self);
-				self->addActor.send(self->wrongStoreTypeRemover);
-			}
-			// add server to wiggler
-			if (self->storageWiggler->contains(server->getId())) {
-				self->storageWiggler->updateMetadata(server->getId(), data);
-			} else {
-				self->storageWiggler->addServer(server->getId(), data);
 			}
 		}
 
-		return Never();
+		// Release the metadata transaction before keeping the tracker pending.
+		co_await Future<Void>(Never());
 	}
 
-	ACTOR static Future<Void> run(Reference<DDTeamCollection> teamCollection,
-	                              Reference<InitialDataDistribution> initData,
-	                              TeamCollectionInterface tci,
-	                              Reference<IAsyncListener<RequestStream<RecruitStorageRequest>>> recruitStorage,
-	                              DDEnabledState const* ddEnabledState) {
-		state DDTeamCollection* self = teamCollection.getPtr();
-		state Future<Void> loggingTrigger = Void();
-		state PromiseStream<Void> serverRemoved;
-		state Future<Void> error = actorCollection(self->addActor.getFuture());
+	static Future<Void> run(Reference<DDTeamCollection> teamCollection,
+	                        Reference<InitialDataDistribution> initData,
+	                        TeamCollectionInterface tci,
+	                        Reference<IAsyncListener<RequestStream<RecruitStorageRequest>>> recruitStorage,
+	                        DDEnabledState const* ddEnabledState) {
+		DDTeamCollection* self = teamCollection.getPtr();
+		Future<Void> loggingTrigger = Void();
+		PromiseStream<Void> serverRemoved;
+		Future<Void> error = actorCollection(self->addActor.getFuture());
 
 		try {
-			wait(self->init(initData, *ddEnabledState));
+			co_await self->init(initData, *ddEnabledState);
 			initData.clear(); // release reference count
 			self->addActor.send(self->serverGetTeamRequests(tci));
 
 			TraceEvent("DDTeamCollectionBegin", self->distributorId).detail("Primary", self->primary);
-			wait(self->readyToStart || error);
+			co_await (self->readyToStart || error);
 			TraceEvent("DDTeamCollectionReadyToStart", self->distributorId).detail("Primary", self->primary);
 
 			// removeBadTeams() does not always run. We may need to restart the actor when needed.
@@ -3614,28 +3625,34 @@ public:
 			self->addActor.send(self->monitorPerpetualStorageWiggle());
 			// SOMEDAY: Monitor FF/serverList for (new) servers that aren't in allServers and add or remove them
 
-			loop choose {
-				when(UID removedServer = waitNext(self->removedServers.getFuture())) {
+			while (true) {
+				auto res =
+				    co_await race(self->removedServers.getFuture(),
+				                  self->removedTSS.getFuture(),
+				                  self->zeroHealthyTeams->onChange(),
+				                  loggingTrigger,
+				                  self->serverTrackerErrorOut.getFuture(), // Propagate storageServerTracker errors.
+				                  error);
+				if (res.index() == 0) {
+					UID removedServer = std::get<0>(res);
 					CODE_PROBE(true, "Storage server removed from database");
 					self->removeServer(removedServer);
 					serverRemoved.send(Void());
 
 					self->restartRecruiting.trigger();
-				}
-				when(UID removedTSS = waitNext(self->removedTSS.getFuture())) {
+				} else if (res.index() == 1) {
+					UID removedTSS = std::get<1>(res);
 					CODE_PROBE(true, "TSS removed from database");
 					self->removeTSS(removedTSS);
 					serverRemoved.send(Void());
 
 					self->restartRecruiting.trigger();
-				}
-				when(wait(self->zeroHealthyTeams->onChange())) {
+				} else if (res.index() == 2) {
 					if (self->zeroHealthyTeams->get()) {
 						self->restartRecruiting.trigger();
 						self->noHealthyTeams();
 					}
-				}
-				when(wait(loggingTrigger)) {
+				} else if (res.index() == 3) {
 					int highestPriority = 0;
 					for (auto it : self->priority_teams) {
 						if (it.second > 0) {
@@ -3661,8 +3678,6 @@ public:
 
 					loggingTrigger = delay(SERVER_KNOBS->DATA_DISTRIBUTION_LOGGING_INTERVAL, TaskPriority::FlushTrace);
 				}
-				when(wait(self->serverTrackerErrorOut.getFuture())) {} // Propagate errors from storageServerTracker
-				when(wait(error)) {}
 			}
 		} catch (Error& e) {
 			if (e.code() != error_code_movekeys_conflict)
@@ -7521,78 +7536,66 @@ public:
 };
 
 TEST_CASE("DataDistribution/AddTeamsBestOf/UseMachineID") {
-	wait(DDTeamCollectionUnitTest::AddTeamsBestOf_UseMachineID());
-	return Void();
+	co_await DDTeamCollectionUnitTest::AddTeamsBestOf_UseMachineID();
 }
 
 TEST_CASE("DataDistribution/AddTeamsBestOf/NotUseMachineID") {
-	wait(DDTeamCollectionUnitTest::AddTeamsBestOf_NotUseMachineID());
-	return Void();
+	co_await DDTeamCollectionUnitTest::AddTeamsBestOf_NotUseMachineID();
 }
 
 TEST_CASE("DataDistribution/AddAllTeams/isExhaustive") {
 	DDTeamCollectionUnitTest::AddAllTeams_isExhaustive();
-	return Void();
+	co_return;
 }
 
 TEST_CASE("/DataDistribution/AddAllTeams/withLimit") {
 	DDTeamCollectionUnitTest::AddAllTeams_withLimit();
-	return Void();
+	co_return;
 }
 
 TEST_CASE("/DataDistribution/AddTeamsBestOf/SkippingBusyServers") {
-	wait(DDTeamCollectionUnitTest::AddTeamsBestOf_SkippingBusyServers());
-	return Void();
+	co_await DDTeamCollectionUnitTest::AddTeamsBestOf_SkippingBusyServers();
 }
 
 TEST_CASE("/DataDistribution/AddTeamsBestOf/NotEnoughServers") {
-	wait(DDTeamCollectionUnitTest::AddTeamsBestOf_NotEnoughServers());
-	return Void();
+	co_await DDTeamCollectionUnitTest::AddTeamsBestOf_NotEnoughServers();
 }
 
 TEST_CASE("/DataDistribution/GetTeam/NewServersNotNeeded") {
-	wait(DDTeamCollectionUnitTest::GetTeam_NewServersNotNeeded());
-	return Void();
+	co_await DDTeamCollectionUnitTest::GetTeam_NewServersNotNeeded();
 }
 
 TEST_CASE("/DataDistribution/GetTeam/HealthyCompleteSource") {
-	wait(DDTeamCollectionUnitTest::GetTeam_HealthyCompleteSource());
-	return Void();
+	co_await DDTeamCollectionUnitTest::GetTeam_HealthyCompleteSource();
 }
 
 TEST_CASE("/DataDistribution/GetTeam/TrueBestLeastUtilized") {
-	wait(DDTeamCollectionUnitTest::GetTeam_TrueBestLeastUtilized());
-	return Void();
+	co_await DDTeamCollectionUnitTest::GetTeam_TrueBestLeastUtilized();
 }
 
 TEST_CASE("/DataDistribution/GetTeam/TrueBestMostUtilized") {
-	wait(DDTeamCollectionUnitTest::GetTeam_TrueBestMostUtilized());
-	return Void();
+	co_await DDTeamCollectionUnitTest::GetTeam_TrueBestMostUtilized();
 }
 
 TEST_CASE("/DataDistribution/GetTeam/ServerUtilizationBelowCutoff") {
-	wait(DDTeamCollectionUnitTest::GetTeam_ServerUtilizationBelowCutoff());
-	return Void();
+	co_await DDTeamCollectionUnitTest::GetTeam_ServerUtilizationBelowCutoff();
 }
 
 TEST_CASE("/DataDistribution/GetTeam/ServerUtilizationNearCutoff") {
-	wait(DDTeamCollectionUnitTest::GetTeam_ServerUtilizationNearCutoff());
-	return Void();
+	co_await DDTeamCollectionUnitTest::GetTeam_ServerUtilizationNearCutoff();
 }
 
 TEST_CASE("/DataDistribution/GetTeam/TrueBestLeastReadBandwidth") {
-	wait(DDTeamCollectionUnitTest::GetTeam_TrueBestLeastReadBandwidth());
-	return Void();
+	co_await DDTeamCollectionUnitTest::GetTeam_TrueBestLeastReadBandwidth();
 }
 
 TEST_CASE("/DataDistribution/GetTeam/DeprioritizeWigglePausedTeam") {
-	wait(DDTeamCollectionUnitTest::GetTeam_DeprioritizeWigglePausedTeam());
-	return Void();
+	co_await DDTeamCollectionUnitTest::GetTeam_DeprioritizeWigglePausedTeam();
 }
 
 TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithMinAge") {
-	state Reference<StorageWiggler> wiggler = makeReference<StorageWiggler>(nullptr);
-	state double startTime = now();
+	Reference<StorageWiggler> wiggler = makeReference<StorageWiggler>(nullptr);
+	double startTime = now();
 	wiggler->addServer(UID(1, 0),
 	                   StorageMetadataType(startTime - SERVER_KNOBS->DD_STORAGE_WIGGLE_MIN_SS_AGE_SEC + 5.0,
 	                                       KeyValueStoreType::SSD_BTREE_V2));
@@ -7613,12 +7616,12 @@ TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithMinAge") {
 	{
 		std::cout << "Finish Initial Check. Start test getNextWigglingServerID() loop...\n";
 		// test the getNextWigglingServerID() loop
-		UID id = wait(DDTeamCollectionImpl::getNextWigglingServerID(wiggler));
+		UID id = co_await DDTeamCollectionImpl::getNextWigglingServerID(wiggler);
 		ASSERT(id == UID(1, 0));
 	}
 
 	std::cout << "Test after addServer() ...\n";
-	state Future<UID> nextFuture = DDTeamCollectionImpl::getNextWigglingServerID(wiggler);
+	Future<UID> nextFuture = DDTeamCollectionImpl::getNextWigglingServerID(wiggler);
 	ASSERT(!nextFuture.isReady());
 	startTime = now();
 	StorageMetadataType metadata(startTime + SERVER_KNOBS->DD_STORAGE_WIGGLE_MIN_SS_AGE_SEC + 100.0,
@@ -7628,28 +7631,27 @@ TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithMinAge") {
 
 	std::cout << "Test after updateServer() ...\n";
 	StorageWiggler* ptr = wiggler.getPtr();
-	wait(trigger(
+	co_await trigger(
 	    [ptr]() {
 		    ptr->updateMetadata(UID(5, 0),
 		                        StorageMetadataType(now() - SERVER_KNOBS->DD_STORAGE_WIGGLE_MIN_SS_AGE_SEC,
 		                                            KeyValueStoreType::SSD_BTREE_V2));
 	    },
-	    delay(5.0)));
-	wait(success(nextFuture));
+	    delay(5.0));
+	co_await nextFuture;
 	ASSERT(now() - startTime < SERVER_KNOBS->DD_STORAGE_WIGGLE_MIN_SS_AGE_SEC + 100.0);
 	ASSERT(nextFuture.get() == UID(5, 0));
-	return Void();
 }
 
 TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithTSS") {
-	state std::unique_ptr<DDTeamCollection> collection =
+	std::unique_ptr<DDTeamCollection> collection =
 	    DDTeamCollectionUnitTest::testMachineTeamCollection(1, makeReference<PolicyOne>(), 5);
-	state Reference<StorageWiggler> wiggler = makeReference<StorageWiggler>(collection.get());
+	Reference<StorageWiggler> wiggler = makeReference<StorageWiggler>(collection.get());
 
 	std::cout << "Test when need TSS ... \n";
 	collection->configuration.usableRegions = 1;
 	collection->configuration.desiredTSSCount = 1;
-	state double startTime = now();
+	double startTime = now();
 	wiggler->addServer(UID(1, 0),
 	                   StorageMetadataType(startTime + SERVER_KNOBS->DD_STORAGE_WIGGLE_MIN_SS_AGE_SEC + 150.0,
 	                                       KeyValueStoreType::SSD_BTREE_V2));
@@ -7658,51 +7660,42 @@ TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithTSS") {
 	                                       KeyValueStoreType::SSD_BTREE_V2));
 	ASSERT(!wiggler->getNextServerId(true).present());
 	ASSERT(wiggler->getNextServerId(collection->reachTSSPairTarget()) == UID(1, 0));
-	UID id = wait(DDTeamCollectionImpl::getNextWigglingServerID(wiggler, {}, collection.get()));
+	UID id = co_await DDTeamCollectionImpl::getNextWigglingServerID(wiggler, {}, collection.get());
 	ASSERT(now() - startTime < SERVER_KNOBS->DD_STORAGE_WIGGLE_MIN_SS_AGE_SEC + 150.0);
 	ASSERT(id == UID(2, 0));
-	return Void();
 }
 
 TEST_CASE("/DataDistribution/GetTeam/CutOffByCpu") {
-	wait(DDTeamCollectionUnitTest::GetTeam_CutOffByCpu());
-	return Void();
+	co_await DDTeamCollectionUnitTest::GetTeam_CutOffByCpu();
 }
 
 TEST_CASE("/DataDistribution/GetTeam/PreferWithinShardRange") {
 	if (!SERVER_KNOBS->ENFORCE_SHARD_COUNT_PER_TEAM) {
-		return Void();
+		co_return;
 	}
-	wait(DDTeamCollectionUnitTest::GetTeam_PreferShardsWithinLimit());
-	return Void();
+	co_await DDTeamCollectionUnitTest::GetTeam_PreferShardsWithinLimit();
 }
 
 TEST_CASE("/DataDistribution/Recruitment/RecruitmentFailedCooldownReleasesId") {
-	wait(DDTeamCollectionUnitTest::InitializeStorage_RecruitmentFailedCooldownReleasesId());
-	return Void();
+	co_await DDTeamCollectionUnitTest::InitializeStorage_RecruitmentFailedCooldownReleasesId();
 }
 
 TEST_CASE("/DataDistribution/StorageServerFailureTracker/ReadyRecoverySkipsRemovalCheck") {
-	wait(DDTeamCollectionUnitTest::StorageServerFailureTracker_ReadyRecoverySkipsRemovalCheck());
-	return Void();
+	co_await DDTeamCollectionUnitTest::StorageServerFailureTracker_ReadyRecoverySkipsRemovalCheck();
 }
 
 TEST_CASE("/DataDistribution/Recruitment/MonitorTracksRecruitmentTransitions") {
-	wait(DDTeamCollectionUnitTest::MonitorStorageServerRecruitment_TracksRecruitmentTransitions());
-	return Void();
+	co_await DDTeamCollectionUnitTest::MonitorStorageServerRecruitment_TracksRecruitmentTransitions();
 }
 
 TEST_CASE("/DataDistribution/ServerList/RestartsFetchOnRemoval") {
-	wait(DDTeamCollectionUnitTest::WaitServerListChange_RestartsFetchOnRemoval());
-	return Void();
+	co_await DDTeamCollectionUnitTest::WaitServerListChange_RestartsFetchOnRemoval();
 }
 
 TEST_CASE("/DataDistribution/TeamTracker/RetriesMergedShardForUndesiredServer") {
-	wait(DDTeamCollectionUnitTest::TeamTracker_RetriesMergedShardForUndesiredServer());
-	return Void();
+	co_await DDTeamCollectionUnitTest::TeamTracker_RetriesMergedShardForUndesiredServer();
 }
 
 TEST_CASE("/DataDistribution/TeamTracker/RechecksHealthyZone") {
-	wait(DDTeamCollectionUnitTest::TeamTracker_RechecksHealthyZone());
-	return Void();
+	co_await DDTeamCollectionUnitTest::TeamTracker_RechecksHealthyZone();
 }

--- a/fdbserver/datadistributor/DDTeamCollection.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.cpp
@@ -373,7 +373,7 @@ public:
 	// portion of teams that have longer storage queues
 	// A team storage queue size is defined as the longest storage queue size among all SSes of the team
 	static int64_t calculateTeamStorageQueueThreshold(const std::vector<Reference<TCTeamInfo>>& teams) {
-		if (teams.size() == 0) {
+		if (teams.empty()) {
 			return std::numeric_limits<int64_t>::max(); // disable this funcationality
 		}
 		std::vector<int64_t> queueLengthList;
@@ -538,7 +538,7 @@ public:
 
 			// self->teams.size() can be 0 under the ConfigureTest.txt test when we change configurations
 			// The situation happens rarely. We may want to eliminate this situation someday
-			if (!self->teams.size()) {
+			if (self->teams.empty()) {
 				req.reply.send(std::make_pair(Optional<Reference<IDataDistributionTeam>>(), foundSrc));
 				co_return;
 			}
@@ -779,7 +779,7 @@ public:
 							self->addTeam(servers, IsInitialTeam::True);
 						} else {
 							tempSet->clear();
-							for (auto it : servers) {
+							for (const auto& it : servers) {
 								tempMap->add(it->getLastKnownInterface().locality, &it->getId());
 							}
 
@@ -797,7 +797,7 @@ public:
 						}
 					} else {
 						serverIds.clear();
-						for (auto it : servers) {
+						for (const auto& it : servers) {
 							serverIds.push_back(it->getId());
 						}
 						TraceEvent(SevWarnAlways, "CannotAddSubset", self->distributorId)
@@ -837,10 +837,8 @@ public:
 			}
 		}
 
-		std::set<std::vector<UID>>::iterator teamIter =
-		    self->primary ? initTeams->primaryTeams.begin() : initTeams->remoteTeams.begin();
-		std::set<std::vector<UID>>::iterator teamIterEnd =
-		    self->primary ? initTeams->primaryTeams.end() : initTeams->remoteTeams.end();
+		auto teamIter = self->primary ? initTeams->primaryTeams.begin() : initTeams->remoteTeams.begin();
+		auto teamIterEnd = self->primary ? initTeams->primaryTeams.end() : initTeams->remoteTeams.end();
 		for (; teamIter != teamIterEnd; ++teamIter) {
 			self->addTeam(*teamIter, IsInitialTeam::True);
 			co_await yield();
@@ -938,7 +936,7 @@ public:
 				// a team is added as an initial team
 				int addedTeams = self->addTeamsBestOf(teamsToBuild, desiredTeams, maxTeams);
 
-				if (addedTeams <= 0 && self->teams.size() == 0) {
+				if (addedTeams <= 0 && self->teams.empty()) {
 					TraceEvent(SevWarn, "NoTeamAfterBuildTeam", self->distributorId)
 					    .detail("ServerTeamNum", self->teams.size())
 					    .detail("Debug", "Check information below");
@@ -1299,7 +1297,7 @@ public:
 									// t is the team in primary DC or the remote DC
 									auto& t =
 									    j < teams.first.size() ? teams.first[j] : teams.second[j - teams.first.size()];
-									if (!t.servers.size()) {
+									if (t.servers.empty()) {
 										maxPriority = std::max(maxPriority, SERVER_KNOBS->PRIORITY_POPULATE_REGION);
 										break;
 									}
@@ -1483,8 +1481,9 @@ public:
 								            self->shardsAffectedByTeamFailure->getNumberOfShards(i.second->getId()));
 
 								status.isUndesired = true;
-							} else
+							} else {
 								wakeUpTrackers.push_back(i.second->wakeUpTracker);
+							}
 						}
 					}
 				}
@@ -1557,13 +1556,14 @@ public:
 						break;
 					}
 					AddressExclusion testAddr;
-					if (i == 0)
+					if (i == 0) {
 						testAddr = AddressExclusion(a.ip);
-					else if (i == 1)
+					} else if (i == 1) {
 						testAddr = AddressExclusion(server->getLastKnownInterface().secondaryAddress().get().ip,
 						                            server->getLastKnownInterface().secondaryAddress().get().port);
-					else if (i == 2)
+					} else if (i == 2) {
 						testAddr = AddressExclusion(server->getLastKnownInterface().secondaryAddress().get().ip);
+					}
 					DDTeamCollection::Status testStatus = self->excludedServers.get(testAddr);
 
 					if (testStatus == DDTeamCollection::Status::WIGGLING &&
@@ -1749,7 +1749,7 @@ public:
 						self->resetLocalitySet();
 
 						bool addedNewBadTeam = false;
-						for (auto it : newBadTeams) {
+						for (const auto& it : newBadTeams) {
 							if (self->removeTeam(it)) {
 								self->addTeam(it->getServers(), IsInitialTeam::True);
 								addedNewBadTeam = true;
@@ -1933,7 +1933,7 @@ public:
 		co_await self->waitUntilHealthy();
 		co_await self->addSubsetComplete.getFuture();
 		TraceEvent("DDRemovingBadServerTeams", self->distributorId).detail("Primary", self->primary);
-		for (auto it : self->badTeams) {
+		for (const auto& it : self->badTeams) {
 			it->tracker.cancel();
 		}
 		self->badTeams.clear();
@@ -2133,7 +2133,7 @@ public:
 
 					// Check if a server will have 0 team after the team is removed
 					for (auto& s : team->getServers()) {
-						if (s->getTeams().size() == 0) {
+						if (s->getTeams().empty()) {
 							TraceEvent(SevError, "MachineTeamRemoverTooAggressive", self->distributorId)
 							    .detail("Server", s->getId())
 							    .detail("ServerTeam", team->getDesc());
@@ -3072,8 +3072,7 @@ public:
 					// if we need to get rid of some TSS processes, signal to either cancel recruitment or kill existing
 					// TSS processes
 					if (!pendingTSSCheck && (tssToRecruit < 0 || self->zeroHealthyTeams->get()) &&
-					    (self->isTssRecruiting ||
-					     (self->zeroHealthyTeams->get() && self->tss_info_by_pair.size() > 0))) {
+					    (self->isTssRecruiting || (self->zeroHealthyTeams->get() && !self->tss_info_by_pair.empty()))) {
 						checkTss = self->initialFailureReactionDelay;
 					}
 				}
@@ -3222,7 +3221,7 @@ public:
 						fCandidateWorker = Future<RecruitStorageReply>();
 					} else if (res.index() == 2) {
 						if (!pendingTSSCheck && self->zeroHealthyTeams->get() &&
-						    (self->isTssRecruiting || self->tss_info_by_pair.size() > 0)) {
+						    (self->isTssRecruiting || !self->tss_info_by_pair.empty())) {
 							checkTss = self->initialFailureReactionDelay;
 						}
 					} else if (res.index() == 3) {
@@ -3451,7 +3450,7 @@ public:
 		std::vector<std::pair<UID, StorageWiggleValue>> res =
 		    co_await readStorageWiggleValues(self->dbContext(), self->primary, false);
 
-		if (res.size() > 0) {
+		if (!res.empty()) {
 			// SOMEDAY: support wiggle multiple SS at once
 			ASSERT(!self->wigglingId.present()); // only single process wiggle is allowed
 
@@ -3608,7 +3607,7 @@ public:
 
 			self->traceTeamCollectionInfo();
 
-			if (self->includedDCs.size()) {
+			if (!self->includedDCs.empty()) {
 				// start this actor before any potential recruitments can happen
 				self->addActor.send(self->updateReplicasKey(self->includedDCs[0]));
 			}
@@ -3750,7 +3749,7 @@ public:
 			    .detail("Primary", self->isPrimary());
 
 			int i{ 0 };
-			std::map<UID, Reference<TCServerInfo>>::iterator server = server_info.begin();
+			auto server = server_info.begin();
 			for (i = 0; i < server_info.size(); i++) {
 				auto serverStats = server->second->getStorageStats();
 				TraceEvent("ServerInfo", self->getDistributorId())
@@ -3849,7 +3848,7 @@ public:
 			TraceEvent("MachineInfo", self->getDistributorId())
 			    .detail("Size", machine_info.size())
 			    .detail("Primary", self->isPrimary());
-			std::map<Standalone<StringRef>, Reference<TCMachineInfo>>::iterator machine = machine_info.begin();
+			auto machine = machine_info.begin();
 			bool isMachineHealthy = false;
 			for (i = 0; i < machine_info.size(); i++) {
 				Reference<TCMachineInfo> _machine = machine->second;
@@ -4554,7 +4553,7 @@ bool DDTeamCollection::satisfiesPolicy(const std::vector<Reference<TCServerInfo>
 	}
 
 	bool result = storageServerSet->selectReplicas(configuration.storagePolicy, forcedEntries, resultEntries);
-	return result && resultEntries.size() == 0;
+	return result && resultEntries.empty();
 }
 
 DDTeamCollection::DDTeamCollection(DDTeamCollectionInitParams const& params)
@@ -4684,9 +4683,9 @@ std::vector<UID> DDTeamCollection::getRandomHealthyTeam(const UID& excludeServer
 	}
 
 	// Prefer a healthy team not containing excludeServer.
-	if (candidates.size() > 0) {
+	if (!candidates.empty()) {
 		return teams[candidates[deterministicRandom()->randomInt(0, candidates.size())]]->getServerIDs();
-	} else if (backup.size() > 0) {
+	} else if (!backup.empty()) {
 		// The backup choice is a team with at least one server besides excludeServer, in this
 		// case, the team will be possibly relocated to a healthy destination later by DD.
 		std::vector<UID> servers = teams[backup[deterministicRandom()->randomInt(0, backup.size())]]->getServerIDs();
@@ -5098,7 +5097,7 @@ Reference<TCMachineTeamInfo> DDTeamCollection::addMachineTeam(std::vector<Refere
 	machineTeams.push_back(machineTeamInfo);
 
 	// Assign machine teams to machine
-	for (auto machine : machines) {
+	for (const auto& machine : machines) {
 		// A machine's machineTeams vector should not hold duplicate machineTeam members
 		ASSERT_WE_THINK(std::count(machine->machineTeams.begin(), machine->machineTeams.end(), machineTeamInfo) == 0);
 		machine->machineTeams.push_back(machineTeamInfo);
@@ -5313,7 +5312,7 @@ int DDTeamCollection::addBestMachineTeams(int machineTeamsToBuild) {
 			// Step 3: Create a representative process for each machine.
 			// Construct forcedAttribute from leastUsedMachines.
 			// We will use forcedAttribute to call existing function to form a team
-			if (leastUsedMachines.size()) {
+			if (!leastUsedMachines.empty()) {
 				forcedAttributes.clear();
 				// Randomly choose 1 least used machine
 				Reference<TCMachineInfo> tcMachineInfo = deterministicRandom()->randomChoice(leastUsedMachines);
@@ -5673,7 +5672,7 @@ bool DDTeamCollection::notEnoughTeamsForAServer() const {
 
 int DDTeamCollection::addTeamsBestOf(int teamsToBuild, int desiredTeams, int maxTeams) {
 	ASSERT_GE(teamsToBuild, 0);
-	ASSERT_WE_THINK(machine_info.size() > 0 || server_info.size() == 0);
+	ASSERT_WE_THINK(!machine_info.empty() || server_info.empty());
 	ASSERT_WE_THINK(SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER >= 1 && configuration.storageTeamSize >= 1);
 
 	int addedTeams = 0;
@@ -5765,7 +5764,7 @@ int DDTeamCollection::addTeamsBestOf(int teamsToBuild, int desiredTeams, int max
 					++chosenServerCount;
 				} else {
 					std::vector<Reference<TCServerInfo>> healthyProcesses;
-					for (auto it : machine->serversOnMachine) {
+					for (const auto& it : machine->serversOnMachine) {
 						if (!server_status.get(it->getId()).isUnhealthy()) {
 							healthyProcesses.push_back(it);
 						}
@@ -6207,7 +6206,7 @@ void DDTeamCollection::removeServer(UID removedServer) {
 	// Remove machine if no server on it
 	// Note: Remove machine (and machine team) after server teams have been removed, because
 	// we remove a machine team only when the server teams on it have been removed
-	if (removedMachineInfo->serversOnMachine.size() == 0) {
+	if (removedMachineInfo->serversOnMachine.empty()) {
 		removeMachine(removedMachineInfo);
 	}
 
@@ -6650,14 +6649,14 @@ public:
 		std::unique_ptr<DDTeamCollection> collection = testTeamCollection(teamSize, policy, processSize);
 
 		GetStorageMetricsReply mid_avail;
-		mid_avail.capacity.bytes = 1000 * 1024 * 1024;
-		mid_avail.available.bytes = 400 * 1024 * 1024;
-		mid_avail.load.bytes = 100 * 1024 * 1024;
+		mid_avail.capacity.bytes = 1000LL * 1024 * 1024;
+		mid_avail.available.bytes = 400LL * 1024 * 1024;
+		mid_avail.load.bytes = 100LL * 1024 * 1024;
 
 		GetStorageMetricsReply high_avail;
-		high_avail.capacity.bytes = 1000 * 1024 * 1024;
-		high_avail.available.bytes = 800 * 1024 * 1024;
-		high_avail.load.bytes = 90 * 1024 * 1024;
+		high_avail.capacity.bytes = 1000LL * 1024 * 1024;
+		high_avail.available.bytes = 800LL * 1024 * 1024;
+		high_avail.load.bytes = 90LL * 1024 * 1024;
 
 		collection->addTeam(std::set<UID>({ UID(1, 0), UID(2, 0), UID(3, 0) }), IsInitialTeam::True);
 		collection->addTeam(std::set<UID>({ UID(2, 0), UID(3, 0), UID(4, 0) }), IsInitialTeam::True);
@@ -6702,14 +6701,14 @@ public:
 		std::unique_ptr<DDTeamCollection> collection = testTeamCollection(teamSize, policy, processSize);
 
 		GetStorageMetricsReply mid_avail;
-		mid_avail.capacity.bytes = 1000 * 1024 * 1024;
-		mid_avail.available.bytes = 400 * 1024 * 1024;
-		mid_avail.load.bytes = 100 * 1024 * 1024;
+		mid_avail.capacity.bytes = 1000LL * 1024 * 1024;
+		mid_avail.available.bytes = 400LL * 1024 * 1024;
+		mid_avail.load.bytes = 100LL * 1024 * 1024;
 
 		GetStorageMetricsReply high_avail;
-		high_avail.capacity.bytes = 1000 * 1024 * 1024;
-		high_avail.available.bytes = 800 * 1024 * 1024;
-		high_avail.load.bytes = 90 * 1024 * 1024;
+		high_avail.capacity.bytes = 1000LL * 1024 * 1024;
+		high_avail.available.bytes = 800LL * 1024 * 1024;
+		high_avail.load.bytes = 90LL * 1024 * 1024;
 
 		collection->addTeam(std::set<UID>({ UID(1, 0), UID(2, 0), UID(3, 0) }), IsInitialTeam::True);
 		collection->addTeam(std::set<UID>({ UID(2, 0), UID(3, 0), UID(4, 0) }), IsInitialTeam::True);
@@ -6756,14 +6755,14 @@ public:
 		std::unique_ptr<DDTeamCollection> collection = testTeamCollection(teamSize, policy, processSize);
 
 		GetStorageMetricsReply mid_avail;
-		mid_avail.capacity.bytes = 1000 * 1024 * 1024;
-		mid_avail.available.bytes = 400 * 1024 * 1024;
-		mid_avail.load.bytes = 100 * 1024 * 1024;
+		mid_avail.capacity.bytes = 1000LL * 1024 * 1024;
+		mid_avail.available.bytes = 400LL * 1024 * 1024;
+		mid_avail.load.bytes = 100LL * 1024 * 1024;
 
 		GetStorageMetricsReply high_avail;
-		high_avail.capacity.bytes = 1000 * 1024 * 1024;
-		high_avail.available.bytes = 800 * 1024 * 1024;
-		high_avail.load.bytes = 90 * 1024 * 1024;
+		high_avail.capacity.bytes = 1000LL * 1024 * 1024;
+		high_avail.available.bytes = 800LL * 1024 * 1024;
+		high_avail.load.bytes = 90LL * 1024 * 1024;
 
 		collection->addTeam(std::set<UID>({ UID(1, 0), UID(2, 0), UID(3, 0) }), IsInitialTeam::True);
 		collection->addTeam(std::set<UID>({ UID(2, 0), UID(3, 0), UID(4, 0) }), IsInitialTeam::True);
@@ -6807,14 +6806,14 @@ public:
 		std::unique_ptr<DDTeamCollection> collection = testTeamCollection(teamSize, policy, processSize);
 
 		GetStorageMetricsReply mid_avail;
-		mid_avail.capacity.bytes = 1000 * 1024 * 1024;
-		mid_avail.available.bytes = 400 * 1024 * 1024;
-		mid_avail.load.bytes = 100 * 1024 * 1024;
+		mid_avail.capacity.bytes = 1000LL * 1024 * 1024;
+		mid_avail.available.bytes = 400LL * 1024 * 1024;
+		mid_avail.load.bytes = 100LL * 1024 * 1024;
 
 		GetStorageMetricsReply high_avail;
-		high_avail.capacity.bytes = 1000 * 1024 * 1024;
-		high_avail.available.bytes = 800 * 1024 * 1024;
-		high_avail.load.bytes = 90 * 1024 * 1024;
+		high_avail.capacity.bytes = 1000LL * 1024 * 1024;
+		high_avail.available.bytes = 800LL * 1024 * 1024;
+		high_avail.load.bytes = 90LL * 1024 * 1024;
 
 		collection->addTeam(std::set<UID>({ UID(1, 0), UID(2, 0), UID(3, 0) }), IsInitialTeam::True);
 		collection->addTeam(std::set<UID>({ UID(2, 0), UID(3, 0), UID(4, 0) }), IsInitialTeam::True);
@@ -6859,12 +6858,12 @@ public:
 		GetStorageMetricsReply low_avail;
 		low_avail.capacity.bytes = SERVER_KNOBS->MIN_AVAILABLE_SPACE * 20;
 		low_avail.available.bytes = SERVER_KNOBS->MIN_AVAILABLE_SPACE / 2;
-		low_avail.load.bytes = 90 * 1024 * 1024;
+		low_avail.load.bytes = 90LL * 1024 * 1024;
 
 		GetStorageMetricsReply high_avail;
-		high_avail.capacity.bytes = 2000 * 1024 * 1024;
-		high_avail.available.bytes = 800 * 1024 * 1024;
-		high_avail.load.bytes = 90 * 1024 * 1024;
+		high_avail.capacity.bytes = 2000LL * 1024 * 1024;
+		high_avail.available.bytes = 800LL * 1024 * 1024;
+		high_avail.load.bytes = 90LL * 1024 * 1024;
 
 		collection->addTeam(std::set<UID>({ UID(1, 0), UID(2, 0), UID(3, 0) }), IsInitialTeam::True);
 		collection->addTeam(std::set<UID>({ UID(2, 0), UID(3, 0), UID(4, 0) }), IsInitialTeam::True);
@@ -6911,15 +6910,15 @@ public:
 			low_avail.capacity.bytes =
 			    SERVER_KNOBS->MIN_AVAILABLE_SPACE * (2 / SERVER_KNOBS->MIN_AVAILABLE_SPACE_RATIO);
 		} else {
-			low_avail.capacity.bytes = 2000 * 1024 * 1024;
+			low_avail.capacity.bytes = 2000LL * 1024 * 1024;
 		}
 		low_avail.available.bytes = (SERVER_KNOBS->MIN_AVAILABLE_SPACE_RATIO * 1.1) * low_avail.capacity.bytes;
-		low_avail.load.bytes = 90 * 1024 * 1024;
+		low_avail.load.bytes = 90LL * 1024 * 1024;
 
 		GetStorageMetricsReply high_avail;
-		high_avail.capacity.bytes = 2000 * 1024 * 1024;
-		high_avail.available.bytes = 800 * 1024 * 1024;
-		high_avail.load.bytes = 90 * 1024 * 1024;
+		high_avail.capacity.bytes = 2000LL * 1024 * 1024;
+		high_avail.available.bytes = 800LL * 1024 * 1024;
+		high_avail.load.bytes = 90LL * 1024 * 1024;
 
 		collection->addTeam(std::set<UID>({ UID(1, 0), UID(2, 0), UID(3, 0) }), IsInitialTeam::True);
 		collection->addTeam(std::set<UID>({ UID(2, 0), UID(3, 0), UID(4, 0) }), IsInitialTeam::True);
@@ -6961,12 +6960,12 @@ public:
 		int teamSize = 1;
 		std::unique_ptr<DDTeamCollection> collection = testTeamCollection(teamSize, policy, processSize);
 
-		int64_t capacity = 1000 * 1024 * 1024, available = 800 * 1024 * 1024;
+		int64_t capacity = 1000LL * 1024 * 1024, available = 800LL * 1024 * 1024;
 		std::vector<int64_t> read_bandwidths{
-			300 * 1024 * 1024, 100 * 1024 * 1024, 500 * 1024 * 1024, 100 * 1024 * 1024, 900 * 1024 * 1024
+			300LL * 1024 * 1024, 100LL * 1024 * 1024, 500LL * 1024 * 1024, 100LL * 1024 * 1024, 900LL * 1024 * 1024
 		};
 		std::vector<int64_t> load_bytes{
-			50 * 1024 * 1024, 600 * 1024 * 1024, 800 * 1024 * 1024, 200 * 1024 * 1024, 100 * 1024 * 1024
+			50LL * 1024 * 1024, 600LL * 1024 * 1024, 800LL * 1024 * 1024, 200LL * 1024 * 1024, 100LL * 1024 * 1024
 		};
 		GetStorageMetricsReply metrics[5];
 		for (int i = 0; i < 5; ++i) {
@@ -7034,14 +7033,14 @@ public:
 		int teamSize = 3;
 		std::unique_ptr<DDTeamCollection> collection = testTeamCollection(teamSize, policy, processSize);
 		GetStorageMetricsReply mid_avail;
-		mid_avail.capacity.bytes = 1000 * 1024 * 1024;
-		mid_avail.available.bytes = 400 * 1024 * 1024;
-		mid_avail.load.bytes = 100 * 1024 * 1024;
+		mid_avail.capacity.bytes = 1000LL * 1024 * 1024;
+		mid_avail.available.bytes = 400LL * 1024 * 1024;
+		mid_avail.load.bytes = 100LL * 1024 * 1024;
 
 		GetStorageMetricsReply high_avail;
-		high_avail.capacity.bytes = 1000 * 1024 * 1024;
-		high_avail.available.bytes = 800 * 1024 * 1024;
-		high_avail.load.bytes = 90 * 1024 * 1024;
+		high_avail.capacity.bytes = 1000LL * 1024 * 1024;
+		high_avail.available.bytes = 800LL * 1024 * 1024;
+		high_avail.load.bytes = 90LL * 1024 * 1024;
 
 		collection->addTeam(std::set<UID>({ UID(1, 0), UID(2, 0), UID(3, 0) }), IsInitialTeam::True);
 		collection->addTeam(std::set<UID>({ UID(2, 0), UID(3, 0), UID(4, 0) }), IsInitialTeam::True);
@@ -7096,24 +7095,24 @@ public:
 		                         ForReadBalance::True);
 		collection->teamPivots.lastPivotValuesUpdate = -100;
 
-		int64_t capacity = SERVER_KNOBS->MIN_AVAILABLE_SPACE * 20, loadBytes = 90 * 1024 * 1024;
+		int64_t capacity = SERVER_KNOBS->MIN_AVAILABLE_SPACE * 20, loadBytes = 90LL * 1024 * 1024;
 		GetStorageMetricsReply high_s_high_r;
 		high_s_high_r.capacity.bytes = capacity;
 		high_s_high_r.available.bytes = SERVER_KNOBS->MIN_AVAILABLE_SPACE * 5;
 		high_s_high_r.load.bytes = loadBytes;
-		high_s_high_r.load.opsReadPerKSecond = 7000 * 1000;
+		high_s_high_r.load.opsReadPerKSecond = 7000LL * 1000;
 
 		GetStorageMetricsReply high_s_low_r;
 		high_s_low_r.capacity.bytes = capacity;
 		high_s_low_r.available.bytes = SERVER_KNOBS->MIN_AVAILABLE_SPACE * 5;
 		high_s_low_r.load.bytes = loadBytes;
-		high_s_low_r.load.opsReadPerKSecond = 100 * 1000;
+		high_s_low_r.load.opsReadPerKSecond = 100LL * 1000;
 
 		GetStorageMetricsReply low_s_low_r;
 		low_s_low_r.capacity.bytes = capacity;
 		low_s_low_r.available.bytes = SERVER_KNOBS->MIN_AVAILABLE_SPACE / 2;
 		low_s_low_r.load.bytes = loadBytes;
-		low_s_low_r.load.opsReadPerKSecond = 100 * 1000;
+		low_s_low_r.load.opsReadPerKSecond = 100LL * 1000;
 
 		HealthMetrics::StorageStats low_cpu, mid_cpu, high_cpu;
 		// use constant cutoff value


### PR DESCRIPTION
## Summary

- Convert the five remaining DDTeamCollection actors and all 24 TEST_CASE bodies to standard C++ coroutines.
- Remove the actorcompiler include and rename `DDTeamCollection.actor.cpp` to `DDTeamCollection.cpp`; existing source discovery needs no CMake change.
- Preserve ordered race priority, nested-loop control flow, retry behavior, and background-future ownership. Scope metadata-update resources before the terminal pending wait.

## Validation

- Clang 19.1.5 Release builds of `fdbserver_datadistributor_test` and `fdbserver` passed with warnings treated as errors.
- Full DataDistributor suite: 53/53 passed in normal mode and 53/53 in Sim2, both with seed 424242.
- `PerpetualWiggleStorageMigration.toml`, seed 424242 with buggify off: passed with no error-severity trace events. Verified the selected server migrated to RocksDB and two wiggle cycles completed with matching server removals.
- clang-format 19.1.7, rewriter roundtrip, and `git diff --check` passed.

## Draft review notes

- The rename exposes 84 clang-tidy warnings on unchanged constructs. Three ineffective moves introduced by the rewrite were fixed; the remaining diagnostics have not been cleaned up or suppressed.
- `ExcludeIncludeStorageServers.toml` with buggify on (seeds 424243, 424244, 1, and 42) reported success but exited early. These runs do not establish full exclusion-loop coverage.
- `updateStorageMetadata` releases its resources before the terminal `Never` await. Explicitly cancelling that coroutine makes its future cancellation-ready, unlike returning `Never`; the current explicit cancellation occurs after removal wins the race, with no subsequent observation of that future.
- Validation did not use ASAN/UBSAN, and the migration seed did not take the optional clear-engine branch.
