### PR TITLE
Prevent removing range-lock owners with active locks

### DIFF
--- a/fdbcli/RangeLockCommand.cpp
+++ b/fdbcli/RangeLockCommand.cpp
@@ -137,6 +137,11 @@ Future<bool> rangeLockCommandActor(Database cx, std::vector<StringRef> tokens) {
 			if (e.code() == error_code_actor_cancelled) {
 				throw;
 			}
+			if (e.code() == error_code_range_lock_reject) {
+				fmt::println("ERROR: cannot unregister owner: owner still holds range locks; "
+				             "stop acquisitions, release the locks, and retry");
+				co_return false;
+			}
 			co_return reportRangeLockError(e, "unregister owner");
 		}
 		fmt::println("Unregistered range lock owner: {}", ownerId);

--- a/fdbclient/RangeLock.cpp
+++ b/fdbclient/RangeLock.cpp
@@ -87,6 +87,29 @@ Future<Void> removeRangeLockOwner(Database cx, RangeLockOwnerName ownerUniqueID)
 			}
 			RangeLockOwner owner = decodeRangeLockOwner(res.get());
 			ASSERT(owner.isValid());
+			// Every page must share the deletion's read version and conflict ranges.
+			// Restart the scan on retry so a concurrent acquisition cannot leave an orphan.
+			Key beginKey = normalKeys.begin;
+			while (beginKey < normalKeys.end) {
+				RangeResult result = co_await krmGetRanges(&tr, rangeLockPrefix, KeyRangeRef(beginKey, normalKeys.end));
+				ASSERT(result.size() > 1 && result.back().key > beginKey);
+				for (int i = 0; i < result.size() - 1; ++i) {
+					if (result[i].value.empty()) {
+						continue;
+					}
+					RangeLockStateSet locks = decodeRangeLockStateSet(result[i].value);
+					ASSERT(locks.isValid());
+					for (const auto& [name, lock] : locks.getLocks()) {
+						if (lock.getOwnerUniqueId() == ownerUniqueID) {
+							TraceEvent(SevDebug, "RemoveRangeLockOwnerRejected")
+							    .detail("Owner", ownerUniqueID)
+							    .detail("Range", KeyRangeRef(result[i].key, result[i + 1].key));
+							throw range_lock_reject();
+						}
+					}
+				}
+				beginKey = result.back().key;
+			}
 			tr.clear(rangeLockOwnerKeyFor(ownerUniqueID));
 			co_await tr.commit();
 			co_return;

--- a/fdbclient/include/fdbclient/RangeLock.h
+++ b/fdbclient/include/fdbclient/RangeLock.h
@@ -245,7 +245,8 @@ private:
 // A range can only be locked by a registered owner.
 Future<Void> registerRangeLockOwner(Database cx, RangeLockOwnerName ownerUniqueID, std::string description);
 
-// Remove an owner from the database metadata.
+// Remove an owner only if it holds no locks; otherwise throw range_lock_reject.
+// An already absent owner is a no-op.
 Future<Void> removeRangeLockOwner(Database cx, RangeLockOwnerName ownerUniqueID);
 
 // Get all registered rangeLock owners.

--- a/fdbserver/workloads/RangeLock.cpp
+++ b/fdbserver/workloads/RangeLock.cpp
@@ -21,6 +21,7 @@
 #include "fdbclient/AuditUtils.h"
 #include "fdbclient/RangeLock.h"
 #include "fdbclient/FDBTypes.h"
+#include "fdbclient/KeyRangeMap.h"
 #include "fdbclient/SystemData.h"
 #include "fdbserver/core/TesterInterface.h"
 #include "fdbserver/tester/workloads.h"
