### PR TITLE
Backport #12440 and #12464 to release-7.4: fix ServerKnobCollection::trySetKnob short-circuiting shadowed knob overrides

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -26,6 +26,14 @@
 #include "flow/UnitTest.h"
 #include "flow/flow.h"
 
+int getSimulatedTxnTimeoutSeconds() {
+	if (deterministicRandom()->truePercent(90)) {
+		return 5;
+	} else {
+		return deterministicRandom()->randomInt(1, 11); // [1, 10]
+	}
+}
+
 #define init(...) KNOB_FN(__VA_ARGS__, INIT_ATOMIC_KNOB, INIT_KNOB)(__VA_ARGS__)
 
 ClientKnobs::ClientKnobs(Randomize randomize, IsSimulated isSimulated) {
@@ -185,7 +193,7 @@ void ClientKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 	init( BACKUP_TASKS_PER_AGENT,                   10 );
 	init( BACKUP_POLL_PROGRESS_SECONDS,             10 );
 	init( VERSIONS_PER_SECOND,                     1e6 ); // Must be the same as SERVER_KNOBS->VERSIONS_PER_SECOND
-	init( MAX_WRITE_TRANSACTION_LIFE_VERSIONS, 5 * VERSIONS_PER_SECOND);  // Must be the same as SERVER_KNOBS->MAX_WRITE_TRANSACTION_LIFE_VERSIONS
+	init( MAX_WRITE_TRANSACTION_LIFE_VERSIONS, 5 * VERSIONS_PER_SECOND);  if (isSimulated) MAX_WRITE_TRANSACTION_LIFE_VERSIONS = getSimulatedTxnTimeoutSeconds() * VERSIONS_PER_SECOND;
 	init( SIM_BACKUP_TASKS_PER_AGENT,               10 );
 	init( BACKUP_RANGEFILE_BLOCK_SIZE,      1024 * 1024);
 	init( BACKUP_LOGFILE_BLOCK_SIZE,        1024 * 1024);

--- a/fdbclient/ServerKnobCollection.cpp
+++ b/fdbclient/ServerKnobCollection.cpp
@@ -48,7 +48,16 @@ Optional<KnobValue> ServerKnobCollection::tryParseKnobValue(std::string const& k
 }
 
 bool ServerKnobCollection::trySetKnob(std::string const& knobName, KnobValueRef const& knobValue) {
-	return clientKnobCollection.trySetKnob(knobName, knobValue) || knobValue.visitSetKnob(knobName, serverKnobs);
+	// Do not short circuit by directly returning:
+	//     clientKnobCollection.trySetKnob(knobName, knobValue) || knobValue.visitSetKnob(knobName, serverKnobs)
+	// This is because some knobs have the same name in client and server e.g. MAX_WRITE_TRANSACTION_LIFE_VERSIONS
+	// When setting such knobs, we want both client and server knob to have their value updated
+	// Short circuiting would mean that server knob named FOO won't be updated if client knob FOO was updated
+	// Instead, we attempt setting client and server knobs in separate statements, and return true
+	// if at least one of the set attempts was succesful.
+	const bool setClientKnob = clientKnobCollection.trySetKnob(knobName, knobValue);
+	const bool setServerKnob = knobValue.visitSetKnob(knobName, serverKnobs);
+	return setClientKnob || setServerKnob;
 }
 
 bool ServerKnobCollection::isAtomic(std::string const& knobName) const {

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -29,16 +29,6 @@ ServerKnobs::ServerKnobs(Randomize randomize, ClientKnobs* clientKnobs, IsSimula
 	initialize(randomize, clientKnobs, isSimulated);
 }
 
-// Returns a deterministically random transaction timeout value for simulation testing.
-// More weight is given to the famous 5s timeout, but [1, 10] range is returned with lower weight.
-int randomTxnTimeoutSeconds() {
-	if (deterministicRandom()->truePercent(90)) {
-		return 5;
-	} else {
-		return deterministicRandom()->randomInt(1, 11); // [1, 10]
-	}
-}
-
 void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSimulated isSimulated) {
 	// clang-format off
 	init( ALLOW_DANGEROUS_KNOBS,                               isSimulated );
@@ -52,8 +42,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ENABLE_VERSION_VECTOR_HA_OPTIMIZATION,               false );
 	init( ENABLE_VERSION_VECTOR_REPLY_RECOVERY,                false );
 
-	init( MAX_READ_TRANSACTION_LIFE_VERSIONS,      5 * VERSIONS_PER_SECOND ); if (isSimulated) MAX_READ_TRANSACTION_LIFE_VERSIONS = randomTxnTimeoutSeconds() * VERSIONS_PER_SECOND;
-	init( MAX_WRITE_TRANSACTION_LIFE_VERSIONS,     5 * VERSIONS_PER_SECOND ); if (randomize && BUGGIFY) MAX_WRITE_TRANSACTION_LIFE_VERSIONS=std::max<int>(1, 1 * VERSIONS_PER_SECOND);
+	init( MAX_READ_TRANSACTION_LIFE_VERSIONS,      5 * VERSIONS_PER_SECOND ); if (isSimulated) MAX_READ_TRANSACTION_LIFE_VERSIONS = getSimulatedTxnTimeoutSeconds() * VERSIONS_PER_SECOND;
+	init( MAX_WRITE_TRANSACTION_LIFE_VERSIONS,     5 * VERSIONS_PER_SECOND ); if (isSimulated) MAX_WRITE_TRANSACTION_LIFE_VERSIONS = clientKnobs->MAX_WRITE_TRANSACTION_LIFE_VERSIONS;
 	init( MAX_COMMIT_BATCH_INTERVAL,                             2.0 ); if( randomize && BUGGIFY ) MAX_COMMIT_BATCH_INTERVAL = 0.5; // Each commit proxy generates a CommitTransactionBatchRequest at least this often, so that versions always advance smoothly
 	MAX_COMMIT_BATCH_INTERVAL = std::min(MAX_COMMIT_BATCH_INTERVAL, MAX_READ_TRANSACTION_LIFE_VERSIONS/double(2*VERSIONS_PER_SECOND)); // Ensure that the proxy commits 2 times every MAX_READ_TRANSACTION_LIFE_VERSIONS, otherwise the master will not give out versions fast enough
 	MAX_COMMIT_BATCH_INTERVAL = std::min(MAX_COMMIT_BATCH_INTERVAL, MAX_WRITE_TRANSACTION_LIFE_VERSIONS/double(2*VERSIONS_PER_SECOND)); // Ensure that the proxy commits 2 times every MAX_WRITE_TRANSACTION_LIFE_VERSIONS, otherwise the master will not give out versions fast enough

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -29,6 +29,16 @@ ServerKnobs::ServerKnobs(Randomize randomize, ClientKnobs* clientKnobs, IsSimula
 	initialize(randomize, clientKnobs, isSimulated);
 }
 
+// Returns a deterministically random transaction timeout value for simulation testing.
+// More weight is given to the famous 5s timeout, but [1, 10] range is returned with lower weight.
+int randomTxnTimeoutSeconds() {
+	if (deterministicRandom()->truePercent(90)) {
+		return 5;
+	} else {
+		return deterministicRandom()->randomInt(1, 11); // [1, 10]
+	}
+}
+
 void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSimulated isSimulated) {
 	// clang-format off
 	init( ALLOW_DANGEROUS_KNOBS,                               isSimulated );
@@ -42,8 +52,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ENABLE_VERSION_VECTOR_HA_OPTIMIZATION,               false );
 	init( ENABLE_VERSION_VECTOR_REPLY_RECOVERY,                false );
 
