### PR TITLE
Backup: time bulkdump and bulkload jobs out on absence of progress

### DIFF
--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -71,9 +71,21 @@ std::atomic<int> g_bulkDumpTaskCompleteCount(0);
 std::atomic<int> g_bulkLoadRestoreTaskCompleteCount(0);
 
 // Helper function to monitor BulkDump job completion
-// Returns true if job completed successfully, false if timed out
+// Returns true if the job completed, false if it stopped making progress for timeoutDuration.
+//
+// The budget is a no-progress window, not a total duration. A dump advances one bounded slice per
+// scheduling round (the SS returns after SS_BULKDUMP_BATCH_COUNT_MAX_PER_REQUEST batches and the
+// remainder is re-dispatched on a later round), so total time scales with the size of the range and
+// with how finely it is sharded -- not with the health of the job. A wall-clock budget therefore fails
+// dumps that are advancing perfectly well, while still not catching a job that is truly wedged sooner
+// than the budget. Measuring absence of progress separates the two.
 Future<bool> monitorBulkDumpJobCompletion(Database cx, UID jobId, double timeoutDuration, double pollInterval) {
-	double timeoutStart = now();
+	double lastProgressTime = now();
+	size_t lastCompleteCount = 0;
+	// Counting completed ranges walks the job's bulkdump metadata, so it must be sampled far more
+	// coarsely than the liveness poll.
+	double progressCheckInterval = std::max(pollInterval, timeoutDuration / 10);
+	double lastProgressCheck = now();
 	Transaction tr(cx);
 
 	while (true) {
@@ -86,8 +98,26 @@ Future<bool> monitorBulkDumpJobCompletion(Database cx, UID jobId, double timeout
 				co_return true; // Job completed successfully
 			}
 
-			if (now() - timeoutStart > timeoutDuration) {
-				co_return false; // Timed out
+			if (now() - lastProgressCheck >= progressCheckInterval) {
+				lastProgressCheck = now();
+				// A sample that fails carries no information: leave the window running rather than
+				// letting a transient read error either fail the backup or extend its deadline.
+				try {
+					size_t completeCount = co_await getBulkDumpCompleteTaskCount(cx, currentJob.get().getJobRange());
+					if (completeCount > lastCompleteCount) {
+						lastCompleteCount = completeCount;
+						lastProgressTime = now();
+					}
+				} catch (Error& e) {
+					if (e.code() == error_code_actor_cancelled) {
+						throw;
+					}
+					TraceEvent(SevWarn, "BulkDumpProgressCheckFailed").error(e).detail("BulkDumpJobId", jobId);
+				}
+			}
+
+			if (now() - lastProgressTime > timeoutDuration) {
+				co_return false; // No progress within the window
 			}
 
 			co_await delay(pollInterval);
@@ -632,6 +662,13 @@ Future<std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>> getBulk
 
 // Monitor BulkLoad job completion and update restore progress counters
 // restoreUid is used to update the RestoreConfig progress
+//
+// Returns false when the job stops making progress for timeoutDuration, not when it has simply been
+// running that long. A restore's duration is a function of how much data it moves, so a wall-clock budget
+// aborts large restores that are advancing normally -- BULKLOAD_JOB_TIMEOUT's own comment concedes as much
+// ("large DBs may take days" against a 24 hour default). The task counters this loop already maintains for
+// the status display are exactly the progress signal needed, so measuring absence of progress costs
+// nothing extra here.
 Future<bool> monitorBulkLoadJobCompletionWithProgress(Database cx,
                                                       UID jobId,
                                                       UID restoreUid,
@@ -639,7 +676,9 @@ Future<bool> monitorBulkLoadJobCompletionWithProgress(Database cx,
                                                       double timeoutDuration,
                                                       double pollInterval,
                                                       bool lockAware) {
-	double timeoutStart = now();
+	double lastProgressTime = now();
+	int64_t lastCompletedTasks = -1;
+	int64_t lastCompletedBytes = -1;
 	RestoreConfig restore(restoreUid);
 
 	while (true) {
@@ -653,6 +692,11 @@ Future<bool> monitorBulkLoadJobCompletionWithProgress(Database cx,
 		// Update progress based on completed bulkload tasks
 		try {
 			auto [completed, submitted, triggered, running, total, bytes] = co_await getBulkLoadTaskProgress(cx, jobId);
+			if (completed > lastCompletedTasks || bytes > lastCompletedBytes) {
+				lastCompletedTasks = completed;
+				lastCompletedBytes = bytes;
+				lastProgressTime = now();
+			}
 			if (total > 0) {
 				// For bulkload restores, fileBlockCount is 0, so use task count as "blocks"
 				// This provides meaningful progress tracking for the restore status display
@@ -700,8 +744,8 @@ Future<bool> monitorBulkLoadJobCompletionWithProgress(Database cx,
 			TraceEvent(SevWarn, "BulkLoadRestoreProgressError").error(e).detail("JobId", jobId);
 		}
 
-		if (now() - timeoutStart > timeoutDuration) {
-			co_return false; // Timed out
+		if (now() - lastProgressTime > timeoutDuration) {
+			co_return false; // No progress within the window
 		}
 
 		co_await delay(pollInterval);
@@ -3699,7 +3743,9 @@ struct BulkDumpTaskFunc : BackupTaskFuncBase {
 					    .detail("BackupUID", config.getUid())
 					    .detail("BulkDumpJobId", bulkDumpJob.getJobId())
 					    .detail("TimeoutDuration", CLIENT_KNOBS->BULKDUMP_JOB_TIMEOUT)
-					    .detail("Reason", "BulkDump did not complete; backup would not be bulkload-restorable");
+					    .detail("Reason",
+					            "BulkDump made no progress within the timeout; backup would not be "
+					            "bulkload-restorable");
 					Params.timeoutOccurred().set(task, true);
 					throw backup_error();
 				}
@@ -4311,7 +4357,8 @@ struct BulkLoadRestoreTaskFunc : RestoreTaskFuncBase {
 					TraceEvent(SevWarn, "BulkLoadRestoreTimeout")
 					    .detail("RestoreUID", restore.getUid())
 					    .detail("BulkLoadJobId", bulkLoadJob.getJobId())
-					    .detail("TimeoutDuration", CLIENT_KNOBS->BULKLOAD_JOB_TIMEOUT);
+					    .detail("TimeoutDuration", CLIENT_KNOBS->BULKLOAD_JOB_TIMEOUT)
+					    .detail("Reason", "BulkLoad restore made no progress within the timeout");
 					// Restore original BulkLoad mode before throwing
 					if (originalBulkLoadMode != 1) {
 						co_await setBulkLoadMode(cx, originalBulkLoadMode);


### PR DESCRIPTION
BULKDUMP_JOB_TIMEOUT and BULKLOAD_JOB_TIMEOUT are spent against total elapsed time, so both monitors abort jobs that are advancing normally. Their own comments concede the premise is wrong -- "24 hours - large DBs may take days" annotating a 24 hour budget -- because neither duration is a function of health. A dump advances one bounded slice per scheduling round: the storage server returns after SS_BULKDUMP_BATCH_COUNT_MAX_PER_REQUEST batches and the remainder is re-dispatched on a later round, so a range that begins life as a single shard needs far more rounds than the budget allows. A restore's duration likewise tracks the data it moves.

Measured on a narrow-fleet simulation where the first location read returns one shard for the whole key space: seven seeds abort a dump that is demonstrably progressing -- 47 ranges persisted Complete, the frontier advancing across re-dispatch rounds -- and report a backup failure for it. Since #13936 that failure is no longer silent, which is what made this visible.

Time out on absence of progress instead, keeping the knobs as the no-progress window so a genuinely wedged job is still caught. The restore monitor already computes the task counters it needs for its own status display. The dump monitor has no such counter, so it samples getBulkDumpCompleteTaskCount at a tenth of the window -- that call walks the job's metadata and cannot run at poll frequency -- and treats a failed sample as carrying no information, neither failing the backup nor extending its deadline.

Seven previously failing seeds now complete the dump; twenty paired seeds show no regression.

`  20260825-190030-stack_misc-98e6eef2c4d4a0bc        compressed=True data_size=38725762 duration=3749156 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:32:50 sanity=False started=100000 stopped=20260825-193320 submitted=20260825-190030 timeout=5400 username=stack_misc`