@@ -228,6 +229,137 @@ struct RangeLocking : TestWorkload {
 		co_await removeRangeLockOwner(cx, owner);
 		co_await removeRangeLockOwner(cx, collidingOwner);
 		TraceEvent("RangeLockLogicalIdentityPassed");
+	}
+
+	Future<Void> testOwnerRemoval(Database cx) {
+		const RangeLockOwnerName owner = "RangeLockOwnerRemoval";
+		const RangeLockOwnerName foreignOwner = "RangeLockOwnerRemovalForeign";
+		const std::vector<KeyRange> foreignRanges = {
+			KeyRangeRef("rangeLockOwnerRemoval/a"_sr, "rangeLockOwnerRemoval/b"_sr),
+			KeyRangeRef("rangeLockOwnerRemoval/c"_sr, "rangeLockOwnerRemoval/d"_sr),
+			KeyRangeRef("rangeLockOwnerRemoval/e"_sr, "rangeLockOwnerRemoval/f"_sr)
+		};
+		const KeyRange range = KeyRangeRef("rangeLockOwnerRemoval/y"_sr, normalKeys.end);
+		co_await registerRangeLockOwner(cx, owner, "owner whose locks must survive unregister");
+		co_await registerRangeLockOwner(cx, foreignOwner, foreignOwner);
+		for (const auto& foreignRange : foreignRanges) {
+			co_await takeExclusiveReadLockOnRange(cx, foreignRange, foreignOwner);
+		}
+		co_await takeExclusiveReadLockOnRange(cx, range, owner);
+
+		Transaction scan(cx);
+		while (true) {
+			Error err;
+			try {
+				scan.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
+				scan.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				const RangeResult firstPage = co_await krmGetRanges(&scan, rangeLockPrefix, normalKeys);
+				ASSERT(firstPage.more && firstPage.back().key < range.begin);
+				break;
+			} catch (Error& e) {
+				err = e;
+			}
+			co_await scan.onError(err);
+		}
+
+		const auto ownerBefore = co_await getRangeLockOwner(cx, owner);
+		ASSERT(ownerBefore.present());
+		const auto locksBefore = co_await findExclusiveReadLockOnRange(cx, normalKeys);
+		ASSERT(locksBefore.size() == foreignRanges.size() + 1);
+		co_await expectOperationRejected(removeRangeLockOwner(cx, owner), error_code_range_lock_reject);
+		const auto ownerAfter = co_await getRangeLockOwner(cx, owner);
+		ASSERT(ownerAfter.present() && rangeLockOwnerValue(ownerAfter.get()) == rangeLockOwnerValue(ownerBefore.get()));
+		const auto locksAfter = co_await findExclusiveReadLockOnRange(cx, normalKeys);
+		ASSERT(locksAfter == locksBefore);
+		co_await expectClearRejected(cx, range);
+		TraceEvent("RangeLockOwnerRemovalPagedScanPassed");
+
+		co_await releaseExclusiveReadLockOnRange(cx, range, owner);
+		co_await removeRangeLockOwner(cx, owner);
+		co_await removeRangeLockOwner(cx, owner);
+		const auto removedOwner = co_await getRangeLockOwner(cx, owner);
+		ASSERT(!removedOwner.present());
+		const auto remainingLocks = co_await findExclusiveReadLockOnRange(cx, normalKeys);
+		ASSERT(remainingLocks.size() == foreignRanges.size());
+		for (int i = 0; i < foreignRanges.size(); ++i) {
+			ASSERT(remainingLocks[i].first == foreignRanges[i]);
+			ASSERT(remainingLocks[i].second ==
+			       RangeLockState(RangeLockType::ExclusiveReadLock, foreignOwner, foreignRanges[i]));
+		}
+		co_await testOwnerRemovalRace(cx);
+		co_await releaseExclusiveReadLockByUser(cx, foreignOwner);
+		co_await removeRangeLockOwner(cx, foreignOwner);
+		TraceEvent("RangeLockOwnerRemovalPassed");
+	}
+
+	Future<Void> testOwnerRemovalConflict(Database cx) {
+		const RangeLockOwnerName owner = "RangeLockOwnerRemovalConflict";
+		const KeyRange range = KeyRangeRef("rangeLockOwnerRemovalConflict/a"_sr, "rangeLockOwnerRemovalConflict/b"_sr);
+		Transaction acquire(cx);
+		while (true) {
+			Error err;
+			try {
+				co_await registerRangeLockOwner(cx, owner, owner);
+				co_await takeExclusiveReadLockOnRange(&acquire, range, owner);
+				co_await removeRangeLockOwner(cx, owner);
+				break;
+			} catch (Error& e) {
+				err = e;
+			}
+			co_await acquire.onError(err);
+		}
+		const ErrorOr<Void> commitResult = co_await errorOr(acquire.commit());
+		ASSERT(commitResult.isError());
+		co_await acquire.onError(commitResult.getError());
+		co_await expectOperationRejected(takeExclusiveReadLockOnRange(cx, range, owner), error_code_range_lock_failed);
+		const auto removedOwner = co_await getRangeLockOwner(cx, owner);
+		const auto remainingLocks = co_await findExclusiveReadLockOnRange(cx, range);
+		ASSERT(!removedOwner.present() && remainingLocks.empty());
+		TraceEvent("RangeLockOwnerRemovalConflictPassed").detail("CommitError", commitResult.getError().code());
+	}
+
+	Future<Void> testOwnerRemovalRace(Database cx) {
+		const RangeLockOwnerName owner = "RangeLockOwnerRemovalRace";
+		const KeyRange range = KeyRangeRef("rangeLockOwnerRemoval/0"_sr, "rangeLockOwnerRemoval/1"_sr);
+		int acquireWins = 0;
+		int removeWins = 0;
+		for (int i = 0; i < 10; ++i) {
+			co_await registerRangeLockOwner(cx, owner, owner);
+			Future<ErrorOr<Void>> taking;
+			Future<ErrorOr<Void>> removing;
+			if (i % 2 == 0) {
+				taking = errorOr(takeExclusiveReadLockOnRange(cx, range, owner));
+				removing = errorOr(removeRangeLockOwner(cx, owner));
+			} else {
+				removing = errorOr(removeRangeLockOwner(cx, owner));
+				taking = errorOr(takeExclusiveReadLockOnRange(cx, range, owner));
+			}
+			const ErrorOr<Void> takeResult = co_await taking;
+			const ErrorOr<Void> removeResult = co_await removing;
+			if (takeResult.isError() && takeResult.getError().code() != error_code_range_lock_failed) {
+				throw takeResult.getError();
+			}
+			if (removeResult.isError() && removeResult.getError().code() != error_code_range_lock_reject) {
+				throw removeResult.getError();
+			}
+			ASSERT(takeResult.isError() != removeResult.isError());
+			const auto registeredOwner = co_await getRangeLockOwner(cx, owner);
+			const auto locks = co_await findExclusiveReadLockOnRange(cx, range);
+			if (!takeResult.isError()) {
+				++acquireWins;
+				ASSERT(registeredOwner.present());
+				ASSERT(locks.size() == 1 && locks[0].first == range &&
+				       locks[0].second == RangeLockState(RangeLockType::ExclusiveReadLock, owner, range));
+				co_await releaseExclusiveReadLockOnRange(cx, range, owner);
+				co_await removeRangeLockOwner(cx, owner);
+			} else {
+				++removeWins;
+				ASSERT(!registeredOwner.present() && locks.empty());
+			}
+		}
+		TraceEvent("RangeLockOwnerRemovalRacePassed")
+		    .detail("AcquireWins", acquireWins)
+		    .detail("RemoveWins", removeWins);
 	}
 
 	std::string getLockRangesString(const std::vector<std::pair<KeyRange, RangeLockState>>& locks) {
@@ -700,6 +832,8 @@ struct RangeLocking : TestWorkload {
 		}
 		co_await testNormalKeyspaceBoundary(cx);
 		co_await testLogicalIdentity(cx);
+		co_await testOwnerRemoval(cx);
+		co_await testOwnerRemovalConflict(cx);
 		co_await complexTest(this, cx);
 		co_await testUnlockByUser(this, cx);
 	}

