### PR TITLE
Deduplicate storage-server locality exclusion expansion

### DIFF
--- a/fdbserver/datadistributor/DDTeamCollection.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.cpp
@@ -6390,6 +6390,39 @@ public:
 		    PublicRequestStream<GetValueRequest>(Endpoint({ NetworkAddress(IPAddress(0x01010101), id) }, UID(id, 1)));
 	}
 
+	static void ExclusionTracker_LocalityAddresses() {
+		const NetworkAddress primary(IPAddress(0x01010102), 2);
+		const NetworkAddress secondary(IPAddress(0x01010102), 3);
+		StorageServerInterface server;
+		setTestEndpoint(server, 1);
+		server.getKeyValues = PublicRequestStream<GetKeyValuesRequest>(Endpoint({ primary, secondary }, UID(2, 1)));
+		server.locality.set("zoneid"_sr, "zone-a"_sr);
+		server.locality.set("dcid"_sr, "primary"_sr);
+		server.locality.set("unset"_sr, {});
+
+		std::set<AddressExclusion> excluded{ AddressExclusion(IPAddress(0x01010103), 4) };
+		const auto original = excluded;
+		ExclusionTracker::appendAddressesMatchingLocalities(server, {}, excluded);
+		ASSERT(excluded == original);
+		ExclusionTracker::appendAddressesMatchingLocalities(
+		    server, { { "absent", "zone-a" }, { "unset", "" }, { "zoneid", "zone-b" } }, excluded);
+		ASSERT(excluded == original);
+		ExclusionTracker::appendAddressesMatchingLocalities(
+		    server, { { "zoneid", "zone-a" }, { "dcid", "primary" }, { "zoneid", "zone-a" } }, excluded);
+		auto expected = original;
+		expected.insert(AddressExclusion(primary.ip, primary.port));
+		expected.insert(AddressExclusion(secondary.ip, secondary.port));
+		ASSERT(excluded == expected);
+
+		std::set<AddressExclusion> failed;
+		ExclusionTracker::appendAddressesMatchingLocalities(server, { { "zoneid", "zone-b" } }, failed);
+		ASSERT(failed.empty());
+		server.getKeyValues = PublicRequestStream<GetKeyValuesRequest>(Endpoint({ primary }, UID(3, 1)));
+		ExclusionTracker::appendAddressesMatchingLocalities(server, { { "zoneid", "zone-a" } }, failed);
+		ASSERT(failed == std::set<AddressExclusion>({ AddressExclusion(primary.ip, primary.port) }));
+		ASSERT(excluded == expected);
+	}
+
 	static std::unique_ptr<DDTeamCollection> testTeamCollection(
 	    int teamSize,
 	    Reference<IReplicationPolicy> policy,
@@ -7697,4 +7730,9 @@ TEST_CASE("/DataDistribution/TeamTracker/RetriesMergedShardForUndesiredServer") 
 
 TEST_CASE("/DataDistribution/TeamTracker/RechecksHealthyZone") {
 	co_await DDTeamCollectionUnitTest::TeamTracker_RechecksHealthyZone();
+}
+
+TEST_CASE("/DataDistribution/ExclusionTracker/LocalityAddresses") {
+	DDTeamCollectionUnitTest::ExclusionTracker_LocalityAddresses();
+	co_return;
 }

--- a/fdbserver/datadistributor/DDTeamCollection.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.cpp
@@ -6390,39 +6390,6 @@ public:
 		    PublicRequestStream<GetValueRequest>(Endpoint({ NetworkAddress(IPAddress(0x01010101), id) }, UID(id, 1)));
 	}
 
