### PR TITLE
Deduplicate coalesced range-map insertion

### DIFF
--- a/fdbclient/KeyRangeMap.cpp
+++ b/fdbclient/KeyRangeMap.cpp
@@ -25,9 +25,6 @@
 #include "fdbclient/ReadYourWrites.h"
 #include "flow/UnitTest.h"
 
-#include <initializer_list>
-#include <utility>
-
 void KeyRangeActorMap::getRangesAffectedByInsertion(const KeyRangeRef& keys, std::vector<KeyRange>& affectedRanges) {
 	auto s = map.rangeContaining(keys.begin);
 	if (s.begin() != keys.begin && s.value().isValid() && !s.value().isReady())
@@ -319,102 +316,6 @@ Future<Void> krmSetRangeCoalescing(Reference<ReadYourWritesTransaction> const& t
                                    KeyRange const& maxRange,
                                    Value const& value) {
 	return holdWhile(tr, krmSetRangeCoalescing_(tr.getPtr(), mapPrefix, range, maxRange, value));
-}
-
-namespace {
-
-class CoalescedRangeValueMetric {
-public:
-	CoalescedRangeValueMetric() = default;
-	CoalescedRangeValueMetric(const CoalescedRangeValueMetric&) { ++copies; }
-	static int copyCount() { return copies; }
-
-	template <class StoredKey>
-	int64_t operator()(const MapPair<StoredKey, int>& entry) const {
-		return 1 + entry.value;
-	}
-
-private:
-	static inline int copies = 0;
-};
-
-template <class Map>
-void checkCoalescedRanges(const Map& map,
-                          std::initializer_list<std::pair<KeyRef, int>> expected,
-                          int64_t expectedMetric) {
-	auto expectedRange = expected.begin();
-	auto ranges = map.ranges();
-	for (auto range = ranges.begin(); range != ranges.end(); ++range) {
-		ASSERT(expectedRange != expected.end());
-		ASSERT(range.begin() == expectedRange->first);
-		ASSERT_EQ(range.value(), expectedRange->second);
-		++expectedRange;
-		ASSERT(range.end() == (expectedRange == expected.end() ? KeyRef(map.mapEnd) : expectedRange->first));
-	}
-	ASSERT(expectedRange == expected.end());
-	ASSERT_EQ(map.sumRange(KeyRef(), KeyRef(map.mapEnd)), expectedMetric);
-}
-
-} // namespace
-
-TEST_CASE("/keyrangemap/coalesced/rangeInsert") {
-	const auto exercise = [](auto& map) {
-		const int metricCopies = CoalescedRangeValueMetric::copyCount();
-		map.insert(KeyRangeRef("b"_sr, "b"_sr), 9);
-		checkCoalescedRanges(map, { { ""_sr, 0 } }, 1);
-
-		map.insert(KeyRangeRef("b"_sr, "d"_sr), 2);
-		checkCoalescedRanges(map, { { ""_sr, 0 }, { "b"_sr, 2 }, { "d"_sr, 0 } }, 5);
-		map.insert(KeyRangeRef("d"_sr, "f"_sr), 2);
-		checkCoalescedRanges(map, { { ""_sr, 0 }, { "b"_sr, 2 }, { "f"_sr, 0 } }, 5);
-		map.insert(KeyRangeRef("a"_sr, "b"_sr), 2);
-		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 2 }, { "f"_sr, 0 } }, 5);
-		map.insert(KeyRangeRef("c"_sr, "e"_sr), 2);
-		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 2 }, { "f"_sr, 0 } }, 5);
-		map.insert(KeyRangeRef("h"_sr, "j"_sr), 2);
-		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 2 }, { "f"_sr, 0 }, { "h"_sr, 2 }, { "j"_sr, 0 } }, 9);
-		map.insert(KeyRangeRef("f"_sr, "h"_sr), 2);
-		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 2 }, { "j"_sr, 0 } }, 5);
-
-		map.insert(KeyRangeRef("c"_sr, "g"_sr), 5);
-		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 2 }, { "c"_sr, 5 }, { "g"_sr, 2 }, { "j"_sr, 0 } }, 14);
-		map.insert(KeyRangeRef("a"_sr, "h"_sr), 4);
-		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 4 }, { "h"_sr, 2 }, { "j"_sr, 0 } }, 10);
-		map.insert(KeyRangeRef("h"_sr, "z"_sr), 7);
-		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 4 }, { "h"_sr, 7 } }, 14);
-		map.insert(KeyRangeRef(""_sr, "z"_sr), 3);
-		checkCoalescedRanges(map, { { ""_sr, 3 } }, 4);
-		map.insert(KeyRangeRef("z"_sr, "z"_sr), 9);
-		checkCoalescedRanges(map, { { ""_sr, 3 } }, 4);
-		ASSERT_EQ(CoalescedRangeValueMetric::copyCount(), metricCopies);
-	};
-
-	CoalescedKeyRangeMap<int, int64_t, CoalescedRangeValueMetric> owning(0, "z"_sr);
-	exercise(owning);
-	CoalescedKeyRefRangeMap<int, int64_t, CoalescedRangeValueMetric> borrowed(0, "z"_sr);
-	exercise(borrowed);
-	co_return;
-}
-
-TEST_CASE("/keyrangemap/coalesced/keyLifetime") {
-	CoalescedKeyRangeMap<int, int64_t, CoalescedRangeValueMetric> owning;
-	{
-		Key input("bd"_sr);
-		owning.insert(KeyRangeRef(input.substr(0, 1), input.substr(1, 1)), 2);
-		mutateString(input)[0] = 'x';
-		mutateString(input)[1] = 'y';
-	}
-	checkCoalescedRanges(owning, { { ""_sr, 0 }, { "b"_sr, 2 }, { "d"_sr, 0 } }, 5);
-
-	Arena retained;
-	CoalescedKeyRefRangeMap<int, int64_t, CoalescedRangeValueMetric> borrowed;
-	{
-		Arena input;
-		borrowed.insert(KeyRangeRef(KeyRef(input, "b"_sr), KeyRef(input, "d"_sr)), 2);
-		retained.dependsOn(input);
-	}
-	checkCoalescedRanges(borrowed, { { ""_sr, 0 }, { "b"_sr, 2 }, { "d"_sr, 0 } }, 5);
-	co_return;
 }
 
 TEST_CASE("/keyrangemap/decoderange/aligned") {

--- a/fdbclient/KeyRangeMap.cpp
+++ b/fdbclient/KeyRangeMap.cpp
@@ -25,6 +25,9 @@
 #include "fdbclient/ReadYourWrites.h"
 #include "flow/UnitTest.h"
 
+#include <initializer_list>
+#include <utility>
+
 void KeyRangeActorMap::getRangesAffectedByInsertion(const KeyRangeRef& keys, std::vector<KeyRange>& affectedRanges) {
 	auto s = map.rangeContaining(keys.begin);
 	if (s.begin() != keys.begin && s.value().isValid() && !s.value().isReady())
@@ -316,6 +319,102 @@ Future<Void> krmSetRangeCoalescing(Reference<ReadYourWritesTransaction> const& t
                                    KeyRange const& maxRange,
                                    Value const& value) {
 	return holdWhile(tr, krmSetRangeCoalescing_(tr.getPtr(), mapPrefix, range, maxRange, value));
+}
+
+namespace {
+
+class CoalescedRangeValueMetric {
+public:
+	CoalescedRangeValueMetric() = default;
+	CoalescedRangeValueMetric(const CoalescedRangeValueMetric&) { ++copies; }
+	static int copyCount() { return copies; }
+
+	template <class StoredKey>
+	int64_t operator()(const MapPair<StoredKey, int>& entry) const {
+		return 1 + entry.value;
+	}
+
+private:
+	static inline int copies = 0;
+};
+
+template <class Map>
+void checkCoalescedRanges(const Map& map,
+                          std::initializer_list<std::pair<KeyRef, int>> expected,
+                          int64_t expectedMetric) {
+	auto expectedRange = expected.begin();
+	auto ranges = map.ranges();
+	for (auto range = ranges.begin(); range != ranges.end(); ++range) {
+		ASSERT(expectedRange != expected.end());
+		ASSERT(range.begin() == expectedRange->first);
+		ASSERT_EQ(range.value(), expectedRange->second);
+		++expectedRange;
+		ASSERT(range.end() == (expectedRange == expected.end() ? KeyRef(map.mapEnd) : expectedRange->first));
+	}
+	ASSERT(expectedRange == expected.end());
+	ASSERT_EQ(map.sumRange(KeyRef(), KeyRef(map.mapEnd)), expectedMetric);
+}
+
+} // namespace
+
+TEST_CASE("/keyrangemap/coalesced/rangeInsert") {
+	const auto exercise = [](auto& map) {
+		const int metricCopies = CoalescedRangeValueMetric::copyCount();
+		map.insert(KeyRangeRef("b"_sr, "b"_sr), 9);
+		checkCoalescedRanges(map, { { ""_sr, 0 } }, 1);
+
+		map.insert(KeyRangeRef("b"_sr, "d"_sr), 2);
+		checkCoalescedRanges(map, { { ""_sr, 0 }, { "b"_sr, 2 }, { "d"_sr, 0 } }, 5);
+		map.insert(KeyRangeRef("d"_sr, "f"_sr), 2);
+		checkCoalescedRanges(map, { { ""_sr, 0 }, { "b"_sr, 2 }, { "f"_sr, 0 } }, 5);
+		map.insert(KeyRangeRef("a"_sr, "b"_sr), 2);
+		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 2 }, { "f"_sr, 0 } }, 5);
+		map.insert(KeyRangeRef("c"_sr, "e"_sr), 2);
+		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 2 }, { "f"_sr, 0 } }, 5);
+		map.insert(KeyRangeRef("h"_sr, "j"_sr), 2);
+		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 2 }, { "f"_sr, 0 }, { "h"_sr, 2 }, { "j"_sr, 0 } }, 9);
+		map.insert(KeyRangeRef("f"_sr, "h"_sr), 2);
+		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 2 }, { "j"_sr, 0 } }, 5);
+
+		map.insert(KeyRangeRef("c"_sr, "g"_sr), 5);
+		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 2 }, { "c"_sr, 5 }, { "g"_sr, 2 }, { "j"_sr, 0 } }, 14);
+		map.insert(KeyRangeRef("a"_sr, "h"_sr), 4);
+		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 4 }, { "h"_sr, 2 }, { "j"_sr, 0 } }, 10);
+		map.insert(KeyRangeRef("h"_sr, "z"_sr), 7);
+		checkCoalescedRanges(map, { { ""_sr, 0 }, { "a"_sr, 4 }, { "h"_sr, 7 } }, 14);
+		map.insert(KeyRangeRef(""_sr, "z"_sr), 3);
+		checkCoalescedRanges(map, { { ""_sr, 3 } }, 4);
+		map.insert(KeyRangeRef("z"_sr, "z"_sr), 9);
+		checkCoalescedRanges(map, { { ""_sr, 3 } }, 4);
+		ASSERT_EQ(CoalescedRangeValueMetric::copyCount(), metricCopies);
+	};
+
+	CoalescedKeyRangeMap<int, int64_t, CoalescedRangeValueMetric> owning(0, "z"_sr);
+	exercise(owning);
+	CoalescedKeyRefRangeMap<int, int64_t, CoalescedRangeValueMetric> borrowed(0, "z"_sr);
+	exercise(borrowed);
+	co_return;
+}
+
+TEST_CASE("/keyrangemap/coalesced/keyLifetime") {
+	CoalescedKeyRangeMap<int, int64_t, CoalescedRangeValueMetric> owning;
+	{
+		Key input("bd"_sr);
+		owning.insert(KeyRangeRef(input.substr(0, 1), input.substr(1, 1)), 2);
+		mutateString(input)[0] = 'x';
+		mutateString(input)[1] = 'y';
+	}
+	checkCoalescedRanges(owning, { { ""_sr, 0 }, { "b"_sr, 2 }, { "d"_sr, 0 } }, 5);
+
+	Arena retained;
+	CoalescedKeyRefRangeMap<int, int64_t, CoalescedRangeValueMetric> borrowed;
+	{
+		Arena input;
+		borrowed.insert(KeyRangeRef(KeyRef(input, "b"_sr), KeyRef(input, "d"_sr)), 2);
+		retained.dependsOn(input);
+	}
+	checkCoalescedRanges(borrowed, { { ""_sr, 0 }, { "b"_sr, 2 }, { "d"_sr, 0 } }, 5);
+	co_return;
 }
 
 TEST_CASE("/keyrangemap/decoderange/aligned") {

--- a/fdbclient/include/fdbclient/KeyRangeMap.h
+++ b/fdbclient/include/fdbclient/KeyRangeMap.h
@@ -199,15 +199,21 @@ std::vector<KeyRangeWith<Val>> KeyRangeMap<Val, Metric, MetricFunc>::getAffected
 	return affectedRanges;
 }
 