--- a/tests/fast/RangeLocking.toml
+++ b/tests/fast/RangeLocking.toml
@@ -3,6 +3,7 @@
 [[knobs]]
 enable_read_lock_on_range = true
 transaction_lock_rejection_retriable = false
+krm_get_range_limit = 4
 enable_version_vector = false
 enable_version_vector_tlog_unicast = false
 enable_version_vector_reply_recovery = false


### PR DESCRIPTION
## Problem

Removing a registered range-lock owner currently leaves any active locks behind. Normal release operations then fail because the owner record no longer exists.

## Solution

- Scan all range-lock metadata pages in the same transaction as the owner deletion, using conflict-producing reads and restarting the scan on retry.
- Return `range_lock_reject` if any lock belongs to the owner, preserving both the owner and its locks. Removal remains idempotent once the owner is absent.
- Give `fdbcli rangelock unregister` specific guidance to stop acquisitions, release the locks, and retry.
- Extend the existing workload with paginated scans, foreign-owner preservation, concurrent acquisition/removal, and a staged acquisition that must conflict after owner removal.

No metadata encoding changes or automatic unlocks are introduced. This does not repair pre-existing orphaned locks. Owner removal now scans all lock metadata and can retry under concurrent changes.

## Testing

- `fdbclient_test --filter /RangeLock/ --seed 20260825`: 2 tests passed, both normally and with `--simulation`.
- `RangeLocking.toml`: passed with seed 20260825 / buggify off and seed 20260826 / buggify on. All four new regression markers were present; the buggified run exercised both race outcomes.
- `RangeLockCycle.toml`: passed with seed 20260825 / buggify off.
- Fresh single-process CLI smoke test: held-lock unregister rejects with the expected message; owner/locks and original data remain intact; ordinary writes are still rejected; release and repeated unregister succeed.
- Formatting and `git diff --check` passed. Independent source review found no issues.

Build caveat: the build wrapper returned nonzero after successful final links, with no compiler failures. Changed-source hashes and binary freshness were verified before the direct test runs above.