-	bool buggifyShortReadWindow = randomize && BUGGIFY && !ENABLE_VERSION_VECTOR;
-	init( MAX_READ_TRANSACTION_LIFE_VERSIONS,      5 * VERSIONS_PER_SECOND ); if (randomize && BUGGIFY) MAX_READ_TRANSACTION_LIFE_VERSIONS = VERSIONS_PER_SECOND; else if (buggifyShortReadWindow) MAX_READ_TRANSACTION_LIFE_VERSIONS = std::max<int>(1, 0.1 * VERSIONS_PER_SECOND); else if( randomize && BUGGIFY ) MAX_READ_TRANSACTION_LIFE_VERSIONS = 10 * VERSIONS_PER_SECOND;
+	init( MAX_READ_TRANSACTION_LIFE_VERSIONS,      5 * VERSIONS_PER_SECOND ); if (isSimulated) MAX_READ_TRANSACTION_LIFE_VERSIONS = randomTxnTimeoutSeconds() * VERSIONS_PER_SECOND;
 	init( MAX_WRITE_TRANSACTION_LIFE_VERSIONS,     5 * VERSIONS_PER_SECOND ); if (randomize && BUGGIFY) MAX_WRITE_TRANSACTION_LIFE_VERSIONS=std::max<int>(1, 1 * VERSIONS_PER_SECOND);
 	init( MAX_COMMIT_BATCH_INTERVAL,                             2.0 ); if( randomize && BUGGIFY ) MAX_COMMIT_BATCH_INTERVAL = 0.5; // Each commit proxy generates a CommitTransactionBatchRequest at least this often, so that versions always advance smoothly
 	MAX_COMMIT_BATCH_INTERVAL = std::min(MAX_COMMIT_BATCH_INTERVAL, MAX_READ_TRANSACTION_LIFE_VERSIONS/double(2*VERSIONS_PER_SECOND)); // Ensure that the proxy commits 2 times every MAX_READ_TRANSACTION_LIFE_VERSIONS, otherwise the master will not give out versions fast enough

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -29,6 +29,11 @@
 FDB_BOOLEAN_PARAM(Randomize);
 FDB_BOOLEAN_PARAM(IsSimulated);
 
