### PR TITLE
Fix ServerKnobCollection::trySetKnob short-circuiting shadowed knob overrides (release-7.4)

### DIFF
--- a/fdbclient/ServerKnobCollection.cpp
+++ b/fdbclient/ServerKnobCollection.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "fdbclient/ServerKnobCollection.h"
+#include "flow/UnitTest.h"
 
 ServerKnobCollection::ServerKnobCollection(Randomize randomize, IsSimulated isSimulated)
   : clientKnobCollection(randomize, isSimulated),
@@ -48,9 +49,41 @@ Optional<KnobValue> ServerKnobCollection::tryParseKnobValue(std::string const& k
 }
 
 bool ServerKnobCollection::trySetKnob(std::string const& knobName, KnobValueRef const& knobValue) {
-	return clientKnobCollection.trySetKnob(knobName, knobValue) || knobValue.visitSetKnob(knobName, serverKnobs);
+	// Do not short circuit by directly returning:
+	//     clientKnobCollection.trySetKnob(knobName, knobValue) || knobValue.visitSetKnob(knobName, serverKnobs)
+	// This is because some knobs have the same name in client and server e.g. MAX_WRITE_TRANSACTION_LIFE_VERSIONS
+	// When setting such knobs, we want both client and server knob to have their value updated
+	// Short circuiting would mean that server knob named FOO won't be updated if client knob FOO was updated
+	// Instead, we attempt setting client and server knobs in separate statements, and return true
+	// if at least one of the set attempts was succesful.
+	const bool setClientKnob = clientKnobCollection.trySetKnob(knobName, knobValue);
+	const bool setServerKnob = knobValue.visitSetKnob(knobName, serverKnobs);
+	return setClientKnob || setServerKnob;
 }
 
 bool ServerKnobCollection::isAtomic(std::string const& knobName) const {
 	return clientKnobCollection.isAtomic(knobName) || serverKnobs.isAtomic(knobName);
+}
+
+TEST_CASE("/fdbclient/knobs/shadowedKnobOverrideReachesEveryCollection") {
+	ServerKnobCollection knobs(Randomize::False, IsSimulated::False);
+
+	// max_write_transaction_life_versions is declared in both ClientKnobs and ServerKnobs, and
+	// ClientKnobs.h describes the client field as a "Copy of SERVER_KNOBS". Setting it has to reach
+	// both: trySetKnob used to stop once the client copy matched, leaving the ServerKnobs copy -- the
+	// one the resolver enforces -- at its old value while still reporting success. That silently made
+	// the `[[knobs]] max_write_transaction_life_versions = 5000000` override in
+	// tests/fast/DataLossRecovery.toml a no-op on the server side.
+	const ParsedKnobValue target{ int64_t(7) * knobs.getServerKnobs().VERSIONS_PER_SECOND };
+	ASSERT(knobs.trySetKnob("max_write_transaction_life_versions", KnobValueRef::create(target)));
+	ASSERT_EQ(knobs.getServerKnobs().MAX_WRITE_TRANSACTION_LIFE_VERSIONS, std::get<int64_t>(target));
+	ASSERT_EQ(knobs.getClientKnobs().MAX_WRITE_TRANSACTION_LIFE_VERSIONS, std::get<int64_t>(target));
+
+	// A name only one collection declares must still be settable, and an unknown name must still
+	// report failure so that IKnobCollection::setKnob keeps throwing invalid_option_value.
+	ASSERT(knobs.trySetKnob("max_read_transaction_life_versions", KnobValueRef::create(target)));
+	ASSERT_EQ(knobs.getServerKnobs().MAX_READ_TRANSACTION_LIFE_VERSIONS, std::get<int64_t>(target));
+	ASSERT(!knobs.trySetKnob("this_knob_does_not_exist", KnobValueRef::create(target)));
+
+	return Void();
 }


### PR DESCRIPTION
One-hunk fix for a `release-7.4`-only bug, cherry-picked from `main`. Supersedes #13931, which backported the whole two-commit upstream series and pulled in unrelated simulation-fuzzing changes.

`ServerKnobCollection::trySetKnob` short circuited:

```cpp
return clientKnobCollection.trySetKnob(knobName, knobValue) || knobValue.visitSetKnob(knobName, serverKnobs);
```

For a knob name declared in **both** `ClientKnobs` and `ServerKnobs`, the client copy is assigned, `true` is returned, and `serverKnobs` is never touched — while `setKnob` reports success. On `release-7.4` that affects `MAX_WRITE_TRANSACTION_LIFE_VERSIONS`, `VERSIONS_PER_SECOND`, `GLOBAL_CONFIG_REFRESH_TIMEOUT` and `FASTRESTORE_ATOMICOP_WEIGHT`. Because every override path funnels through `IKnobCollection::setKnob`, this also silently broke `--knob-...` on a real `fdbserver`, not just simulation.

