### PR TITLE
StorageServer: remove duplicate AuditRange detail in AuditRequestInvalid trace event

### DIFF
--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -12055,8 +12055,7 @@ Future<Void> serveAuditStorageRequests(StorageServer* self, FutureStream<AuditSt
 			    .detail("AuditRange", req.range)
 			    .detail("DDId", req.ddId)
 			    .detail("AuditId", req.id)
-			    .detail("AuditType", req.getType())
-			    .detail("AuditRange", req.range);
+			    .detail("AuditType", req.getType());
 			req.reply.sendError(audit_storage_cancelled());
 			continue;
 		}


### PR DESCRIPTION
## Summary

The `AuditRequestInvalid` trace event in `serveAuditStorageRequests()` sets the `AuditRange` detail twice. This change removes the redundant second call so the event is logged with each field exactly once.

## Details

In `fdbserver/storageserver/storageserver.cpp`, the trace event that fires when an audit request fails validation looks like this:


TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways, "AuditRequestInvalid")
    .detail("AuditRange", req.range)
    .detail("DDId", req.ddId)
    .detail("AuditId", req.id)
    .detail("AuditType", req.getType())
    .detail("AuditRange", req.range);   (duplicate)


`AuditRange` is added on the first line and again on the last line, using the same `req.range` value both times.

`TraceEventFields::addField()` in `flow/Trace.cpp` simply appends every field to a list. It does not check for or merge duplicate keys:


void TraceEventFields::addField(const std::string& key, const std::string& value) {
    bytes += key.size() + value.size();
    fields.emplace_back(key, value);
}


Because of that, the event is serialized with the `AuditRange` key present twice.

## Why this matters

Trace events are written in both XML and JSON formats.

* In the XML format each detail becomes an attribute, and the result ends up as `AuditRange="..." ... AuditRange="..."` on the same element. Repeated attribute names are not valid XML, so a strict parser will reject the record.
* In the JSON format the same key appears twice in one object, which is ambiguous and is handled inconsistently across JSON parsers.

Either way, any tooling that ingests trace logs can trip over this record every time an invalid audit request is received. Since both calls use the identical value, the second one adds no information at all.

## The fix

Remove the duplicate `.detail("AuditRange", req.range)` line. The remaining fields, including the first `AuditRange`, are untouched, so no logged information is lost. This is a small, self contained correctness fix with no behavioral change beyond producing a well formed trace record.

## Testing

No functional behavior changes. The event now emits each detail key once, which restores valid XML and JSON output for this trace record.
