### PR TITLE
Index native CDC tag owners by representative stream

### DIFF
--- a/design/cdc.md
+++ b/design/cdc.md
@@ -359,6 +359,7 @@ than transaction state:
 | --- | --- | --- |
 | `\xff\x02/cdc/minVersion/<streamId>` | `Version` | Earliest version that an active stream may still require. |
 | `\xff\x02/cdc/retiredTagPopVersion/<tag>` | `Version` | Final pop watermark required after a stream using a tag is removed. |
+| `\xff\x02/cdc/tagOwner/<tag>` | `CDCStreamId` | Derived representative stream used to look up a current tag's proxy owner. |
 
 The initial `minVersion` is written with a versionstamp at stream
 registration. When a consumer acknowledges processing through version `V`, the
@@ -394,6 +395,22 @@ properties rather than exceptional cases.
 
 The current proxy assignment at registration uses an available CDC proxy; it
 does not yet balance by stream traffic, memory use, or consumer lag.
+
+Registration reuses a tag's owner through a persisted representative stream.
+The lookup validates, in the registration transaction, that the representative
+is active and still uses that current tag, then reads its authoritative
+per-stream proxy assignment. Proxy replacement therefore does not require a
+second ownership update. A missing or stale entry is reconstructed from active
+stream metadata; registration on an unused tag establishes its first
+representative. Removing the representative clears the entry without disturbing
+other streams or their retained history.
+
+This index avoids repeated global ownership discovery for stable shared tags.
+It is derived storage-backed system data, not routing or retention authority,
+and can be discarded and rebuilt. Existing streams need no eager migration;
+validation also rejects stale representatives left by older metadata writers.
+The allocator's stream-count scan remains necessary, and ownership discovery
+still scans global metadata when the representative is absent or invalid.
 
 ### Metadata lifecycle example
 