-template <class Val, class Metric, class MetricFunc>
-void CoalescedKeyRangeMap<Val, Metric, MetricFunc>::insert(const KeyRangeRef& keys, const Val& value) {
+namespace KeyRangeMapImpl {
+
+template <class StoredKey, class Val, class Metric, class MetricFunc>
+void insertCoalescedRange(Map<StoredKey, Val, MapPair<StoredKey, Val>, Metric>& map,
+                          const MetricFunc& mf,
+                          const Key& mapEnd,
+                          const KeyRangeRef& keys,
+                          const Val& value) {
 	ASSERT(keys.end <= mapEnd);
 
 	if (keys.empty())
 		return;
 
-	auto begin = RangeMap<Key, Val, KeyRangeRef, Metric, MetricFunc>::map.lower_bound(keys.begin);
-	auto end = RangeMap<Key, Val, KeyRangeRef, Metric, MetricFunc>::map.lower_bound(keys.end);
+	auto begin = map.lower_bound(keys.begin);
+	auto end = map.lower_bound(keys.end);
 	bool insertEnd = false;
 	bool insertBegin = false;
 	Val endVal;
@@ -236,17 +242,22 @@ void CoalescedKeyRangeMap<Val, Metric, MetricFunc>::insert(const KeyRangeRef& ke
 			insertBegin = true;
 	}
 
-	RangeMap<Key, Val, KeyRangeRef, Metric, MetricFunc>::map.erase(begin, end);
+	map.erase(begin, end);
 	if (insertEnd) {
-		MapPair<Key, Val> p(keys.end, endVal);
-		RangeMap<Key, Val, KeyRangeRef, Metric, MetricFunc>::map.insert(
-		    p, true, RangeMap<Key, Val, KeyRangeRef, Metric, MetricFunc>::mf(p));
+		MapPair<StoredKey, Val> p(keys.end, endVal);
+		map.insert(p, true, mf(p));
 	}
 	if (insertBegin) {
-		MapPair<Key, Val> p(keys.begin, value);
-		RangeMap<Key, Val, KeyRangeRef, Metric, MetricFunc>::map.insert(
-		    p, true, RangeMap<Key, Val, KeyRangeRef, Metric, MetricFunc>::mf(p));
+		MapPair<StoredKey, Val> p(keys.begin, value);
+		map.insert(p, true, mf(p));
 	}
+}
+
+} // namespace KeyRangeMapImpl
+
+template <class Val, class Metric, class MetricFunc>
+void CoalescedKeyRangeMap<Val, Metric, MetricFunc>::insert(const KeyRangeRef& keys, const Val& value) {
+	KeyRangeMapImpl::insertCoalescedRange(this->map, this->mf, mapEnd, keys, value);
 }
 
 template <class Val, class Metric, class MetricFunc>
@@ -299,52 +310,7 @@ void CoalescedKeyRangeMap<Val, Metric, MetricFunc>::insert(const KeyRef& key, co
 
 template <class Val, class Metric, class MetricFunc>
 void CoalescedKeyRefRangeMap<Val, Metric, MetricFunc>::insert(const KeyRangeRef& keys, const Val& value) {
-	ASSERT(keys.end <= mapEnd);
-
-	if (keys.empty())
-		return;
-
-	auto begin = RangeMap<KeyRef, Val, KeyRangeRef, Metric, MetricFunc>::map.lower_bound(keys.begin);
-	auto end = RangeMap<KeyRef, Val, KeyRangeRef, Metric, MetricFunc>::map.lower_bound(keys.end);
-	bool insertEnd = false;
-	bool insertBegin = false;
-	Val endVal;
-
-	if (keys.end != mapEnd) {
-		if (end->key != keys.end) {
-			auto before_end = end;
-			before_end.decrementNonEnd();
-			if (value != before_end->value) {
-				insertEnd = true;
-				endVal = before_end->value;
-			}
-		}
-
-		if (!insertEnd && end->value == value && end->key != mapEnd) {
-			++end;
-		}
-	}
-
-	if (keys.begin == allKeys.begin) {
-		insertBegin = true;
-	} else {
-		auto before_begin = begin;
-		before_begin.decrementNonEnd();
-		if (before_begin->value != value)
-			insertBegin = true;
-	}
-
-	RangeMap<KeyRef, Val, KeyRangeRef, Metric, MetricFunc>::map.erase(begin, end);
-	if (insertEnd) {
-		MapPair<KeyRef, Val> p(keys.end, endVal);
-		RangeMap<KeyRef, Val, KeyRangeRef, Metric, MetricFunc>::map.insert(
-		    p, true, RangeMap<KeyRef, Val, KeyRangeRef, Metric, MetricFunc>::mf(p));
-	}
-	if (insertBegin) {
-		MapPair<KeyRef, Val> p(keys.begin, value);
-		RangeMap<KeyRef, Val, KeyRangeRef, Metric, MetricFunc>::map.insert(
-		    p, true, RangeMap<KeyRef, Val, KeyRangeRef, Metric, MetricFunc>::mf(p));
-	}
+	KeyRangeMapImpl::insertCoalescedRange(this->map, this->mf, mapEnd, keys, value);
 }
 
 template <class Val, class Metric, class MetricFunc>


### PR DESCRIPTION
## Summary

- Share the range-insert algorithm used by `CoalescedKeyRangeMap` and `CoalescedKeyRefRangeMap` through a typed implementation helper.
- Preserve owning versus borrowed keys, boundary-value lifetime, metric evaluation, and insertion order. Leave the single-key overloads and public classes unchanged.

## Validation

- Full `fdbclient_test` (Clang Release): 97 passed, 0 failed.
- `git diff --check` passed.

No simulation or performance testing was run.
