### PR TITLE
Backup: fail a backup whose bulkdump did not complete

### DIFF
--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -3683,12 +3683,25 @@ struct BulkDumpTaskFunc : BackupTaskFuncBase {
 				                                                       CLIENT_KNOBS->BULKDUMP_JOB_TIMEOUT,
 				                                                       5.0); // Poll every 5 seconds
 
+				// A bulkdump that did not finish leaves no keyspace snapshot, and therefore no bulkDumpJobId
+				// for a bulkload restore to locate its data. Reporting the backup as successful in that
+				// state claims delivery of something that was asked for and not produced: the caller finds
+				// out only much later, when a restore aborts with BulkLoadRestoreNoBulkDumpJobId and
+				// appears to blame the restore for a backup-side omission hours earlier.
+				//
+				// This also restores symmetry the path had lost. The dataset-completeness check below fails
+				// the backup for the same class of problem, but it sits inside the `completed` branch and so
+				// never ran on this route -- a timeout was the one way to skip every check and still report
+				// success. Mode restoration needs no handling here; the catch below already does it on the
+				// error path.
 				if (!completed) {
-					TraceEvent(SevWarn, "BulkDumpTaskTimeout")
+					TraceEvent(SevError, "BulkDumpTaskTimeout")
 					    .detail("BackupUID", config.getUid())
 					    .detail("BulkDumpJobId", bulkDumpJob.getJobId())
-					    .detail("TimeoutDuration", CLIENT_KNOBS->BULKDUMP_JOB_TIMEOUT);
+					    .detail("TimeoutDuration", CLIENT_KNOBS->BULKDUMP_JOB_TIMEOUT)
+					    .detail("Reason", "BulkDump did not complete; backup would not be bulkload-restorable");
 					Params.timeoutOccurred().set(task, true);
+					throw backup_error();
 				}
 
 				TraceEvent("BulkDumpTaskComplete")


### PR DESCRIPTION
## Problem

`monitorBulkDumpJobCompletion` returning false was treated as a warning:

```cpp
bool completed = co_await monitorBulkDumpJobCompletion(cx, jobId, CLIENT_KNOBS->BULKDUMP_JOB_TIMEOUT, 5.0);
if (!completed) {
    TraceEvent(SevWarn, "BulkDumpTaskTimeout")...   // SevWarn
    Params.timeoutOccurred().set(task, true);       // recorded, never read
}
...
if (completed) {                                    // everything below is gated
    verifyBulkDumpDatasetCompleteness(...)           // fails the backup if data is missing
    writeKeyspaceSnapshotFile(...)                   // writes the bulkDumpJobId a restore needs
}
```

A timed-out dump therefore skipped the completeness check and the keyspace snapshot, and the backup still
reported success. The artifact has no `bulkDumpJobId`, so no bulkload restore can use it. First loud symptom
is `SevError BulkLoadRestoreNoBulkDumpJobId` at restore time, hours later, pointing at the wrong subsystem.

## Fix

Fail the backup at the point of detection.

This closes an asymmetry rather than adding a rule: `verifyBulkDumpDatasetCompleteness` already fails the
backup for the same class of problem — data promised, not present — but it sits inside the `completed`
branch, so timeout was the one route that skipped every check and still succeeded.

- No cleanup at the throw site: the enclosing handler logs `BulkDumpTaskError` and restores `bulkDump` mode
  before rethrowing.
- `BulkDumpTaskTimeout` keeps its name and gains a `Reason`; only severity changes. The condition is still
  exactly a timeout, so renaming would break trace searches for no gain.
- The now-redundant `if (completed)` guard is left in place to keep the change one readable block rather
  than a fifty-line reindentation.

## Behaviour change

Backups that previously succeeded while silently degrading now fail. The three `BackupS3Blob` tests set
their own budgets — `bulkdump_job_timeout` = 1200 plain, 5400 MultiRange and WithChaos — so any test whose
budget is too small for its shard count will now fail loudly instead of leaving an unrestorable backup.
Those budgets are worth re-checking as this lands, and Joshua's wider seed spread is where an undersized one
would show up.

## Testing

All three restore suites, two seeds each, all pass with `BulkDumpTaskWroteSnapshot` present and no timeout —
the new path stays dormant on healthy runs:

```
PASS plain      seeds 101, 202
PASS MultiRange seeds 101, 202
PASS WithChaos  seeds 101, 202
```

The failure path was observed before this change under `min_shard_bytes` 1000x below default (one manifest
per shard, thousands of dump tasks): the dump exceeded the plain variant's 1200s budget, the backup reported
success with no snapshot, and the following restore aborted with `BulkLoadRestoreNoBulkDumpJobId`.

Rebased onto current `main` now that #13924 has merged; this PR contains one commit.