+// Returns a deterministically random transaction timeout value for simulation testing.
+// More weight is given to the famous 5s timeout, but [1, 10] range is returned with lower weight.
+// This is only be used in simulation.
+int getSimulatedTxnTimeoutSeconds();
+
 class SWIFT_CXX_IMMORTAL_SINGLETON_TYPE ClientKnobs : public KnobsImpl<ClientKnobs> {
 public:
 	int TOO_MANY; // FIXME: this should really be split up so we can control these more specifically

--- a/flow/DeterministicRandom.cpp
+++ b/flow/DeterministicRandom.cpp
@@ -21,6 +21,7 @@
 #include "fmt/format.h"
 #include "flow/Arena.h"
 #include "flow/DeterministicRandom.h"
+#include "flow/UnitTest.h"
 
 #include <cstring>
 
@@ -141,6 +142,12 @@ void DeterministicRandom::randomBytes(uint8_t* buf, int length) {
 	}
 }
 
+bool DeterministicRandom::truePercent(const int percent) {
+	ASSERT_GT(percent, 0);
+	ASSERT_LT(percent, 100);
+	return this->randomInt(1, 101) <= percent;
+}
+
 uint64_t DeterministicRandom::peek() const {
 	return next;
 }
@@ -150,4 +157,117 @@ void DeterministicRandom::addref() {
 }
 void DeterministicRandom::delref() {
 	ReferenceCounted<DeterministicRandom>::delref();
+}
+
+TEST_CASE("/flow/DeterministicRandom/truePercent") {
+	constexpr int trials = 10000;
+
+	{
+		// Test with a fixed seed for reproducibility
+		DeterministicRandom rng(12345);
+
+		// Test 1% probability - should be rare
+		int trueCount1 = 0;
+		for (int i = 0; i < trials; i++) {
+			if (rng.truePercent(1)) {
+				trueCount1++;
+			}
+		}
+
+		// With 1% probability, expect around 100 true out of 10000
+		// Allow for some variance (between 70-130 for 99% confidence)
+		ASSERT(trueCount1 >= 70 && trueCount1 <= 130);
+	}
+
+	{
+		// Test with a fixed seed for reproducibility
+		DeterministicRandom rng(54321);
+
+		// Test 50% probability - should be roughly half
+		int trueCount50 = 0;
+		for (int i = 0; i < trials; i++) {
+			if (rng.truePercent(50)) {
+				trueCount50++;
+			}
+		}
+
+		// With 50% probability, expect around 5000 true out of 10000
+		// Allow for variance (between 4800-5200 for 99% confidence)
+		ASSERT(trueCount50 >= 4800 && trueCount50 <= 5200);
+	}
+
+	{
+		// Test with a fixed seed for reproducibility
+		DeterministicRandom rng(99999);
+
+		// Test 99% probability - should be almost always true
+		int trueCount99 = 0;
+		for (int i = 0; i < trials; i++) {
+			if (rng.truePercent(99)) {
+				trueCount99++;
+			}
+		}
+
+		// With 99% probability, expect around 9900 true out of 10000
+		// Allow for variance (between 9870-9930 for 99% confidence)
+		ASSERT(trueCount99 >= 9870 && trueCount99 <= 9930);
+	}
+
+	{
+		// Test determinism - same seed should produce same results
+		DeterministicRandom rng1(7777);
+		DeterministicRandom rng2(7777);
+		for (int i = 0; i < 100; i++) {
+			ASSERT(rng1.truePercent(75) == rng2.truePercent(75));
+		}
+	}
+
+	{
+		// Test with a fixed seed for reproducibility
+		DeterministicRandom rng(8888);
+
+		// Test different percentages produce expected ordering
+		int count10 = 0, count30 = 0, count70 = 0, count90 = 0;
+		for (int i = 0; i < trials; i++) {
+			DeterministicRandom rngTemp(8888 + i); // Different seed for each trial
+			if (rngTemp.truePercent(10))
+				count10++;
+			if (rngTemp.truePercent(30))
+				count30++;
+			if (rngTemp.truePercent(70))
+				count70++;
+			if (rngTemp.truePercent(90))
+				count90++;
+		}
+
+		// Verify ordering: count10 < count30 < count70 < count90
+		ASSERT(count10 < count30);
+		ASSERT(count30 < count70);
+		ASSERT(count70 < count90);
+	}
+
+	// Test invalid values - these should trigger assertions
+	{
+		DeterministicRandom rng(12345);
+
+		// Lambda to test invalid percentage values
+		auto testInvalidPercent = [&rng](int invalidPercent) {
+			try {
+				[[maybe_unused]] bool result = rng.truePercent(invalidPercent);
+				ASSERT(false); // should not reach here
+			} catch (...) {
+			}
+		};
+
+		// Test various invalid values
+		testInvalidPercent(0); // Should trigger ASSERT_GT(percent, 0)
+		testInvalidPercent(100); // Should trigger ASSERT_LT(percent, 100)
+		testInvalidPercent(-5); // Should trigger ASSERT_GT(percent, 0)
+		testInvalidPercent(150); // Should trigger ASSERT_LT(percent, 100)
+		testInvalidPercent(-100); // Another negative value test
+		testInvalidPercent(101); // Just over 100
+		testInvalidPercent(999); // Much larger than 100
+	}
+
+	return Void();
 }

