### PR TITLE
Accept disabled legacy modes in simulation configuration

### DIFF
--- a/fdbserver/SimulatedCluster.cpp
+++ b/fdbserver/SimulatedCluster.cpp
@@ -60,6 +60,7 @@
 #include "flow/TypeTraits.h"
 #include "flow/FaultInjection.h"
 #include "flow/CodeProbeUtils.h"
+#include "flow/UnitTest.h"
 #include "fdbserver/core/FDBSimulationPolicy.h"
 #include "flow/IConnection.h"
 #include "flow/CoroUtils.h"
@@ -103,6 +104,14 @@ constexpr bool hasRocksDB =
     false
 #endif
     ;
+
+bool isDisabledLegacyMode(std::string_view key, const toml::value& value) {
+	if ((key != "tenantModes" && key != "encryptModes") || !value.is_array()) {
+		return false;
+	}
+	const auto& modes = value.as_array();
+	return modes.size() == 1 && modes.front().is_string() && modes.front().as_string() == "disabled";
+}
 
 } // anonymous namespace
 
@@ -328,6 +337,10 @@ class TestConfig : public BasicTestConfig {
 		void set(std::string_view key, const value_type& value) {
 			auto iter = confMap.find(key);
 			if (iter == confMap.end()) {
+				// Restart inputs shared with older binaries must keep these retired modes disabled.
+				if (isDisabledLegacyMode(key, value)) {
+					return;
+				}
 				std::cerr << "Unknown configuration attribute " << key << std::endl;
 				TraceEvent("UnknownConfigurationAttribute").detail("Name", std::string(key));
 				throw unknown_error();
@@ -598,6 +611,44 @@ public:
 	TestConfig() = default;
 	explicit(false) TestConfig(const BasicTestConfig& config) : BasicTestConfig(config) {}
 };
+
+TEST_CASE("/fdbserver/SimulatedCluster/LegacyDisabledModes") {
+	const std::string fileName = joinPath(params.getDataDir(), "legacy-disabled-modes.toml");
+	const auto readConfig = [&](const std::string& options) {
+		{
+			std::ofstream testFile(fileName);
+			testFile << "[configuration]\nmachineCount = 7\n" << options << "\n";
+			testFile.close();
+			ASSERT(testFile.good());
+		}
+		TestConfig config{};
+		config.readFromConfig(fileName.c_str());
+		ASSERT(config.machineCount.present() && config.machineCount.get() == 7);
+	};
+	const auto acceptsMode = [](const char* key, const char* value) {
+		std::istringstream input(std::string(key) + " = " + value);
+		const auto config = toml::parse(input, "legacy-disabled-modes.toml");
+		return isDisabledLegacyMode(key, toml::find(config, key));
+	};
+
+	readConfig("tenantModes = ['disabled']\nencryptModes = ['disabled']");
+	for (const auto* key : { "tenantModes", "encryptModes" }) {
+		readConfig(std::string(key) + " = ['disabled']");
+		for (const auto* value : { "'disabled'",
+		                           "[]",
+		                           "['enabled']",
+		                           "['DISABLED']",
+		                           "['disabled', 'enabled']",
+		                           "['disabled', 'disabled']",
+		                           "[false]",
+		                           "{ mode = 'disabled' }" }) {
+			ASSERT(!acceptsMode(key, value));
+		}
+	}
+	ASSERT(!acceptsMode("tenantMode", "['disabled']"));
+	ASSERT(!acceptsMode("encryptMode", "['disabled']"));
+	return Void();
+}
 
 template <class T>
 T simulate(const T& in) {

--- a/fdbserver/SimulatedCluster.cpp
+++ b/fdbserver/SimulatedCluster.cpp
@@ -60,7 +60,6 @@
 #include "flow/TypeTraits.h"
 #include "flow/FaultInjection.h"
 #include "flow/CodeProbeUtils.h"
-#include "flow/UnitTest.h"
 #include "fdbserver/core/FDBSimulationPolicy.h"
 #include "flow/IConnection.h"
 #include "flow/CoroUtils.h"
@@ -611,44 +610,6 @@ public:
 	TestConfig() = default;
 	explicit(false) TestConfig(const BasicTestConfig& config) : BasicTestConfig(config) {}
 };
-
-TEST_CASE("/fdbserver/SimulatedCluster/LegacyDisabledModes") {
-	const std::string fileName = joinPath(params.getDataDir(), "legacy-disabled-modes.toml");
-	const auto readConfig = [&](const std::string& options) {
-		{
-			std::ofstream testFile(fileName);
-			testFile << "[configuration]\nmachineCount = 7\n" << options << "\n";
-			testFile.close();
-			ASSERT(testFile.good());
-		}
-		TestConfig config{};
-		config.readFromConfig(fileName.c_str());
-		ASSERT(config.machineCount.present() && config.machineCount.get() == 7);
-	};
-	const auto acceptsMode = [](const char* key, const char* value) {
-		std::istringstream input(std::string(key) + " = " + value);
-		const auto config = toml::parse(input, "legacy-disabled-modes.toml");
-		return isDisabledLegacyMode(key, toml::find(config, key));
-	};
-
-	readConfig("tenantModes = ['disabled']\nencryptModes = ['disabled']");
-	for (const auto* key : { "tenantModes", "encryptModes" }) {
-		readConfig(std::string(key) + " = ['disabled']");
-		for (const auto* value : { "'disabled'",
-		                           "[]",
-		                           "['enabled']",
-		                           "['DISABLED']",
-		                           "['disabled', 'enabled']",
-		                           "['disabled', 'disabled']",
-		                           "[false]",
-		                           "{ mode = 'disabled' }" }) {
-			ASSERT(!acceptsMode(key, value));
-		}
-	}
-	ASSERT(!acceptsMode("tenantMode", "['disabled']"));
-	ASSERT(!acceptsMode("encryptMode", "['disabled']"));
-	return Void();
-}
 
 template <class T>
 T simulate(const T& in) {


### PR DESCRIPTION
## Summary

Unbounded `from_*` restart tests may legally use the current binary for their first phase. Their shared configurations retain `tenantModes = ['disabled']` and `encryptModes = ['disabled']` so historical binaries do not enable those features, but the current server rejects these retired configuration keys before simulation starts.

- Accept exactly `['disabled']` for these two legacy options in the simulation configuration reader.
- Preserve rejection of unsupported values, malformed shapes, and unrelated unknown keys.
- Leave restart inputs and binary selection unchanged.
- Add full-reader acceptance tests for the options individually and together, plus predicate checks on parsed TOML for unsupported values, malformed shapes, and unknown keys.

This fixes a pre-existing parser compatibility failure surfaced by Joshua on #13930; it is independent of that PR's changes.

## Validation

- Reproduced the startup rejection on unchanged `main` with `SnapTestSimpleRestart` and `SnapTestAttrition` before applying the fix.
- Compiled and linked `fdbserver` with Clang 19.1.5 in Release mode, with zero compilation failures. The build wrapper returned exit 1 after linking; the checks below exercised the resulting executable directly.
- `/fdbserver/SimulatedCluster/LegacyDisabledModes` passed both as a standalone unit test and in simulation (seed `20260821`, buggify on).
- All 18 invalid-configuration subprocess checks produced the expected unknown-attribute diagnostic and error 4000, without timeouts.
- All five unmodified restart pairs below passed both phases (10 successful phases). Each second phase used the first seed plus one.

| Restart pair under `restarting/from_7.4.0/` | Binaries | First-phase seed | First-phase buggify |
| --- | --- | --- | --- |
| `SnapTestSimpleRestart` | current → current | `3212932915` | on |
| `SnapCycleRestart` | current → current | `3661386216` | on |
| `SnapTestAttrition` | current → current | `1359282202` | off |
| `SnapTestRestart` | current → current | `2632227479` | off |
| `SnapTestSimpleRestart` | 7.4.6 → current | `3212932915` | on |