The change is taken from **#12464** (`596f4cba6d`, Syed Paymaan Raza), on `main` since 2025-11-05. `release-7.4`'s copy of `ServerKnobCollection.cpp` is **byte-identical** to that commit's pre-image (blob `99413ceb23`), so the hunk applies with **zero adaptation**.

## How it surfaced

`tests/fast/DataLossRecovery.toml` sets both transaction-life windows to 5s specifically to defeat BUGGIFY — its comment describes this exact failure mode. Only the read knob got through, because it isn't shadowed.

```
fdbserver -r simulation -f tests/fast/DataLossRecovery.toml -s 3630903977 -b on
```

4 SevErrors; one real, three cascading:

| # | Type | Error |
|---|------|-------|
| 1 | `TestFailure` (Workload=DataLossRecovery) | **`start_move_keys_too_many_retries`** (1250) |
| 2 | `StartFailedForWorkloadDataLossRecovery` | `operation_failed` |
| 3 | `RunTests` | `operation_failed` |
| 4 | `SetupAndRunError` | `operation_failed` |

From the trace, at t=0 there are **three** relevant `Knob` lines — `max_read...=1000000` (ServerKnobs, buggified), `max_write...=5000000` (ClientKnobs) **and** `max_write...=1000000` (ServerKnobs, buggified). At t=1 `AssignKnobValue` sets read to 5000000, which reaches `SERVER_KNOBS`, and write to 5000000, which is a no-op on the client copy. So the read window became 5s as intended while the **write window stayed at the buggified 1s**.

The resolver rejects commits whose read snapshot is older than `commitVersion - MAX_WRITE_TRANSACTION_LIFE_VERSIONS` (`Resolver.actor.cpp:339` → `SkipList.cpp:837`). One `startMoveKeys` transaction takes ~2.4s on a 45-machine simulated cluster, so every attempt blew the 1s window; 50 retries, then `start_move_keys_too_many_retries` (`MoveKeys.actor.cpp:1193`).

Evidence ruling out a sick cluster: a single `MasterRecoveryState` sequence at t=5.59 ending `fully_recovered`, nothing during the failure window; ratekeeper idle (`TPSLimit` mostly `1e+09`, `WorstStorageServerVersionLag=0`); and decisively `ResolverMetrics.TransactionsTooOld` on the system-keyspace resolver climbing `40 → 44 → 51 → … → 99` across t=102→187 while **every other resolver reports 0** for the whole run. With the read window correctly at 5s, 2.4s transactions could not have failed on reads — it is the write window.

Three other tests were also silently not getting the server-side value they ask for: `tests/slow/GcGenerations.toml`, `tests/fast/EncryptedBackupCorrectness.toml`, `tests/negative/ResolverIgnoreTooOld.toml`.

## Why this is narrower than #13931

The rest of #12464, and its predecessor #12440, restructure how the transaction-life windows are fuzzed in simulation: moving the fuzzing into `ClientKnobs` as `getSimulatedTxnTimeoutSeconds()`, adding `IRandom::truePercent` (plus ~120 lines of `DeterministicRandom` tests), and replacing the read-window BUGGIFY ladder with a 5s-weighted random — which drops the `buggifyShortReadWindow` 0.1s case and the 10× case. None of that is needed to fix this bug, and on a release branch it changes simulation coverage for **every** test. So it's left out.

Worth noting what is *not* included and why. Making the two copies agree is not required here: the only consequence of them disagreeing is that `KnobProtectiveGroup::snapshotOriginalKnobs` records the client value and restores it into `SERVER_KNOBS` on teardown. All four affected tomls declare their `[[knobs]]` at top level and contain exactly one `[[test]]` block, so that group lives for the whole run and restores at process exit with nothing after it — confirmed by the trace, where the restoring `AssignKnobValue` lands at t=218.25, the very end. The effect is unobservable, so no extra change is justified.

## Testing

- ✅ Builds.
- Adds `/fdbclient/knobs/shadowedKnobOverrideReachesEveryCollection`, covering the shadowed case (override must reach both collections), the single-collection case, and the unknown-knob case (must still return false so `setKnob` keeps throwing `invalid_option_value`).
- ⏳ `fdbserver -r simulation -f tests/fast/DataLossRecovery.toml -s 3630903977 -b on` — previously 4 SevErrors, expected to pass.
- ⏳ Joshua.

Unlike #13931 this does not alter fuzzing, so the blast radius is limited to tests that explicitly override a shadowed knob — the four listed above. `tests/negative/ResolverIgnoreTooOld.toml` is the one to watch: it asks for a *shorter* 1s write window and until now was silently getting whatever BUGGIFY chose, so its override takes effect for the first time.

## No corresponding `main` PR

`main` already has this. The files have since moved there (`ServerKnobs.cpp` → `fdbserver/core/`, the `*KnobCollection.cpp` files replaced by a free `trySetServerKnob`), so this patch is `release-7.4`-shaped only. `release-7.3` carries the identical short circuit and needs the same fix.