--- a/flow/include/flow/DeterministicRandom.h
+++ b/flow/include/flow/DeterministicRandom.h
@@ -56,6 +56,7 @@ public:
 	char randomAlphaNumeric() override;
 	std::string randomAlphaNumeric(int length) override;
 	void randomBytes(uint8_t* buf, int length) override;
+	bool truePercent(const int percent) override;
 	uint64_t peek() const override;
 	void addref() override;
 	void delref() override;

--- a/flow/include/flow/IRandom.h
+++ b/flow/include/flow/IRandom.h
@@ -150,6 +150,16 @@ public:
 	virtual std::string randomAlphaNumeric(int length) = 0;
 	virtual void randomBytes(uint8_t* buf, int length) = 0;
 	virtual uint32_t randomSkewedUInt32(uint32_t min, uint32_t maxPlusOne) = 0;
+
+	// Given an input percentage, returns true with a probability of that percentage.
+	// Valid range: 1 <= percent <= 99
+	// 0 percent -> not allowed since it will always be false anyway
+	// 100 percent -> not allowed since it will always be true anyway
+	// 1 percent -> returns true with a probability of 1% (0.01)
+	// 50 percent -> returns true with a probability of 50% (0.5)
+	// 99 percent -> returns true with a probability of 99% (0.99)
+	virtual bool truePercent(const int percent) = 0;
+
 	virtual uint64_t peek() const = 0; // returns something that is probably different for different random states.
 	                                   // Deterministic (and idempotent) for a deterministic generator.
 


### PR DESCRIPTION
Backports the two-commit "5s fuzzing" series from `main` to `release-7.4`:

- **#12440** `05d36e167d` — fuzz the read transaction-life window in simulation
- **#12464** `596f4cba6d` — fuzz the write window, and **fix `ServerKnobCollection::trySetKnob` short-circuiting**

The second commit is the one that matters here. `main` has had this since 2025-11-05; `release-7.4` never got either commit. The second commit fixes nightly 7.4 failures:

```
| fast/DataLossRecovery.toml                          | 3630903977 |         1 |
| fast/DataLossRecovery.toml                          | 1937341837 |         1 |
```

## The bug on release-7.4

`ServerKnobCollection::trySetKnob` short circuited:

```cpp
return clientKnobCollection.trySetKnob(knobName, knobValue) || knobValue.visitSetKnob(knobName, serverKnobs);
```

For a knob name declared in **both** `ClientKnobs` and `ServerKnobs`, the client copy is assigned, `true` is returned, and `serverKnobs` is never touched — while `setKnob` reports success. On `release-7.4` that affects `MAX_WRITE_TRANSACTION_LIFE_VERSIONS`, `VERSIONS_PER_SECOND`, `GLOBAL_CONFIG_REFRESH_TIMEOUT` and `FASTRESTORE_ATOMICOP_WEIGHT`. Because every override path funnels through `IKnobCollection::setKnob`, this also silently broke `--knob-...` on a real `fdbserver`, not just simulation.

## How it surfaced