-	static void ExclusionTracker_LocalityAddresses() {
-		const NetworkAddress primary(IPAddress(0x01010102), 2);
-		const NetworkAddress secondary(IPAddress(0x01010102), 3);
-		StorageServerInterface server;
-		setTestEndpoint(server, 1);
-		server.getKeyValues = PublicRequestStream<GetKeyValuesRequest>(Endpoint({ primary, secondary }, UID(2, 1)));
-		server.locality.set("zoneid"_sr, "zone-a"_sr);
-		server.locality.set("dcid"_sr, "primary"_sr);
-		server.locality.set("unset"_sr, {});
-
-		std::set<AddressExclusion> excluded{ AddressExclusion(IPAddress(0x01010103), 4) };
-		const auto original = excluded;
-		ExclusionTracker::appendAddressesMatchingLocalities(server, {}, excluded);
-		ASSERT(excluded == original);
-		ExclusionTracker::appendAddressesMatchingLocalities(
-		    server, { { "absent", "zone-a" }, { "unset", "" }, { "zoneid", "zone-b" } }, excluded);
-		ASSERT(excluded == original);
-		ExclusionTracker::appendAddressesMatchingLocalities(
-		    server, { { "zoneid", "zone-a" }, { "dcid", "primary" }, { "zoneid", "zone-a" } }, excluded);
-		auto expected = original;
-		expected.insert(AddressExclusion(primary.ip, primary.port));
-		expected.insert(AddressExclusion(secondary.ip, secondary.port));
-		ASSERT(excluded == expected);
-
-		std::set<AddressExclusion> failed;
-		ExclusionTracker::appendAddressesMatchingLocalities(server, { { "zoneid", "zone-b" } }, failed);
-		ASSERT(failed.empty());
-		server.getKeyValues = PublicRequestStream<GetKeyValuesRequest>(Endpoint({ primary }, UID(3, 1)));
-		ExclusionTracker::appendAddressesMatchingLocalities(server, { { "zoneid", "zone-a" } }, failed);
-		ASSERT(failed == std::set<AddressExclusion>({ AddressExclusion(primary.ip, primary.port) }));
-		ASSERT(excluded == expected);
-	}
-
 	static std::unique_ptr<DDTeamCollection> testTeamCollection(
 	    int teamSize,
 	    Reference<IReplicationPolicy> policy,
@@ -7730,9 +7697,4 @@ TEST_CASE("/DataDistribution/TeamTracker/RetriesMergedShardForUndesiredServer") 
 
 TEST_CASE("/DataDistribution/TeamTracker/RechecksHealthyZone") {
 	co_await DDTeamCollectionUnitTest::TeamTracker_RechecksHealthyZone();
-}
-
-TEST_CASE("/DataDistribution/ExclusionTracker/LocalityAddresses") {
-	DDTeamCollectionUnitTest::ExclusionTracker_LocalityAddresses();
-	co_return;
 }

--- a/fdbserver/datadistributor/ExclusionTracker.h
+++ b/fdbserver/datadistributor/ExclusionTracker.h
@@ -112,41 +112,8 @@ struct ExclusionTracker {
 				RangeResult serverList = fServerList.get();
 				for (auto& s : serverList) {
 					auto decodedServer = decodeServerListValue(s.value);
-					// Check if the server is excluded based on a locality.
-					for (auto& excludedLocality : decodedExcludedLocalities) {
-						if (!decodedServer.locality.isPresent(excludedLocality.first)) {
-							continue;
-						}
-
-						if (decodedServer.locality.get(excludedLocality.first) != excludedLocality.second) {
-							continue;
-						}
-
-						auto addresses = decodedServer.getKeyValues.getEndpoint().addresses;
-						newExcluded.insert(AddressExclusion(addresses.address.ip, addresses.address.port));
-						if (addresses.secondaryAddress.present()) {
-							auto secondaryAddress = addresses.secondaryAddress.get();
-							newExcluded.insert(AddressExclusion(secondaryAddress.ip, secondaryAddress.port));
-						}
-					}
-
-					// Check if the server is excluded as failed based on a locality.
-					for (auto& failedLocality : decodedFailedLocalities) {
-						if (!decodedServer.locality.isPresent(failedLocality.first)) {
-							continue;
-						}
-
-						if (decodedServer.locality.get(failedLocality.first) != failedLocality.second) {
-							continue;
-						}
-
-						auto addresses = decodedServer.getKeyValues.getEndpoint().addresses;
-						newFailed.insert(AddressExclusion(addresses.address.ip, addresses.address.port));
-						if (addresses.secondaryAddress.present()) {
-							auto secondaryAddress = addresses.secondaryAddress.get();
-							newFailed.insert(AddressExclusion(secondaryAddress.ip, secondaryAddress.port));
-						}
-					}
+					appendAddressesMatchingLocalities(decodedServer, decodedExcludedLocalities, newExcluded);
+					appendAddressesMatchingLocalities(decodedServer, decodedFailedLocalities, newFailed);
 				}
 
 				bool foundChange = false;
@@ -180,6 +147,30 @@ struct ExclusionTracker {
 			if (hasErr) {
 				TraceEvent("ExclusionTrackerError").error(err);
 				co_await tr.onError(err);
+			}
+		}
+	}
+
+private:
+	friend class DDTeamCollectionUnitTest;
+
+	static void appendAddressesMatchingLocalities(StorageServerInterface const& server,
+	                                              std::vector<std::pair<std::string, std::string>> const& localities,
+	                                              std::set<AddressExclusion>& exclusions) {
+		for (auto const& locality : localities) {
+			if (!server.locality.isPresent(locality.first)) {
+				continue;
+			}
+
+			if (server.locality.get(locality.first) != locality.second) {
+				continue;
+			}
+
+			auto addresses = server.getKeyValues.getEndpoint().addresses;
+			exclusions.insert(AddressExclusion(addresses.address.ip, addresses.address.port));
+			if (addresses.secondaryAddress.present()) {
+				auto secondaryAddress = addresses.secondaryAddress.get();
+				exclusions.insert(AddressExclusion(secondaryAddress.ip, secondaryAddress.port));
 			}
 		}
 	}

--- a/fdbserver/datadistributor/ExclusionTracker.h
+++ b/fdbserver/datadistributor/ExclusionTracker.h
@@ -152,8 +152,6 @@ struct ExclusionTracker {
 	}
 
 private:
-	friend class DDTeamCollectionUnitTest;
-
 	static void appendAddressesMatchingLocalities(StorageServerInterface const& server,
 	                                              std::vector<std::pair<std::string, std::string>> const& localities,
 	                                              std::set<AddressExclusion>& exclusions) {


### PR DESCRIPTION
## Summary

- Share locality matching and primary/secondary address insertion through one private `ExclusionTracker` helper.
- Reuse it for excluded and failed localities while preserving their separate destination sets, the `getKeyValues` endpoint, and transaction/watch behavior.

## Validation

- Clang Release compilation and linking of `fdbserver_datadistributor_test` completed.
- Full `fdbserver_datadistributor_test` after removing the locality-address unit test: 53 passed, 0 failed.
- `git diff --check` passed.

The build wrapper returned exit code 1 after linking. Source hashes and binary freshness were verified before successful direct test execution. No simulation or performance testing was run.
