### PR TITLE
BulkDump: keep the read failure that a bulkdump retry is hiding

### DIFF
--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -5087,10 +5087,6 @@ Future<Void> getRangeDataToDump(StorageServer* data,
 	Key beginKey = range.begin;
 	output->lastKey = KeyRef(output->arena, range.begin);
 	bool immediateError = true;
-	// Cause of a first-read failure, rethrown below. Collapsing it into retry() would hide the one
-	// distinction the caller acts on: it gives up immediately on wrong_shard_server (a stale range
-	// assignment, which no amount of retrying against this server can fix) and retries anything else.
-	Error firstReadError;
 	// Accumulate data read from local storage to output->kvs and make sampling until any error presents
 	while (true) {
 		// Read data and stop for any error
@@ -5122,7 +5118,10 @@ Future<Void> getRangeDataToDump(StorageServer* data,
 			    .detail("Version", version)
 			    .detail("FirstRead", immediateError);
 			if (immediateError) {
-				firstReadError = e;
+				// Rethrow rather than collapsing into retry(): the caller gives up immediately on
+				// wrong_shard_server -- a stale range assignment, which no amount of retrying against
+				// this server can fix -- and retries anything else.
+				throw e;
 			}
 			break;
 		}
@@ -5161,9 +5160,9 @@ Future<Void> getRangeDataToDump(StorageServer* data,
 		beginKey = keyAfter(output->lastKey);
 	}
 
-	if (immediateError) {
-		throw firstReadError.isValid() ? firstReadError : retry();
-	}
+	// A first-read failure throws from the catch above, so reaching here means at least one read
+	// succeeded. immediateError is cleared immediately after the try/catch, before any other break.
+	ASSERT(!immediateError);
 }
 
 // The SS actor handling bulk dump task sent from DD.

--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -5087,6 +5087,10 @@ Future<Void> getRangeDataToDump(StorageServer* data,
 	Key beginKey = range.begin;
 	output->lastKey = KeyRef(output->arena, range.begin);
 	bool immediateError = true;
+	// Cause of a first-read failure, rethrown below. Collapsing it into retry() would hide the one
+	// distinction the caller acts on: it gives up immediately on wrong_shard_server (a stale range
+	// assignment, which no amount of retrying against this server can fix) and retries anything else.
+	Error firstReadError;
 	// Accumulate data read from local storage to output->kvs and make sampling until any error presents
 	while (true) {
 		// Read data and stop for any error
@@ -5110,6 +5114,15 @@ Future<Void> getRangeDataToDump(StorageServer* data,
 		} catch (Error& e) {
 			if (e.code() == error_code_actor_cancelled) {
 				throw e;
+			}
+			TraceEvent(SevWarn, "SSBulkDumpRangeReadFailed", data->thisServerID)
+			    .errorUnsuppressed(e)
+			    .detail("Range", range)
+			    .detail("BeginKey", beginKey)
+			    .detail("Version", version)
+			    .detail("FirstRead", immediateError);
+			if (immediateError) {
+				firstReadError = e;
 			}
 			break;
 		}
@@ -5149,7 +5162,7 @@ Future<Void> getRangeDataToDump(StorageServer* data,
 	}
 
 	if (immediateError) {
-		throw retry();
+		throw firstReadError.isValid() ? firstReadError : retry();
 	}
 }
 


### PR DESCRIPTION
getRangeDataToDump collapses any failure of its first read into retry(), so the one distinction the caller acts on is lost. The SS bulkdump handler gives up immediately on wrong_shard_server -- a range assignment that has gone stale, which retrying against this server can never satisfy -- but it never sees that code, so the task instead spends its whole 50-attempt budget re-reading a range it does not own. Observed in simulation as exactly 51 SSBulkDumpError events carrying only error_code_retry, with no record anywhere of what actually failed.

Rethrow the original error, and trace it: a retry that discards its own cause cannot be diagnosed from a trace log.