`tests/fast/DataLossRecovery.toml` sets both transaction-life windows to 5s specifically to defeat BUGGIFY — its comment describes this exact failure mode. Only the read knob got through:

```
fdbserver -r simulation -f tests/fast/DataLossRecovery.toml -s 3630903977 -b on
```

4 SevErrors; one real, three cascading:

| # | Type | Error |
|---|------|-------|
| 1 | `TestFailure` (Workload=DataLossRecovery) | **`start_move_keys_too_many_retries`** (1250) |
| 2 | `StartFailedForWorkloadDataLossRecovery` | `operation_failed` |
| 3 | `RunTests` | `operation_failed` |
| 4 | `SetupAndRunError` | `operation_failed` |

From the trace: at t=0 there are **three** relevant `Knob` lines — `max_read...=1000000` (ServerKnobs, buggified), `max_write...=5000000` (ClientKnobs) **and** `max_write...=1000000` (ServerKnobs, buggified). At t=1 `AssignKnobValue` sets read to 5000000 (reaches `SERVER_KNOBS`) and write to 5000000 (a no-op on the client copy). So the read window was 5s as intended while the **write window stayed at the buggified 1s**.

The resolver rejects commits whose read snapshot is older than `commitVersion - MAX_WRITE_TRANSACTION_LIFE_VERSIONS` (`Resolver.actor.cpp:339` → `SkipList.cpp:837`). One `startMoveKeys` transaction takes ~2.4s on a 45-machine simulated cluster, so every attempt blew the 1s window; 50 retries then `start_move_keys_too_many_retries` (`MoveKeys.actor.cpp:1193`).

Confirming evidence, which rules out a sick cluster: a single `MasterRecoveryState` sequence at t=5.59 ending `fully_recovered` with nothing during the failure window; ratekeeper idle (`TPSLimit` mostly `1e+09`, `WorstStorageServerVersionLag=0`); and decisively, `ResolverMetrics.TransactionsTooOld` on the system-keyspace resolver climbing `40 → 44 → 51 → … → 99` across t=102→187 while **every other resolver reports 0** for the entire run. With the read window correctly at 5s, 2.4s transactions could not have failed on reads — it is the write window.

Three other tests were also silently not getting the server-side value they ask for: `tests/slow/GcGenerations.toml`, `tests/fast/EncryptedBackupCorrectness.toml`, `tests/negative/ResolverIgnoreTooOld.toml`.

## Adaptations from upstream

Neither commit applies cleanly. Two deliberate deviations, both noted in the commit messages:

**1. Knob declaration layout.** `release-7.4` declares the transaction-life-version knobs in their original positions — `ClientKnobs.cpp` beside the backup knobs, `ServerKnobs.cpp` below `ENABLE_VERSION_VECTOR` (because `buggifyShortReadWindow` depended on it). `main` hoisted both into a dedicated "knobs that control 5s timeout" section. The value changes are applied **in place** rather than moving declarations, to keep the diff reviewable. The now-unused `buggifyShortReadWindow` local is deleted, as upstream did.

**2. Include churn dropped.** #12464 also removed includes from `ClientKnobs.cpp` (`FDBTypes.h`, `SystemData.h`, `Tenant.h`) and `ServerKnobs.cpp` (`CompressionUtils.h`, `flow.h`), compensating elsewhere with `fdbrpc.h` in `WaitFailure.actor.cpp` and `TDMetric.actor.h` in `BulkLoading.h`. **None of that is applied here.** `release-7.4`'s `ServerKnobs.cpp` still calls `CompressionUtils::toString`/`getRandomFilter` for `BLOB_GRANULE_COMPRESSION_FILTER` — `main` no longer does — so dropping that include would break the build. And upstream's removal of `fdbrpc.h` from `ServerKnobs.h` only fixed up the transitive consumers that `main` happens to have; `release-7.4`'s set may differ. The cleanup is incidental to the fix, so this backport changes behaviour only.

After the backport the three knob lines match `main` character-for-character.

## Behaviour change to be aware of

Read-window fuzzing is now `getSimulatedTxnTimeoutSeconds()` (90% → 5s, else 1–10s) instead of the old BUGGIFY ladder, so `release-7.4` loses the `buggifyShortReadWindow` 0.1s case and the 10× case. Write-window fuzzing moves to `ClientKnobs` as the single source, with `ServerKnobs` taking its value from the client copy — so the two can no longer disagree.

**`tests/negative/ResolverIgnoreTooOld.toml` is the one to watch**: it asks for a *shorter* 1s write window and until now was silently getting whatever BUGGIFY chose, so its override starts taking effect for the first time.

