### PR TITLE
Avoid recovery on old backup worker failure

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -519,18 +519,9 @@ ACTOR Future<Void> TagPartitionedLogSystem::onError_internal(TagPartitionedLogSy
 						}
 					}
 				}
-				// Monitor changes of backup workers for old epochs.
-				for (const auto& worker : old.tLogs[0]->backupWorkers) {
-					if (worker->get().present()) {
-						backupFailed.push_back(waitFailureClient(worker->get().interf().waitFailure,
-						                                         SERVER_KNOBS->BACKUP_TIMEOUT,
-						                                         -SERVER_KNOBS->BACKUP_TIMEOUT /
-						                                             SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
-						                                         /*trace=*/true));
-					} else {
-						changes.push_back(worker->onChange());
-					}
-				}
+				// Old-epoch backup workers are stateless and persist their progress. We intentionally do not
+				// start a transaction-system recovery on their failure, since repeated recoveries could stall
+				// recovery and hurt availability.
 			}
 		}
 


### PR DESCRIPTION
cherry-pick of #13712

This PR avoids restarting transaction-system recovery when a Backup V2 worker draining an old log epoch fails.

During recovery, unfinished backup work from earlier epochs is recruited using its persisted progress. Once recruitment completes, LogSystem::onError() monitors those old-epoch workers and converts a worker failure into backup_worker_failed. If recovery has not yet completed, this starts another recovery generation, which recruits the unfinished work again. Repeated worker failures can therefore prevent the transaction system from completing recovery and make the database unavailable.

Old-epoch backup workers are stateless and persist their progress. A failed worker can cause backup progress to stall and conservatively retain the corresponding old log generation, but it should not restart transaction-system recovery.

This PR removes only the old-epoch backup-worker failure monitor. Current-epoch backup-worker monitoring and initialization failure handling remain unchanged. The old log generation continues to be retained until its backup work completes or is otherwise resolved.


100K simulation run:
20260823-105500-neethu-e3b2ba25c8b0c4cd            compressed=True data_size=60589368 duration=4247731 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:50:12 sanity=False started=100000 stopped=20260823-114512 submitted=20260823-105500 timeout=5400 username=neethu