--- a/fdbclient/NativeCdc.cpp
+++ b/fdbclient/NativeCdc.cpp
@@ -129,9 +129,11 @@ Future<Optional<UID>> getNativeCdcProxyAssignmentForTag(Transaction* tr, Tag tar
 		const CDCStreamId streamId = decodeCDCTagOwnerValue(indexedStream.get());
 		Future<Optional<Value>> activeStream = tr->get(cdcStreamKeyFor(streamId));
 		RangeResult history = co_await tr->getRange(cdcTagHistoryRangeFor(streamId), 1, Snapshot::False, Reverse::True);
+		// Keep the await separate so GCC 13 does not evaluate history.front() before the short-circuit guards.
+		const Optional<Value> activeStreamValue = co_await activeStream;
 		// The index is derived: removal or retagging can invalidate its representative, and the per-stream
 		// assignment remains authoritative across proxy replacement, including by older metadata writers.
-		if ((co_await activeStream).present() && !history.empty() &&
+		if (activeStreamValue.present() && !history.empty() &&
 		    decodeCDCTagHistoryKey(history.front().key).tag == targetTag) {
 			Optional<UID> proxyId = co_await getNativeCdcProxyAssignment(tr, streamId);
 			if (proxyId.present()) {

--- a/fdbclient/NativeCdc.cpp
+++ b/fdbclient/NativeCdc.cpp
@@ -68,6 +68,8 @@ public:
 		++tagStreamCounts[tag.id];
 	}
 
+	bool hasStreams(Tag tag) const { return tagStreamCounts.contains(tag.id); }
+
 	std::pair<CDCStreamId, Tag> allocate(int tagCount) const {
 		if (sawStream && maxStreamId == std::numeric_limits<CDCStreamId>::max()) {
 			throw operation_failed();
@@ -120,8 +122,27 @@ Future<Tag> getNativeCdcCurrentTag(Transaction* tr, CDCStreamId streamId) {
 	co_return decodeCDCTagHistoryKey(history.front().key).tag;
 }
 
-// TODO: Persist current per-tag ownership so registration does not reconstruct it by scanning all active streams.
 Future<Optional<UID>> getNativeCdcProxyAssignmentForTag(Transaction* tr, Tag targetTag) {
+	const Key ownerKey = cdcTagOwnerKeyFor(targetTag);
+	Optional<Value> indexedStream = co_await tr->get(ownerKey);
+	if (indexedStream.present()) {
+		const CDCStreamId streamId = decodeCDCTagOwnerValue(indexedStream.get());
+		Future<Optional<Value>> activeStream = tr->get(cdcStreamKeyFor(streamId));
+		RangeResult history = co_await tr->getRange(cdcTagHistoryRangeFor(streamId), 1, Snapshot::False, Reverse::True);
+		// The index is derived: removal or retagging can invalidate its representative, and the per-stream
+		// assignment remains authoritative across proxy replacement, including by older metadata writers.
+		if ((co_await activeStream).present() && !history.empty() &&
+		    decodeCDCTagHistoryKey(history.front().key).tag == targetTag) {
+			Optional<UID> proxyId = co_await getNativeCdcProxyAssignment(tr, streamId);
+			if (proxyId.present()) {
+				CODE_PROBE(true, "Native CDC resolves a shared tag owner from its persisted index");
+				co_return proxyId;
+			}
+		}
+		CODE_PROBE(true, "Native CDC rebuilds a stale tag owner index");
+		tr->clear(ownerKey);
+	}
+
 	std::set<CDCStreamId> activeStreamIds;
 	Key begin = cdcStreamKeys.begin;
 	while (begin < cdcStreamKeys.end) {
@@ -156,6 +177,8 @@ Future<Optional<UID>> getNativeCdcProxyAssignmentForTag(Transaction* tr, Tag tar
 		if (tag == targetTag) {
 			Optional<UID> proxyId = co_await getNativeCdcProxyAssignment(tr, streamId);
 			if (proxyId.present()) {
+				tr->set(ownerKey, cdcTagOwnerValue(streamId));
+				CODE_PROBE(true, "Native CDC reconstructs a missing tag owner index from active streams");
 				co_return proxyId;
 			}
 		}
@@ -388,6 +411,9 @@ Future<CDCStreamId> registerNativeCdcStream(Database cx, Key name, KeyRange keys
 					           probe::decoration::rare);
 					const UID selectedProxy = sharedTagProxy.present() ? sharedTagProxy.get() : proxyId;
 					tr.set(cdcProxyKeyFor(streamId, selectedProxy), Value());
+					if (!sharedTagProxy.present()) {
+						tr.set(cdcTagOwnerKeyFor(tag), cdcTagOwnerValue(streamId));
+					}
 					signalNativeCdcProxyAssignmentChange(&tr);
 					co_await tr.commit();
 				}
@@ -413,9 +439,15 @@ Future<CDCStreamId> registerNativeCdcStream(Database cx, Key name, KeyRange keys
 			tr.set(cdcTagHistoryKeyFor(streamId, registrationVersion, tag), Value());
 			tr.atomicOp(
 			    cdcMinVersionKeyFor(streamId), cdcVersionstampedMinVersionValue(), MutationRef::SetVersionstampedValue);
-			Optional<UID> sharedTagProxy = co_await getNativeCdcProxyAssignmentForTag(&tr, tag);
+			Optional<UID> sharedTagProxy;
+			if (allocator.hasStreams(tag)) {
+				sharedTagProxy = co_await getNativeCdcProxyAssignmentForTag(&tr, tag);
+			}
 			const UID selectedProxy = sharedTagProxy.present() ? sharedTagProxy.get() : proxyId;
 			tr.set(cdcProxyKeyFor(streamId, selectedProxy), Value());
+			if (!sharedTagProxy.present()) {
+				tr.set(cdcTagOwnerKeyFor(tag), cdcTagOwnerValue(streamId));
+			}
 			signalNativeCdcProxyAssignmentChange(&tr);
 			co_await tr.commit();
 			co_return streamId;
@@ -474,6 +506,11 @@ Future<bool> removeNativeCdcStream(Database cx, Key name, CDCStreamId streamId, 
 			tr.clear(nameKey);
 			tr.clear(cdcStreamKeyFor(streamId));
 			for (const Tag& tag : removedTags) {
+				const Key ownerKey = cdcTagOwnerKeyFor(tag);
+				Optional<Value> indexedStream = co_await tr.get(ownerKey);
+				if (indexedStream.present() && decodeCDCTagOwnerValue(indexedStream.get()) == streamId) {
+					tr.clear(ownerKey);
+				}
 				tr.set(cdcRetiredTagPopKeyFor(tag), Value());
 				tr.atomicOp(cdcRetiredTagPopVersionKeyFor(tag),
 				            cdcVersionstampedMinVersionValue(),

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -787,6 +787,7 @@ const KeyRangeRef cdcStreamNameKeys("\xff/cdc/name/"_sr, "\xff/cdc/name0"_sr);
 const KeyRef cdcMaxStreamIdKey = "\xff/cdc/maxStreamId"_sr;
 const KeyRangeRef cdcStreamKeys("\xff/cdc/keys/"_sr, "\xff/cdc/keys0"_sr);
 const KeyRangeRef cdcTagHistoryKeys("\xff/cdc/tagHistory/"_sr, "\xff/cdc/tagHistory0"_sr);
+const KeyRangeRef cdcTagOwnerKeys("\xff\x02/cdc/tagOwner/"_sr, "\xff\x02/cdc/tagOwner0"_sr);
 const KeyRangeRef cdcMinVersionKeys("\xff\x02/cdc/minVersion/"_sr, "\xff\x02/cdc/minVersion0"_sr);
 const KeyRangeRef cdcRetiredTagPopKeys("\xff/cdc/retiredTagPop/"_sr, "\xff/cdc/retiredTagPop0"_sr);
 const KeyRangeRef cdcRetiredTagPopVersionKeys("\xff\x02/cdc/retiredTagPopVersion/"_sr,
@@ -882,6 +883,28 @@ CDCTagHistoryEntry decodeCDCTagHistoryKey(KeyRef const& key) {
 	BinaryReader reader(key.removePrefix(cdcTagHistoryKeys.begin), Unversioned());
 	reader >> streamId >> encodedVersion >> tag;
 	return CDCTagHistoryEntry(streamId, bigEndian64(encodedVersion), tag);
+}
+
+Key cdcTagOwnerKeyFor(Tag tag) {
+	BinaryWriter wr(Unversioned());
+	wr.serializeBytes(cdcTagOwnerKeys.begin);
+	wr << tag;
+	return wr.toValue();
+}
+
+Tag decodeCDCTagOwnerKey(KeyRef const& key) {
+	Tag tag;
+	BinaryReader reader(key.removePrefix(cdcTagOwnerKeys.begin), Unversioned());
+	reader >> tag;
+	return tag;
+}
+
+Value cdcTagOwnerValue(CDCStreamId streamId) {
+	return cdcStreamNameValue(streamId);
+}
+
+CDCStreamId decodeCDCTagOwnerValue(ValueRef const& value) {
+	return decodeCDCStreamNameValue(value);
 }
 
 Key cdcMinVersionKeyFor(CDCStreamId streamId) {
@@ -1931,6 +1954,11 @@ TEST_CASE("/SystemData/NativeCDC") {
 	ASSERT_EQ(decodeCDCMaxStreamIdValue(cdcMaxStreamIdValue(streamId)), streamId);
 	ASSERT_EQ(decodeCDCStreamKey(cdcStreamKeyFor(streamId)), streamId);
 	ASSERT_EQ(decodeCDCStreamKeysValue(cdcStreamKeysValue(keys)), keys);
+	const Key tagOwnerKey = cdcTagOwnerKeyFor(tag);
+	ASSERT_EQ(decodeCDCTagOwnerKey(tagOwnerKey), tag);
+	ASSERT(cdcTagOwnerKeys.contains(tagOwnerKey));
+	ASSERT(nonMetadataSystemKeys.contains(tagOwnerKey));
+	ASSERT_EQ(decodeCDCTagOwnerValue(cdcTagOwnerValue(streamId)), streamId);
 	ASSERT_EQ(decodeCDCMinVersionKey(cdcMinVersionKeyFor(streamId)), streamId);
 	ASSERT_EQ(decodeCDCMinVersionValue(cdcMinVersionValue(minVersion)), minVersion);
 	ASSERT(nonMetadataSystemKeys.contains(cdcMinVersionKeyFor(streamId)));

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -323,6 +323,15 @@ Key cdcTagHistoryKeyFor(CDCStreamId streamId, Version version, Tag tag);
 KeyRange cdcTagHistoryRangeFor(CDCStreamId streamId);
 CDCTagHistoryEntry decodeCDCTagHistoryKey(KeyRef const& key);
 
+// "\xff\x02/cdc/tagOwner/[[Tag]]" := "[[CDCStreamId]]"
+// Derived lookup hint, not authoritative ownership. Validate the stream is active
+// on this tag and read its durable proxy assignment in the same transaction.
+extern const KeyRangeRef cdcTagOwnerKeys;
+Key cdcTagOwnerKeyFor(Tag tag);
+Tag decodeCDCTagOwnerKey(KeyRef const& key);
+Value cdcTagOwnerValue(CDCStreamId streamId);
+CDCStreamId decodeCDCTagOwnerValue(ValueRef const& value);
+
 // Native CDC acknowledgement progress is regular storage-server-backed system data.
 // "\xff\x02/cdc/minVersion/[[CDCStreamId]]" := "[[Version]]"
 // The initial value is versionstamped at stream registration commit.

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -613,12 +613,22 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 	                                         CDCProxyInterface proxy,
 	                                         Key name,
 	                                         KeyRange keys,
-	                                         UID expectedOwner) {
+	                                         Optional<CDCStreamId> sharedTagStream = Optional<CDCStreamId>()) {
 		const CDCRegisterStreamReply reply = co_await timeoutError(
 		    proxy.registerStream.getReply(CDCRegisterStreamRequest(name, keys)), operationTimeout);
-		const CDCProxyInterface owner =
-		    co_await timeoutError(waitForAssignedProxy(cx, reply.streamId), operationTimeout);
-		ASSERT_EQ(owner.id(), expectedOwner);
+		co_await timeoutError(waitForAssignedProxy(cx, reply.streamId), operationTimeout);
+		// Recovery can replace the owner while registration or consumption is in flight. Compare live streams
+		// in the same published snapshot instead of retaining a proxy ID across those waits.
+		const auto& assignments = cx->clientInfo->get().streamToCDCProxyId;
+		const auto owner = assignments.find(reply.streamId);
+		ASSERT(owner != assignments.end());
+		UID expectedOwner = proxy.id();
+		if (sharedTagStream.present()) {
+			const auto sharedOwner = assignments.find(sharedTagStream.get());
+			ASSERT(sharedOwner != assignments.end());
+			expectedOwner = sharedOwner->second;
+		}
+		ASSERT_EQ(owner->second, expectedOwner);
 		co_return reply.streamId;
 	}
 
@@ -640,7 +650,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		co_await checkTagOwner(cx, tag, firstId);
 
 		// The public client usually chooses the first proxy, which cannot distinguish an index hit from caller choice.
-		const CDCStreamId removedId = co_await registerThroughProxy(cx, other, secondName, keys, owner.id());
+		const CDCStreamId removedId = co_await registerThroughProxy(cx, other, secondName, keys, firstId);
 		co_await checkTagOwner(cx, tag, firstId);
 		co_await timeoutError(removeNativeCdcStreamClient(cx, secondName), operationTimeout);
 		co_await checkTagOwner(cx, tag, firstId);
@@ -648,7 +658,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		for (const Optional<CDCStreamId> invalidAnchor :
 		     { Optional<CDCStreamId>(), Optional<CDCStreamId>(removedId) }) {
 			co_await overwriteTagOwnerForTesting(cx, tag, invalidAnchor);
-			co_await registerThroughProxy(cx, other, secondName, keys, owner.id());
+			co_await registerThroughProxy(cx, other, secondName, keys, firstId);
 			co_await checkTagOwner(cx, tag, firstId);
 			co_await timeoutError(removeNativeCdcStreamClient(cx, secondName), operationTimeout);
 		}
@@ -662,20 +672,20 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		proxies = cx->clientInfo->get().cdcProxies;
 		ASSERT_EQ(proxies.size(), 2);
 		other = proxies[proxies.front().id() == owner.id() ? 1 : 0];
-		const CDCStreamId secondId = co_await registerThroughProxy(cx, other, secondName, keys, owner.id());
+		const CDCStreamId secondId = co_await registerThroughProxy(cx, other, secondName, keys, firstId);
 		co_await checkTagOwner(cx, tag, firstId);
 		co_await consumeThroughValue(consumer, committed, key, value);
 
 		co_await timeoutError(removeNativeCdcStreamClient(cx, firstName), operationTimeout);
 		co_await checkTagOwner(cx, tag, Optional<CDCStreamId>());
-		co_await registerThroughProxy(cx, other, thirdName, keys, owner.id());
+		co_await registerThroughProxy(cx, other, thirdName, keys, secondId);
 		co_await checkTagOwner(cx, tag, secondId);
 		co_await timeoutError(removeNativeCdcStreamClient(cx, thirdName), operationTimeout);
 		co_await checkTagOwner(cx, tag, secondId);
 		co_await timeoutError(removeNativeCdcStreamClient(cx, secondName), operationTimeout);
 		co_await checkTagOwner(cx, tag, Optional<CDCStreamId>());
 
-		const CDCStreamId reusedId = co_await registerThroughProxy(cx, other, firstName, keys, other.id());
+		const CDCStreamId reusedId = co_await registerThroughProxy(cx, other, firstName, keys);
 		co_await checkTagOwner(cx, tag, reusedId);
 		co_await timeoutError(removeNativeCdcStreamClient(cx, firstName), operationTimeout);
 		co_await checkTagOwner(cx, tag, Optional<CDCStreamId>());

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -69,6 +69,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 	int rounds;
 	int assignmentPublicationChecks;
 	bool testProxyReplacement;
+	bool testTagOwnership;
 	bool injectUndeliveredProxyHalt;
 	bool testMemoryBound;
 	bool testReplyChunking;
@@ -565,6 +566,120 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		const Version committed = co_await writeValue(cx, key, value);
 		co_await consumeThroughValue(consumer, committed, key, value);
 		co_await timeoutError(removeNativeCdcStreamClient(cx, name), operationTimeout);
+	}
+
+	Future<Void> checkTagOwner(Database cx, Tag tag, Optional<CDCStreamId> expected) {
+		Transaction tr(cx);
+		while (true) {
+			Error err;
+			try {
+				tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+				tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				Optional<Value> value = co_await tr.get(cdcTagOwnerKeyFor(tag));
+				ASSERT_EQ(value.present(), expected.present());
+				if (value.present()) {
+					ASSERT_EQ(decodeCDCTagOwnerValue(value.get()), expected.get());
+				}
+				co_return;
+			} catch (Error& e) {
+				err = e;
+			}
+			co_await tr.onError(err);
+		}
+	}
+
+	Future<Void> overwriteTagOwnerForTesting(Database cx, Tag tag, Optional<CDCStreamId> anchor) {
+		Transaction tr(cx);
+		while (true) {
+			Error err;
+			try {
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				if (anchor.present()) {
+					tr.set(cdcTagOwnerKeyFor(tag), cdcTagOwnerValue(anchor.get()));
+				} else {
+					tr.clear(cdcTagOwnerKeyFor(tag));
+				}
+				co_await tr.commit();
+				co_return;
+			} catch (Error& e) {
+				err = e;
+			}
+			co_await tr.onError(err);
+		}
+	}
+
+	Future<CDCStreamId> registerThroughProxy(Database cx,
+	                                         CDCProxyInterface proxy,
+	                                         Key name,
+	                                         KeyRange keys,
+	                                         UID expectedOwner) {
+		const CDCRegisterStreamReply reply = co_await timeoutError(
+		    proxy.registerStream.getReply(CDCRegisterStreamRequest(name, keys)), operationTimeout);
+		const CDCProxyInterface owner =
+		    co_await timeoutError(waitForAssignedProxy(cx, reply.streamId), operationTimeout);
+		ASSERT_EQ(owner.id(), expectedOwner);
+		co_return reply.streamId;
+	}
+
+	Future<Void> validateTagOwnership(Database cx) {
+		ASSERT(streams.empty());
+		ASSERT_EQ(cx->clientInfo->get().nativeCdcTagCount, 1);
+		const Tag tag(tagLocalityCDC, 0);
+		const Key firstName = "native-cdc-e2e/tag-owner/first"_sr;
+		const Key secondName = "native-cdc-e2e/tag-owner/second"_sr;
+		const Key thirdName = "native-cdc-e2e/tag-owner/third"_sr;
+		const Key key = "native-cdc-e2e/tag-owner/data"_sr;
+		const KeyRange keys(KeyRangeRef(key, keyAfter(key)));
+		const CDCStreamId firstId =
+		    co_await timeoutError(registerNativeCdcStreamClient(cx, firstName, keys), operationTimeout);
+		CDCProxyInterface owner = co_await timeoutError(waitForAssignedProxy(cx, firstId), operationTimeout);
+		std::vector<CDCProxyInterface> proxies = cx->clientInfo->get().cdcProxies;
+		ASSERT_EQ(proxies.size(), 2);
+		CDCProxyInterface other = proxies[proxies.front().id() == owner.id() ? 1 : 0];
+		co_await checkTagOwner(cx, tag, firstId);
+
+		// The public client usually chooses the first proxy, which cannot distinguish an index hit from caller choice.
+		const CDCStreamId removedId = co_await registerThroughProxy(cx, other, secondName, keys, owner.id());
+		co_await checkTagOwner(cx, tag, firstId);
+		co_await timeoutError(removeNativeCdcStreamClient(cx, secondName), operationTimeout);
+		co_await checkTagOwner(cx, tag, firstId);
+
+		for (const Optional<CDCStreamId> invalidAnchor :
+		     { Optional<CDCStreamId>(), Optional<CDCStreamId>(removedId) }) {
+			co_await overwriteTagOwnerForTesting(cx, tag, invalidAnchor);
+			co_await registerThroughProxy(cx, other, secondName, keys, owner.id());
+			co_await checkTagOwner(cx, tag, firstId);
+			co_await timeoutError(removeNativeCdcStreamClient(cx, secondName), operationTimeout);
+		}
+
+		Reference<NativeCdcConsumer> consumer =
+		    co_await timeoutError(createNativeCdcConsumer(cx, firstName), operationTimeout);
+		const Value value = "tag-owner-retained-across-replacement"_sr;
+		const Version committed = co_await writeValue(cx, key, value);
+		co_await timeoutError(haltProxyUntilReplaced(cx, owner, false), operationTimeout);
+		owner = co_await timeoutError(waitForAssignedProxy(cx, firstId, owner.id()), operationTimeout);
+		proxies = cx->clientInfo->get().cdcProxies;
+		ASSERT_EQ(proxies.size(), 2);
+		other = proxies[proxies.front().id() == owner.id() ? 1 : 0];
+		const CDCStreamId secondId = co_await registerThroughProxy(cx, other, secondName, keys, owner.id());
+		co_await checkTagOwner(cx, tag, firstId);
+		co_await consumeThroughValue(consumer, committed, key, value);
+
+		co_await timeoutError(removeNativeCdcStreamClient(cx, firstName), operationTimeout);
+		co_await checkTagOwner(cx, tag, Optional<CDCStreamId>());
+		co_await registerThroughProxy(cx, other, thirdName, keys, owner.id());
+		co_await checkTagOwner(cx, tag, secondId);
+		co_await timeoutError(removeNativeCdcStreamClient(cx, thirdName), operationTimeout);
+		co_await checkTagOwner(cx, tag, secondId);
+		co_await timeoutError(removeNativeCdcStreamClient(cx, secondName), operationTimeout);
+		co_await checkTagOwner(cx, tag, Optional<CDCStreamId>());
+
+		const CDCStreamId reusedId = co_await registerThroughProxy(cx, other, firstName, keys, other.id());
+		co_await checkTagOwner(cx, tag, reusedId);
+		co_await timeoutError(removeNativeCdcStreamClient(cx, firstName), operationTimeout);
+		co_await checkTagOwner(cx, tag, Optional<CDCStreamId>());
+		co_await timeoutError(waitForRetiredTagCleanup(cx), operationTimeout);
 	}
 
 	Future<bool> setUnpublishedStreamOwner(Database cx,
@@ -1663,6 +1778,9 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 		} else {
 			co_await timeoutError(waitForRetiredTagCleanup(cx), operationTimeout);
 		}
+		if (testTagOwnership) {
+			co_await timeoutError(validateTagOwnership(cx), operationTimeout);
+		}
 	}
 
 public:
@@ -1677,6 +1795,7 @@ public:
 		rounds = getOption(options, "rounds"_sr, 30);
 		assignmentPublicationChecks = getOption(options, "assignmentPublicationChecks"_sr, 0);
 		testProxyReplacement = getOption(options, "testProxyReplacement"_sr, false);
+		testTagOwnership = getOption(options, "testTagOwnership"_sr, false);
 		injectUndeliveredProxyHalt = getOption(options, "injectUndeliveredProxyHalt"_sr, false);
 		testMemoryBound = getOption(options, "testMemoryBound"_sr, false);
 		testReplyChunking = getOption(options, "testReplyChunking"_sr, false);

--- a/tests/fast/NativeCdcSharedTag.toml
+++ b/tests/fast/NativeCdcSharedTag.toml
@@ -1,6 +1,10 @@
 [configuration]
-config = 'single'
+config = 'single commit_proxies=1 grv_proxies=2'
 singleRegion = true
+# Two proxies distinguish the persisted tag owner from the proxy receiving registration.
+datacenters = 1
+machineCount = 12
+statelessProcessClassesPerDC = 3
 buggify = false
 faultInjection = false
 
@@ -22,6 +26,7 @@ connectionFailuresDisableDuration = 1000000
     keyCount = 6
     writesPerRound = 3
     rounds = 6
+    testTagOwnership = true
     drainProbability = 1.0
     delayBetweenRounds = 0.1
     operationTimeout = 120.0


### PR DESCRIPTION
## Summary

- Persist a derived representative stream for each native CDC tag and resolve its authoritative proxy owner with bounded metadata reads.
- Rebuild missing or stale representatives from existing stream metadata, follow proxy replacements without duplicating owner state, and clear an index entry only when its representative is removed.
- Extend the existing shared-tag workload with two-proxy coverage for indexed registration, reconstruction, replacement, and tag reuse.

The index is additive storage-backed system data, not routing or retention authority. Existing streams require no eager migration. This removes repeated ownership discovery for stable tags; allocator scans and reconstruction fallback remain, and proxy balancing is unchanged.

## Validation

- Focused `fdbclient_test` runs: `/SystemData/NativeCDC` (1/1) and `/NativeCDC/` (4/4) passed.
- `NativeCdcSharedTag`: seeds 1, 2, and 3 passed; each exercised indexed lookup, missing-index reconstruction, and stale-index reconstruction.
- `NativeCdcAssignmentPublication`, `NativeCdcRetiredRecovery`, and `NativeCdcEndToEnd`: seed 1 passed for each.
- `NativeCdcDisableRestart`: both phases passed with seeds 1234/1235, preserving the complete simulation state between phases.
- All eight simulation phases ran with buggify off and no unexpected error traces. These are targeted checks, not a full correctness campaign.
- `clang-format --dry-run --Werror` and `git diff --check` passed.

Both test targets completed compilation and linking with clang. The build wrapper returned a post-link error; fresh executables and matching source hashes were verified before directly running the passing tests above.

## Follow-up validation

With the coroutine guard and workload ownership assertion fixes applied, a GCC 13.3.1 Release campaign filtered to `tests/fast/NativeCdcSharedTag.toml` completed with **50,000 passed, 0 failed, 0 remaining**. Indexed lookup and reconstruction of missing and stale index entries were all exercised.
