### PR TITLE
Expose range lock management through the C API

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -294,10 +294,15 @@ if(NOT WIN32)
       fdb
       ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c_external.so
     )
-    # The CDC API test exercises both the direct and external-client paths.
-    # Enable admission on only these temporary clusters.
+    # Enable the experimental management APIs only on these temporary test clusters.
+    set(C_UNIT_TEST_KNOB_ENVIRONMENT
+      "FDB_KNOB_enable_native_cdc=true"
+      "FDB_KNOB_enable_read_lock_on_range=true"
+      "FDB_KNOB_enable_version_vector=false"
+      "FDB_KNOB_enable_version_vector_tlog_unicast=false"
+      "FDB_KNOB_enable_version_vector_reply_recovery=false")
     set_property(TEST fdb_c_unit_tests fdb_c_external_client_unit_tests APPEND PROPERTY ENVIRONMENT
-      "FDB_KNOB_enable_native_cdc=true")
+      ${C_UNIT_TEST_KNOB_ENVIRONMENT})
     add_unavailable_fdbclient_test(
       NAME disconnected_timeout_unit_tests
       COMMAND $<TARGET_FILE:disconnected_timeout_unit_tests>
@@ -567,7 +572,7 @@ elseif(NOT WIN32 AND NOT APPLE) # Linux Only
     ${SHIM_LIB_TEST_EXTRA_OPTIONS}
     )
   set_property(TEST fdb_c_shim_library_tests APPEND PROPERTY ENVIRONMENT
-    "FDB_KNOB_enable_native_cdc=true")
+    ${C_UNIT_TEST_KNOB_ENVIRONMENT})
 
 endif() # End Linux only
 

--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -28,6 +28,7 @@
 #include "fdbclient/MultiVersionTransaction.h"
 #include "fdbclient/MultiVersionAssignmentVars.h"
 #include "fdbclient/NativeCdcClient.h"
+#include "fdbclient/SystemData.h"
 #include "foundationdb/fdb_c.h"
 #include "foundationdb/fdb_c_internal.h"
 
@@ -63,6 +64,12 @@ int g_api_version = 0;
 /* This must be true so that we can return the data pointer of a
    Standalone<RangeResultRef> as an array of FDBKeyValue. */
 static_assert(sizeof(FDBKeyValue) == sizeof(KeyValueRef), "FDBKeyValue / KeyValueRef size mismatch");
+static_assert(sizeof(FDBRangeLockOwner) == sizeof(FdbCApi::FDBRangeLockOwner) &&
+                  alignof(FDBRangeLockOwner) == alignof(FdbCApi::FDBRangeLockOwner),
+              "FDBRangeLockOwner external client layout mismatch");
+static_assert(sizeof(FDBRangeLock) == sizeof(FdbCApi::FDBRangeLock) &&
+                  alignof(FDBRangeLock) == alignof(FdbCApi::FDBRangeLock),
+              "FDBRangeLock external client layout mismatch");
 static_assert(static_cast<int>(FDB_BG_MUTATION_TYPE_SET_VALUE) == static_cast<int>(MutationRef::Type::SetValue),
               "FDB_BG_MUTATION_TYPE_SET_VALUE enum value mismatch");
 static_assert(static_cast<int>(FDB_BG_MUTATION_TYPE_CLEAR_RANGE) == static_cast<int>(MutationRef::Type::ClearRange),
@@ -84,12 +91,12 @@ struct CNativeCdcConsumeResult {
 	Version lastConsumedVersion = invalidVersion;
 };
 
-FDBKey copyNativeCdcKey(Arena& arena, KeyRef source) {
+FDBKey copyCKey(Arena& arena, KeyRef source) {
 	StringRef copy(arena, source);
 	return FDBKey{ copy.begin(), copy.size() };
 }
 
-FDBKeyRange copyNativeCdcKeyRange(Arena& arena, KeyRangeRef source) {
+FDBKeyRange copyCKeyRange(Arena& arena, KeyRangeRef source) {
 	StringRef begin(arena, source.begin);
 	StringRef end(arena, source.end);
 	return FDBKeyRange{ begin.begin(), begin.size(), end.begin(), end.size() };
@@ -100,9 +107,9 @@ CNativeCdcStreamInfoArray makeCNativeCdcStreamInfoArray(std::vector<NativeCdcStr
 	result.streams.reserve(result.arena, source.size());
 	for (auto const& stream : source) {
 		FDBCdcStreamInfo cStream;
-		cStream.name = copyNativeCdcKey(result.arena, stream.name);
+		cStream.name = copyCKey(result.arena, stream.name);
 		cStream.stream_id = stream.streamId;
-		cStream.key_range = copyNativeCdcKeyRange(result.arena, stream.keys);
+		cStream.key_range = copyCKeyRange(result.arena, stream.keys);
 		cStream.min_version = stream.minVersion;
 		result.streams.push_back(result.arena, cStream);
 	}
@@ -154,6 +161,62 @@ FDBFuture* mapNativeCdcConsumeFuture(ThreadFuture<NativeCdcConsumeResult> source
 		    return makeCNativeCdcConsumeResult(source.get());
 	    });
 	return (FDBFuture*)result.extractPtr();
+}
+
+using CRangeLockOwnerArray = Standalone<VectorRef<FDBRangeLockOwner>>;
+using CRangeLockArray = Standalone<VectorRef<FDBRangeLock>>;
+
+FDBFuture* mapRangeLockOwnersFuture(ThreadFuture<std::vector<RangeLockOwnerInfo>> source) {
+	auto result = mapThreadFuture<std::vector<RangeLockOwnerInfo>, CRangeLockOwnerArray>(
+	    source, [](ErrorOr<std::vector<RangeLockOwnerInfo>> source) -> ErrorOr<CRangeLockOwnerArray> {
+		    if (source.isError()) {
+			    return ErrorOr<CRangeLockOwnerArray>(source.getError());
+		    }
+		    CRangeLockOwnerArray owners;
+		    owners.reserve(owners.arena(), source.get().size());
+		    for (auto const& owner : source.get()) {
+			    owners.push_back(owners.arena(),
+			                     FDBRangeLockOwner{ copyCKey(owners.arena(), owner.ownerId),
+			                                        copyCKey(owners.arena(), owner.description) });
+		    }
+		    return owners;
+	    });
+	return (FDBFuture*)result.extractPtr();
+}
+
+FDBFuture* mapRangeLocksFuture(ThreadFuture<std::vector<RangeLockInfo>> source) {
+	auto result = mapThreadFuture<std::vector<RangeLockInfo>, CRangeLockArray>(
+	    source, [](ErrorOr<std::vector<RangeLockInfo>> source) -> ErrorOr<CRangeLockArray> {
+		    if (source.isError()) {
+			    return ErrorOr<CRangeLockArray>(source.getError());
+		    }
+		    CRangeLockArray locks;
+		    locks.reserve(locks.arena(), source.get().size());
+		    for (auto const& lock : source.get()) {
+			    locks.push_back(locks.arena(),
+			                    FDBRangeLock{ copyCKeyRange(locks.arena(), lock.keys),
+			                                  copyCKeyRange(locks.arena(), lock.lockedRange),
+			                                  copyCKey(locks.arena(), lock.ownerId) });
+		    }
+		    return locks;
+	    });
+	return (FDBFuture*)result.extractPtr();
+}
+
+StringRef rangeLockBytes(uint8_t const* data, int length, bool allowEmpty = true) {
+	if (length < 0 || (length > 0 && data == nullptr) || (!allowEmpty && length == 0)) {
+		throw range_lock_failed();
+	}
+	return StringRef(data, length);
+}
+
+KeyRangeRef rangeLockRange(uint8_t const* beginKey, int beginKeyLength, uint8_t const* endKey, int endKeyLength) {
+	KeyRef begin = rangeLockBytes(beginKey, beginKeyLength);
+	KeyRef end = rangeLockBytes(endKey, endKeyLength);
+	if (begin >= end || end > normalKeys.end) {
+		throw range_lock_failed();
+	}
+	return KeyRangeRef(begin, end);
 }
 
 } // namespace
@@ -433,6 +496,20 @@ extern "C" DLLEXPORT fdb_error_t fdb_future_get_cdc_stream_info_array(FDBFuture*
 	                 *out_count = result.streams.size(););
 }
 
+extern "C" DLLEXPORT fdb_error_t fdb_future_get_range_lock_owner_array(FDBFuture* f,
+                                                                       FDBRangeLockOwner const** out_owners,
+                                                                       int* out_count) {
+	CATCH_AND_RETURN(CRangeLockOwnerArray owners = TSAV(CRangeLockOwnerArray, f)->get(); *out_owners = owners.begin();
+	                 *out_count = owners.size(););
+}
+
+extern "C" DLLEXPORT fdb_error_t fdb_future_get_range_lock_array(FDBFuture* f,
+                                                                 FDBRangeLock const** out_locks,
+                                                                 int* out_count) {
+	CATCH_AND_RETURN(CRangeLockArray locks = TSAV(CRangeLockArray, f)->get(); *out_locks = locks.begin();
+	                 *out_count = locks.size(););
+}
+
 extern "C" DLLEXPORT fdb_error_t fdb_future_get_cdc_consumer(FDBFuture* f, FDBCdcConsumer** out_consumer) {
 	CATCH_AND_RETURN(Reference<INativeCdcConsumer> consumer = TSAV(Reference<INativeCdcConsumer>, f)->get();
 	                 *out_consumer = (FDBCdcConsumer*)consumer.extractPtr(););
@@ -560,6 +637,84 @@ extern "C" DLLEXPORT fdb_error_t fdb_database_create_transaction(FDBDatabase* d,
 	CATCH_AND_RETURN(Reference<ITransaction> tr = DB(d)->createTransaction();
 	                 if (g_api_version <= 15) tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 	                 *out_transaction = (FDBTransaction*)tr.extractPtr(););
+}
+
+extern "C" DLLEXPORT FDBFuture* fdb_database_register_range_lock_owner(FDBDatabase* db,
+                                                                       uint8_t const* owner_id,
+                                                                       int owner_id_length,
+                                                                       uint8_t const* description,
+                                                                       int description_length) {
+	RETURN_FUTURE_ON_ERROR(
+	    Void,
+	    return (FDBFuture*)(DB(db)
+	                            ->registerRangeLockOwner(rangeLockBytes(owner_id, owner_id_length, false),
+	                                                     rangeLockBytes(description, description_length, false))
+	                            .extractPtr()););
+}
+
+extern "C" DLLEXPORT FDBFuture* fdb_database_remove_range_lock_owner(FDBDatabase* db,
+                                                                     uint8_t const* owner_id,
+                                                                     int owner_id_length) {
+	RETURN_FUTURE_ON_ERROR(
+	    Void,
+	    return (
+	        FDBFuture*)(DB(db)->removeRangeLockOwner(rangeLockBytes(owner_id, owner_id_length, false)).extractPtr()););
+}
+
+extern "C" DLLEXPORT FDBFuture* fdb_database_list_range_lock_owners(FDBDatabase* db) {
+	RETURN_FUTURE_ON_ERROR(CRangeLockOwnerArray, return mapRangeLockOwnersFuture(DB(db)->listRangeLockOwners()););
+}
+
+extern "C" DLLEXPORT FDBFuture* fdb_database_take_exclusive_read_lock(FDBDatabase* db,
+                                                                      uint8_t const* begin_key,
+                                                                      int begin_key_length,
+                                                                      uint8_t const* end_key,
+                                                                      int end_key_length,
+                                                                      uint8_t const* owner_id,
+                                                                      int owner_id_length) {
+	RETURN_FUTURE_ON_ERROR(
+	    Void,
+	    return (FDBFuture*)(DB(db)
+	                            ->takeExclusiveReadLock(
+	                                rangeLockRange(begin_key, begin_key_length, end_key, end_key_length),
+	                                rangeLockBytes(owner_id, owner_id_length, false))
+	                            .extractPtr()););
+}
+
+extern "C" DLLEXPORT FDBFuture* fdb_database_release_exclusive_read_lock(FDBDatabase* db,
+                                                                         uint8_t const* begin_key,
+                                                                         int begin_key_length,
+                                                                         uint8_t const* end_key,
+                                                                         int end_key_length,
+                                                                         uint8_t const* owner_id,
+                                                                         int owner_id_length) {
+	RETURN_FUTURE_ON_ERROR(
+	    Void,
+	    return (FDBFuture*)(DB(db)
+	                            ->releaseExclusiveReadLock(
+	                                rangeLockRange(begin_key, begin_key_length, end_key, end_key_length),
+	                                rangeLockBytes(owner_id, owner_id_length, false))
+	                            .extractPtr()););
+}
+
+extern "C" DLLEXPORT FDBFuture* fdb_database_list_exclusive_read_locks(FDBDatabase* db,
+                                                                       uint8_t const* begin_key,
+                                                                       int begin_key_length,
+                                                                       uint8_t const* end_key,
+                                                                       int end_key_length) {
+	RETURN_FUTURE_ON_ERROR(CRangeLockArray,
+	                       return mapRangeLocksFuture(DB(db)->listExclusiveReadLocks(
+	                           rangeLockRange(begin_key, begin_key_length, end_key, end_key_length))););
+}
+
+extern "C" DLLEXPORT FDBFuture* fdb_database_release_all_exclusive_read_locks(FDBDatabase* db,
+                                                                              uint8_t const* owner_id,
+                                                                              int owner_id_length) {
+	RETURN_FUTURE_ON_ERROR(
+	    Void,
+	    return (FDBFuture*)(DB(db)
+	                            ->releaseAllExclusiveReadLocks(rangeLockBytes(owner_id, owner_id_length, false))
+	                            .extractPtr()););
 }
 
 extern "C" DLLEXPORT FDBFuture* fdb_database_register_cdc_stream(FDBDatabase* db,

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -187,6 +187,19 @@ typedef struct keyrange {
 	int end_key_length;
 } FDBKeyRange;
 
+typedef struct range_lock_owner {
+	FDBKey owner_id;
+	FDBKey description;
+} FDBRangeLockOwner;
+
+typedef struct range_lock {
+	/* The portion of the locked range returned by the query. */
+	FDBKeyRange key_range;
+	/* The original range used to acquire the lock; use these bounds to release it. */
+	FDBKeyRange locked_range;
+	FDBKey owner_id;
+} FDBRangeLock;
+
 /*
  * Raw mutation types returned by CDC. The numeric values match
  * MutationRef::Type and, for atomic operations, FDBMutationType.
@@ -397,6 +410,15 @@ DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_future_get_keyrange_array(FDBFuture
                                                                        FDBKeyRange const** out_ranges,
                                                                        int* out_count);
 
+/* The returned arrays and their bytes remain valid until the future is destroyed or releases its memory. */
+DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_future_get_range_lock_owner_array(FDBFuture* f,
+                                                                               FDBRangeLockOwner const** out_owners,
+                                                                               int* out_count);
+
+DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_future_get_range_lock_array(FDBFuture* f,
+                                                                         FDBRangeLock const** out_locks,
+                                                                         int* out_count);
+
 DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_future_get_cdc_stream_info_array(FDBFuture* f,
                                                                               FDBCdcStreamInfo const** out_streams,
                                                                               int* out_count);
@@ -433,6 +455,50 @@ DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_database_set_option(FDBDatabase* d,
 
 DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_database_create_transaction(FDBDatabase* d,
                                                                          FDBTransaction** out_transaction);
+
+/* Range-lock management operations manage their own transactions. All input bytes are copied before returning.
+ * Owners must be registered before acquiring a lock. Acquisition and release require the same owner and exact range.
+ * Ranges must be nonempty and within the user key space. Enforcement requires enable_read_lock_on_range on the servers.
+ * Release locks before removing their owner. Owner identifiers are not authentication credentials. */
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_register_range_lock_owner(FDBDatabase* db,
+                                                                               uint8_t const* owner_id,
+                                                                               int owner_id_length,
+                                                                               uint8_t const* description,
+                                                                               int description_length);
+
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_remove_range_lock_owner(FDBDatabase* db,
+                                                                             uint8_t const* owner_id,
+                                                                             int owner_id_length);
+
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_list_range_lock_owners(FDBDatabase* db);
+
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_take_exclusive_read_lock(FDBDatabase* db,
+                                                                              uint8_t const* begin_key,
+                                                                              int begin_key_length,
+                                                                              uint8_t const* end_key,
+                                                                              int end_key_length,
+                                                                              uint8_t const* owner_id,
+                                                                              int owner_id_length);
+
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_release_exclusive_read_lock(FDBDatabase* db,
+                                                                                 uint8_t const* begin_key,
+                                                                                 int begin_key_length,
+                                                                                 uint8_t const* end_key,
+                                                                                 int end_key_length,
+                                                                                 uint8_t const* owner_id,
+                                                                                 int owner_id_length);
+
+/* Listings may span multiple transactions and do not provide an atomic snapshot. */
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_list_exclusive_read_locks(FDBDatabase* db,
+                                                                               uint8_t const* begin_key,
+                                                                               int begin_key_length,
+                                                                               uint8_t const* end_key,
+                                                                               int end_key_length);
+
+/* Releases this owner's locks in multiple transactions; concurrent lock acquisition must be coordinated separately. */
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_release_all_exclusive_read_locks(FDBDatabase* db,
+                                                                                      uint8_t const* owner_id,
+                                                                                      int owner_id_length);
 
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_register_cdc_stream(FDBDatabase* db,
                                                                          uint8_t const* name,

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -48,6 +48,7 @@
 #include "flow/config.h"
 #include "flow/DeterministicRandom.h"
 #include "flow/IRandom.h"
+#include "flow/ScopeExit.h"
 
 #include "fdb_api.hpp"
 
@@ -1970,6 +1971,224 @@ TEST_CASE("fdb_database_get_server_protocol") {
 	fdb_check(fdb_future_block_until_ready(protocolFuture));
 	fdb_check(fdb_future_get_uint64(protocolFuture, &out));
 	fdb_future_destroy(protocolFuture);
+}
+
+TEST_CASE("Range lock C binding lifecycle") {
+	using FuturePtr = std::unique_ptr<FDBFuture, decltype(&fdb_future_destroy)>;
+	auto ownFuture = [](FDBFuture* future) { return FuturePtr(future, &fdb_future_destroy); };
+	auto bytes = [](std::string const& value) { return reinterpret_cast<uint8_t const*>(value.data()); };
+	auto waitForSuccess = [](FDBFuture* future) {
+		fdb_check(fdb_future_block_until_ready(future));
+		fdb_check(fdb_future_get_error(future));
+	};
+	auto operationError = [&](FDBFuture* future) {
+		auto owned = ownFuture(future);
+		fdb_check(fdb_future_block_until_ready(owned.get()));
+		return fdb_future_get_error(owned.get());
+	};
+	auto take = [&](std::string const& begin, std::string const& end, std::string const& owner) {
+		return operationError(fdb_database_take_exclusive_read_lock(
+		    db, bytes(begin), begin.size(), bytes(end), end.size(), bytes(owner), owner.size()));
+	};
+	auto release = [&](std::string const& begin, std::string const& end, std::string const& owner) {
+		return operationError(fdb_database_release_exclusive_read_lock(
+		    db, bytes(begin), begin.size(), bytes(end), end.size(), bytes(owner), owner.size()));
+	};
+	auto checkRange = [](FDBKeyRange const& range, std::string const& begin, std::string const& end) {
+		CHECK(std::string(reinterpret_cast<char const*>(range.begin_key), range.begin_key_length) == begin);
+		CHECK(std::string(reinterpret_cast<char const*>(range.end_key), range.end_key_length) == end);
+	};
+	auto commitValue = [](std::string const& writeKey) {
+		fdb::Transaction tr(db);
+		while (true) {
+			tr.set(writeKey, "value");
+			fdb::EmptyFuture commit = tr.commit();
+			fdb_error_t err = wait_future(commit);
+			if (!err || err == 1242) { // transaction_rejected_range_locked
+				return err;
+			}
+			fdb::EmptyFuture retry = tr.on_error(err);
+			fdb_check(wait_future(retry));
+		}
+	};
+
+	const std::string owner = key("range-lock-owner/") + '\0' + "first";
+	const std::string otherOwner = key("range-lock-owner/") + '\0' + "second";
+	const std::string description = std::string("C binding") + '\0' + "owner";
+	const std::string updatedDescription = description + " updated";
+	const std::string rangePrefix = key("range-lock-data/") + '\0';
+	const std::string begin = rangePrefix + "a";
+	const std::string end = rangePrefix + "b";
+	const std::string queryBegin = begin + "m";
+	const std::string queryEnd = begin + "n";
+	const std::string secondBegin = rangePrefix + "c";
+	const std::string secondEnd = rangePrefix + "d";
+	const std::string otherBegin = rangePrefix + "e";
+	const std::string otherEnd = rangePrefix + "f";
+
+	ScopeExit cleanup([&] {
+		for (auto const& ownerId : { owner, otherOwner }) {
+			fdb_check(
+			    operationError(fdb_database_release_all_exclusive_read_locks(db, bytes(ownerId), ownerId.size())));
+			fdb_check(operationError(fdb_database_remove_range_lock_owner(db, bytes(ownerId), ownerId.size())));
+		}
+	});
+	insert_data(db, {});
+
+	// The asynchronous registration must retain embedded NULs and its caller's input bytes.
+	std::string ownerInput = owner;
+	std::string descriptionInput = description;
+	auto registered = ownFuture(fdb_database_register_range_lock_owner(
+	    db, bytes(ownerInput), ownerInput.size(), bytes(descriptionInput), descriptionInput.size()));
+	std::fill(ownerInput.begin(), ownerInput.end(), 'x');
+	std::fill(descriptionInput.begin(), descriptionInput.end(), 'x');
+	waitForSuccess(registered.get());
+	registered.reset();
+	fdb_check(operationError(fdb_database_register_range_lock_owner(
+	    db, bytes(otherOwner), otherOwner.size(), bytes(description), description.size())));
+
+	auto ownersFuture = ownFuture(fdb_database_list_range_lock_owners(db));
+	waitForSuccess(ownersFuture.get());
+	FDBRangeLockOwner const* owners = nullptr;
+	int ownerCount = -1;
+	fdb_check(fdb_future_get_range_lock_owner_array(ownersFuture.get(), &owners, &ownerCount));
+	bool foundOwner = false;
+	for (int i = 0; i < ownerCount; ++i) {
+		if (extractString(owners[i].owner_id) == owner) {
+			foundOwner = true;
+			CHECK(extractString(owners[i].description) == description);
+		}
+	}
+	REQUIRE(foundOwner);
+	fdb_future_release_memory(ownersFuture.get());
+	CHECK(fdb_future_get_range_lock_owner_array(ownersFuture.get(), &owners, &ownerCount) == 1102); // future_released
+
+	fdb_check(operationError(fdb_database_register_range_lock_owner(
+	    db, bytes(owner), owner.size(), bytes(updatedDescription), updatedDescription.size())));
+	auto updatedOwnersFuture = ownFuture(fdb_database_list_range_lock_owners(db));
+	waitForSuccess(updatedOwnersFuture.get());
+	fdb_check(fdb_future_get_range_lock_owner_array(updatedOwnersFuture.get(), &owners, &ownerCount));
+	foundOwner = false;
+	for (int i = 0; i < ownerCount; ++i) {
+		if (extractString(owners[i].owner_id) == owner) {
+			foundOwner = true;
+			CHECK(extractString(owners[i].description) == updatedDescription);
+		}
+	}
+	REQUIRE(foundOwner);
+
+	CHECK(take(begin, end, key("unregistered-range-lock-owner")) == 1241); // range_lock_failed
+	std::string beginInput = begin;
+	std::string endInput = end;
+	ownerInput = owner;
+	auto taken = ownFuture(fdb_database_take_exclusive_read_lock(db,
+	                                                             bytes(beginInput),
+	                                                             beginInput.size(),
+	                                                             bytes(endInput),
+	                                                             endInput.size(),
+	                                                             bytes(ownerInput),
+	                                                             ownerInput.size()));
+	std::fill(beginInput.begin(), beginInput.end(), 'x');
+	std::fill(endInput.begin(), endInput.end(), 'x');
+	std::fill(ownerInput.begin(), ownerInput.end(), 'x');
+	waitForSuccess(taken.get());
+	taken.reset();
+	fdb_check(take(begin, end, owner)); // Retrying the same logical acquisition is idempotent.
+	CHECK(take(begin, end, otherOwner) == 1247); // range_lock_reject
+	CHECK(take(queryBegin, queryEnd, owner) == 1247);
+	CHECK(release(begin, end, otherOwner) == 1248); // range_unlock_reject
+	CHECK(release(queryBegin, queryEnd, owner) == 1248);
+
+	auto locksFuture = ownFuture(fdb_database_list_exclusive_read_locks(
+	    db, bytes(queryBegin), queryBegin.size(), bytes(queryEnd), queryEnd.size()));
+	waitForSuccess(locksFuture.get());
+	FDBRangeLock const* locks = nullptr;
+	int lockCount = -1;
+	fdb_check(fdb_future_get_range_lock_array(locksFuture.get(), &locks, &lockCount));
+	REQUIRE(lockCount == 1);
+	checkRange(locks[0].key_range, queryBegin, queryEnd);
+	checkRange(locks[0].locked_range, begin, end);
+	CHECK(extractString(locks[0].owner_id) == owner);
+	fdb_future_release_memory(locksFuture.get());
+	CHECK(fdb_future_get_range_lock_array(locksFuture.get(), &locks, &lockCount) == 1102); // future_released
+	CHECK(commitValue(begin) == 1242); // transaction_rejected_range_locked
+	fdb_check(commitValue(end)); // The end key is outside the half-open lock range.
+
+	fdb_check(release(begin, end, owner));
+	fdb_check(release(begin, end, owner));
+	fdb_check(commitValue(begin));
+	fdb_check(take(begin, end, owner));
+	fdb_check(take(secondBegin, secondEnd, owner));
+	fdb_check(take(otherBegin, otherEnd, otherOwner));
+	fdb_check(operationError(fdb_database_release_all_exclusive_read_locks(db, bytes(owner), owner.size())));
+
+	auto remainingFuture = ownFuture(
+	    fdb_database_list_exclusive_read_locks(db, bytes(begin), begin.size(), bytes(otherEnd), otherEnd.size()));
+	waitForSuccess(remainingFuture.get());
+	fdb_check(fdb_future_get_range_lock_array(remainingFuture.get(), &locks, &lockCount));
+	REQUIRE(lockCount == 1);
+	checkRange(locks[0].key_range, otherBegin, otherEnd);
+	checkRange(locks[0].locked_range, otherBegin, otherEnd);
+	CHECK(extractString(locks[0].owner_id) == otherOwner);
+	fdb_check(commitValue(begin));
+	fdb_check(commitValue(secondBegin));
+	CHECK(commitValue(otherBegin) == 1242);
+	fdb_check(release(otherBegin, otherEnd, otherOwner));
+	fdb_check(commitValue(otherBegin));
+	const uint8_t normalKeysEnd = 0xff;
+	auto emptyLocksFuture = ownFuture(fdb_database_list_exclusive_read_locks(db, nullptr, 0, &normalKeysEnd, 1));
+	waitForSuccess(emptyLocksFuture.get());
+	fdb_check(fdb_future_get_range_lock_array(emptyLocksFuture.get(), &locks, &lockCount));
+	CHECK(lockCount == 0);
+
+	for (auto const& ownerId : { owner, otherOwner }) {
+		fdb_check(operationError(fdb_database_remove_range_lock_owner(db, bytes(ownerId), ownerId.size())));
+	}
+	auto removedOwnersFuture = ownFuture(fdb_database_list_range_lock_owners(db));
+	waitForSuccess(removedOwnersFuture.get());
+	fdb_check(fdb_future_get_range_lock_owner_array(removedOwnersFuture.get(), &owners, &ownerCount));
+	for (int i = 0; i < ownerCount; ++i) {
+		CHECK(extractString(owners[i].owner_id) != owner);
+		CHECK(extractString(owners[i].owner_id) != otherOwner);
+	}
+}
+
+TEST_CASE("Range lock C binding invalid arguments") {
+	using FuturePtr = std::unique_ptr<FDBFuture, decltype(&fdb_future_destroy)>;
+	auto checkRejected = [](FDBFuture* future) {
+		FuturePtr owned(future, &fdb_future_destroy);
+		fdb_check(fdb_future_block_until_ready(owned.get()));
+		CHECK(fdb_future_get_error(owned.get()) == 1241); // range_lock_failed
+	};
+	const auto* owner = reinterpret_cast<uint8_t const*>("owner");
+	const auto* description = reinterpret_cast<uint8_t const*>("description");
+	const auto* begin = reinterpret_cast<uint8_t const*>("a");
+	const auto* end = reinterpret_cast<uint8_t const*>("b");
+	const uint8_t systemEnd[] = { 0xff, 0xff };
+
+	checkRejected(fdb_database_register_range_lock_owner(db, nullptr, 1, description, 11));
+	checkRejected(fdb_database_register_range_lock_owner(db, owner, -1, description, 11));
+	checkRejected(fdb_database_register_range_lock_owner(db, owner, 0, description, 11));
+	checkRejected(fdb_database_register_range_lock_owner(db, owner, 5, nullptr, 1));
+	checkRejected(fdb_database_register_range_lock_owner(db, owner, 5, description, -1));
+	checkRejected(fdb_database_register_range_lock_owner(db, owner, 5, description, 0));
+	checkRejected(fdb_database_remove_range_lock_owner(db, nullptr, 1));
+	checkRejected(fdb_database_release_all_exclusive_read_locks(db, owner, 0));
+
+	for (auto operation : { &fdb_database_take_exclusive_read_lock, &fdb_database_release_exclusive_read_lock }) {
+		checkRejected(operation(db, begin, 1, end, 1, nullptr, 1));
+		checkRejected(operation(db, begin, 1, end, 1, owner, 0));
+		checkRejected(operation(db, nullptr, 1, end, 1, owner, 5));
+		checkRejected(operation(db, begin, 1, end, -1, owner, 5));
+		checkRejected(operation(db, end, 1, begin, 1, owner, 5));
+		checkRejected(operation(db, begin, 1, begin, 1, owner, 5));
+		checkRejected(operation(db, begin, 1, systemEnd, 2, owner, 5));
+	}
+	checkRejected(fdb_database_list_exclusive_read_locks(db, nullptr, 1, end, 1));
+	checkRejected(fdb_database_list_exclusive_read_locks(db, begin, -1, end, 1));
+	checkRejected(fdb_database_list_exclusive_read_locks(db, end, 1, begin, 1));
+	checkRejected(fdb_database_list_exclusive_read_locks(db, begin, 1, begin, 1));
+	checkRejected(fdb_database_list_exclusive_read_locks(db, begin, 1, systemEnd, 2));
 }
 
 TEST_CASE("CDC C binding end-to-end") {

--- a/documentation/sphinx/source/api-c.rst
+++ b/documentation/sphinx/source/api-c.rst
@@ -291,6 +291,8 @@ See :ref:`developer-guide-programming-with-futures` for further (language-indepe
    call to an ``fdb_future_get_*()`` function that returns memory owned by
    the future. This includes :func:`fdb_future_get_key`,
    :func:`fdb_future_get_value`, :func:`fdb_future_get_keyvalue_array`,
+   :func:`fdb_future_get_range_lock_owner_array`,
+   :func:`fdb_future_get_range_lock_array`,
    :func:`fdb_future_get_cdc_stream_info_array`, and
    :func:`fdb_future_get_cdc_versioned_mutations`. It indicates that the
    memory returned by the prior get call is no longer needed by the
@@ -560,6 +562,166 @@ An |database-blurb1| Modifications to a database are performed via transactions.
          ...
          ]
       }
+
+.. _c-range-locks:
+
+Range locks
+-----------
+
+The range-lock C API exposes the experimental exclusive read locks described
+in :doc:`rangelock`. An exclusive read lock prevents ordinary transactions
+from writing to a range while allowing reads. These are administrative,
+database-wide operations; they do not operate on an :type:`FDBTransaction`
+or a tenant.
+
+Applications must select API version 800 or later. If the selected external
+client library lacks a requested range-lock operation, its future reports
+``unsupported_operation`` (2108).
+
+All byte-string inputs use explicit lengths, may contain embedded null bytes,
+and need not be null-terminated. Input memory only needs to remain valid until
+the function returns. Negative lengths, null pointers with positive lengths,
+empty owner IDs, and empty descriptions fail with ``range_lock_failed``
+(1241). A range must be non-empty and contained in normal user key space:
+``begin_key < end_key <= "\xff"``. An empty begin key and the exclusive end
+key ``"\xff"`` are valid. Other range bounds fail with ``range_lock_failed``.
+
+.. warning::
+
+   Successful acquisition persists lock metadata; it does not verify that
+   servers enforce the lock. Commit proxies must have
+   ``knob_enable_read_lock_on_range=true``, and range-lock enforcement is
+   disabled when version-vector modes are enabled. ``LOCK_AWARE`` transactions
+   bypass range locks. Owner IDs are application identifiers, not credentials:
+   these operations do not provide an authorization boundary.
+
+Each operation runs its own transaction retry loop. A successful take or
+release updates its entire range atomically; release-all may commit multiple
+updates.
+Cancellation, destroying an outstanding future, or an uncertain commit outcome
+does not prove that no update committed. Coordinate operations for an owner
+and range before retrying or issuing a conflicting operation. There is no
+acquisition generation or fencing token: a delayed release can remove a later
+lock acquired with the same owner ID and original range.
+
+.. type:: FDBRangeLockOwner
+
+   A registered owner and its description::
+
+      typedef struct {
+          FDBKey owner_id;
+          FDBKey description;
+      } FDBRangeLockOwner;
+
+   Both fields contain bytes and their explicit lengths; callers must not
+   assume null termination. Their memory is owned by the listing future.
+
+.. type:: FDBRangeLock
+
+   A listed exclusive read lock::
+
+      typedef struct {
+          FDBKeyRange key_range;
+          FDBKeyRange locked_range;
+          FDBKey owner_id;
+      } FDBRangeLock;
+
+   ``key_range`` is the locked segment within the requested listing range.
+   ``locked_range`` is the original range used to acquire the lock and can
+   extend beyond that listing range. The lock's identity is its owner ID,
+   original range, and exclusive read lock type. Pass ``locked_range``, not
+   ``key_range``, when releasing the listed lock. All referenced memory is
+   owned by the listing future.
+
+.. function:: FDBFuture* fdb_database_register_range_lock_owner(FDBDatabase* database, uint8_t const* owner_id, int owner_id_length, uint8_t const* description, int description_length)
+
+   Registers ``owner_id`` with a non-empty description. Registering an existing
+   ID updates its description without changing its locks; repeating the same
+   ID and description succeeds. An owner must be registered before taking or
+   releasing an individual range lock.
+
+   |future-returnvoid|
+
+.. function:: FDBFuture* fdb_database_remove_range_lock_owner(FDBDatabase* database, uint8_t const* owner_id, int owner_id_length)
+
+   Removes the owner's registration. Removing a missing owner succeeds.
+   This does not release its locks or check that it has no locks. Stop new
+   acquisitions and release the owner's locks before removing it. If an owner
+   was removed while holding locks, register the same ID again before using
+   :func:`fdb_database_release_exclusive_read_lock()`.
+
+   |future-returnvoid|
+
+.. function:: FDBFuture* fdb_database_list_range_lock_owners(FDBDatabase* database)
+
+   Returns registered owners. Extract the result with
+   :func:`fdb_future_get_range_lock_owner_array()`. The listing may span
+   transaction retries and is not guaranteed to represent one coherent
+   snapshot under concurrent changes.
+
+.. function:: fdb_error_t fdb_future_get_range_lock_owner_array(FDBFuture* future, FDBRangeLockOwner const** out_owners, int* out_count)
+
+   Extracts the owner array returned by
+   :func:`fdb_database_list_range_lock_owners()`. ``out_count`` receives the
+   number of entries. |future-warning| |future-get-return1|
+   |future-get-return2|.
+
+   |future-memory-mine|
+
+.. function:: FDBFuture* fdb_database_take_exclusive_read_lock(FDBDatabase* database, uint8_t const* begin_key, int begin_key_length, uint8_t const* end_key, int end_key_length, uint8_t const* owner_id, int owner_id_length)
+
+   Acquires an exclusive read lock on ``[begin_key, end_key)`` for a registered
+   owner. Repeating the same owner and range succeeds. Any overlapping lock
+   with a different owner or original range rejects the request with
+   ``range_lock_reject`` (1247), including a different overlapping range owned
+   by the same owner. An unregistered owner fails with ``range_lock_failed``.
+
+   With enforcement enabled, ordinary transactions that write to the locked
+   range fail with ``transaction_rejected_range_locked`` (1242), which is
+   retryable through :func:`fdb_transaction_on_error()`.
+
+   |future-returnvoid|
+
+.. function:: FDBFuture* fdb_database_release_exclusive_read_lock(FDBDatabase* database, uint8_t const* begin_key, int begin_key_length, uint8_t const* end_key, int end_key_length, uint8_t const* owner_id, int owner_id_length)
+
+   Releases an exclusive read lock with the same owner and original range.
+   Releasing an unlocked range succeeds, but the owner must still be
+   registered. Any overlapping lock with a different owner or original range
+   rejects the request with ``range_unlock_reject`` (1248). An unregistered
+   owner fails with ``range_lock_failed``.
+
+   |future-returnvoid|
+
+.. function:: FDBFuture* fdb_database_list_exclusive_read_locks(FDBDatabase* database, uint8_t const* begin_key, int begin_key_length, uint8_t const* end_key, int end_key_length)
+
+   Returns exclusive read locks intersecting ``[begin_key, end_key)``. Extract
+   the result with :func:`fdb_future_get_range_lock_array()`. To inspect all
+   locks, use an empty begin key and the one-byte end key ``"\xff"``. The
+   listing may span transaction retries and is not guaranteed to represent one
+   coherent snapshot under concurrent changes.
+
+.. function:: fdb_error_t fdb_future_get_range_lock_array(FDBFuture* future, FDBRangeLock const** out_locks, int* out_count)
+
+   Extracts the lock array returned by
+   :func:`fdb_database_list_exclusive_read_locks()`. ``out_count`` receives the
+   number of entries. |future-warning| |future-get-return1|
+   |future-get-return2|.
+
+   |future-memory-mine|
+
+.. function:: FDBFuture* fdb_database_release_all_exclusive_read_locks(FDBDatabase* database, uint8_t const* owner_id, int owner_id_length)
+
+   Scans normal user key space and releases exclusive read locks belonging to
+   ``owner_id``. Other owners' locks are preserved. This operation does not
+   require the owner to remain registered and does not remove its registration.
+
+   The scan is not atomic: it can commit partial progress before an error or
+   cancellation. Concurrent acquisitions can create locks behind the scan, so
+   successful completion does not guarantee that the owner has no locks.
+   Stop new acquisitions and reconcile outstanding operations before using
+   release-all as cleanup.
+
+   |future-returnvoid|
 
 CDC
 ---

--- a/documentation/sphinx/source/rangelock.rst
+++ b/documentation/sphinx/source/rangelock.rst
@@ -99,6 +99,16 @@ Range locks only take effect when commit proxies are started with ``knob_enable_
 The bulkload-specific commands (``bulkload addlockowner`` / ``bulkload clearlock`` / ``bulkload printlockowner``) remain available; they are a constrained subset of the above scoped to the bulkload workflow.
 
 
+Using the C bindings
+-------------------
+API version 800 exposes asynchronous database operations to register, remove,
+and list owners; take, release, and list exclusive read locks; and release all
+locks for an owner. See :ref:`c-range-locks` for the C interface, result memory
+ownership, exact-range release requirements, and retry and cancellation
+semantics. These bindings preserve the experimental management API behavior;
+a successful acquisition alone does not verify server enforcement.
+
+
 Example usage
 -------------
 When submitting a bulk load task on a range, we block user write traffic to the range.

--- a/documentation/sphinx/source/rangelock.rst
+++ b/documentation/sphinx/source/rangelock.rst
@@ -100,7 +100,7 @@ The bulkload-specific commands (``bulkload addlockowner`` / ``bulkload clearlock
 
 
 Using the C bindings
--------------------
+--------------------
 API version 800 exposes asynchronous database operations to register, remove,
 and list owners; take, release, and list exclusive read locks; and release all
 locks for an owner. See :ref:`c-range-locks` for the C interface, result memory

--- a/fdbclient/MultiVersionTransaction.cpp
+++ b/fdbclient/MultiVersionTransaction.cpp
@@ -395,6 +395,22 @@ ThreadFuture<VersionVector> DLTransaction::getVersionVector() {
 
 namespace {
 
+KeyRange copyKeyRange(FdbCApi::FDBKeyRange const& source) {
+	return KeyRange(KeyRangeRef(KeyRef(static_cast<const uint8_t*>(source.beginKey), source.beginKeyLength),
+	                            KeyRef(static_cast<const uint8_t*>(source.endKey), source.endKeyLength)));
+}
+
+RangeLockOwnerInfo copyRangeLockOwnerInfo(FdbCApi::FDBRangeLockOwner const& source) {
+	return RangeLockOwnerInfo{ Key(KeyRef(source.ownerId.key, source.ownerId.keyLength)),
+		                       Value(ValueRef(source.description.key, source.description.keyLength)) };
+}
+
+RangeLockInfo copyRangeLockInfo(FdbCApi::FDBRangeLock const& source) {
+	return RangeLockInfo{ copyKeyRange(source.keyRange),
+		                  copyKeyRange(source.lockedRange),
+		                  Key(KeyRef(source.ownerId.key, source.ownerId.keyLength)) };
+}
+
 NativeCdcStreamInfo copyNativeCdcStreamInfo(FdbCApi::FDBNativeCdcStreamInfo const& source) {
 	NativeCdcStreamInfo result;
 	result.name = Key(StringRef(source.name.key, source.name.keyLength));
@@ -553,6 +569,95 @@ ThreadFuture<Void> DLDatabase::createSnapshot(const StringRef& uid, const String
 	FdbCApi::FDBFuture* f =
 	    api->databaseCreateSnapshot(db, uid.begin(), uid.size(), snapshot_command.begin(), snapshot_command.size());
 	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) { return Void(); });
+}
+
+ThreadFuture<Void> DLDatabase::registerRangeLockOwner(const KeyRef& ownerId, const StringRef& description) {
+	if (!api->databaseRegisterRangeLockOwner) {
+		return unsupported_operation();
+	}
+
+	FdbCApi::FDBFuture* f = api->databaseRegisterRangeLockOwner(
+	    db, ownerId.begin(), ownerId.size(), description.begin(), description.size());
+	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture*, FdbCApi*) { return Void(); });
+}
+
+ThreadFuture<Void> DLDatabase::removeRangeLockOwner(const KeyRef& ownerId) {
+	if (!api->databaseRemoveRangeLockOwner) {
+		return unsupported_operation();
+	}
+
+	FdbCApi::FDBFuture* f = api->databaseRemoveRangeLockOwner(db, ownerId.begin(), ownerId.size());
+	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture*, FdbCApi*) { return Void(); });
+}
+
+ThreadFuture<std::vector<RangeLockOwnerInfo>> DLDatabase::listRangeLockOwners() {
+	if (!api->databaseListRangeLockOwners || !api->futureGetRangeLockOwnerArray) {
+		return unsupported_operation();
+	}
+
+	FdbCApi::FDBFuture* f = api->databaseListRangeLockOwners(db);
+	return toThreadFuture<std::vector<RangeLockOwnerInfo>>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+		FdbCApi::FDBRangeLockOwner const* owners;
+		int count;
+		FdbCApi::fdb_error_t error = api->futureGetRangeLockOwnerArray(f, &owners, &count);
+		ASSERT(!error);
+		std::vector<RangeLockOwnerInfo> result;
+		result.reserve(count);
+		for (int i = 0; i < count; ++i) {
+			result.push_back(copyRangeLockOwnerInfo(owners[i]));
+		}
+		return result;
+	});
+}
+
+ThreadFuture<Void> DLDatabase::takeExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) {
+	if (!api->databaseTakeExclusiveReadLock) {
+		return unsupported_operation();
+	}
+
+	FdbCApi::FDBFuture* f = api->databaseTakeExclusiveReadLock(
+	    db, keys.begin.begin(), keys.begin.size(), keys.end.begin(), keys.end.size(), ownerId.begin(), ownerId.size());
+	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture*, FdbCApi*) { return Void(); });
+}
+
+ThreadFuture<Void> DLDatabase::releaseExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) {
+	if (!api->databaseReleaseExclusiveReadLock) {
+		return unsupported_operation();
+	}
+
+	FdbCApi::FDBFuture* f = api->databaseReleaseExclusiveReadLock(
+	    db, keys.begin.begin(), keys.begin.size(), keys.end.begin(), keys.end.size(), ownerId.begin(), ownerId.size());
+	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture*, FdbCApi*) { return Void(); });
+}
+
+ThreadFuture<std::vector<RangeLockInfo>> DLDatabase::listExclusiveReadLocks(const KeyRangeRef& keys) {
+	if (!api->databaseListExclusiveReadLocks || !api->futureGetRangeLockArray) {
+		return unsupported_operation();
+	}
+
+	FdbCApi::FDBFuture* f = api->databaseListExclusiveReadLocks(
+	    db, keys.begin.begin(), keys.begin.size(), keys.end.begin(), keys.end.size());
+	return toThreadFuture<std::vector<RangeLockInfo>>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+		FdbCApi::FDBRangeLock const* locks;
+		int count;
+		FdbCApi::fdb_error_t error = api->futureGetRangeLockArray(f, &locks, &count);
+		ASSERT(!error);
+		std::vector<RangeLockInfo> result;
+		result.reserve(count);
+		for (int i = 0; i < count; ++i) {
+			result.push_back(copyRangeLockInfo(locks[i]));
+		}
+		return result;
+	});
+}
+
+ThreadFuture<Void> DLDatabase::releaseAllExclusiveReadLocks(const KeyRef& ownerId) {
+	if (!api->databaseReleaseAllExclusiveReadLocks) {
+		return unsupported_operation();
+	}
+
+	FdbCApi::FDBFuture* f = api->databaseReleaseAllExclusiveReadLocks(db, ownerId.begin(), ownerId.size());
+	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture*, FdbCApi*) { return Void(); });
 }
 
 ThreadFuture<CDCStreamId> DLDatabase::registerNativeCdcStream(const KeyRef& name, const KeyRangeRef& keys) {
@@ -777,6 +882,23 @@ void DLApi::init() {
 	                   fdbCPath,
 	                   "fdb_database_get_client_status",
 	                   headerVersion >= ApiVersion::withGetClientStatus().version());
+	// Clients predating the range-lock API can advertise the same API version, so these symbols stay optional.
+	loadClientFunction(
+	    &api->databaseRegisterRangeLockOwner, lib, fdbCPath, "fdb_database_register_range_lock_owner", false);
+	loadClientFunction(
+	    &api->databaseRemoveRangeLockOwner, lib, fdbCPath, "fdb_database_remove_range_lock_owner", false);
+	loadClientFunction(&api->databaseListRangeLockOwners, lib, fdbCPath, "fdb_database_list_range_lock_owners", false);
+	loadClientFunction(
+	    &api->databaseTakeExclusiveReadLock, lib, fdbCPath, "fdb_database_take_exclusive_read_lock", false);
+	loadClientFunction(
+	    &api->databaseReleaseExclusiveReadLock, lib, fdbCPath, "fdb_database_release_exclusive_read_lock", false);
+	loadClientFunction(
+	    &api->databaseListExclusiveReadLocks, lib, fdbCPath, "fdb_database_list_exclusive_read_locks", false);
+	loadClientFunction(&api->databaseReleaseAllExclusiveReadLocks,
+	                   lib,
+	                   fdbCPath,
+	                   "fdb_database_release_all_exclusive_read_locks",
+	                   false);
 	loadClientFunction(&api->databaseRegisterNativeCdcStream,
 	                   lib,
 	                   fdbCPath,
@@ -915,6 +1037,9 @@ void DLApi::init() {
 	    &api->futureGetKeyValueArray, lib, fdbCPath, "fdb_future_get_keyvalue_array", headerVersion >= 0);
 	loadClientFunction(
 	    &api->futureGetMappedKeyValueArray, lib, fdbCPath, "fdb_future_get_mappedkeyvalue_array", headerVersion >= 710);
+	loadClientFunction(
+	    &api->futureGetRangeLockOwnerArray, lib, fdbCPath, "fdb_future_get_range_lock_owner_array", false);
+	loadClientFunction(&api->futureGetRangeLockArray, lib, fdbCPath, "fdb_future_get_range_lock_array", false);
 	loadClientFunction(&api->futureGetNativeCdcStreamInfoArray,
 	                   lib,
 	                   fdbCPath,
@@ -1654,6 +1779,34 @@ ThreadFuture<Void> MultiVersionDatabase::forceRecoveryWithDataLoss(const StringR
 
 ThreadFuture<Void> MultiVersionDatabase::createSnapshot(const StringRef& uid, const StringRef& snapshot_command) {
 	return executeOperation(&IDatabase::createSnapshot, uid, snapshot_command);
+}
+
+ThreadFuture<Void> MultiVersionDatabase::registerRangeLockOwner(const KeyRef& ownerId, const StringRef& description) {
+	return executeOperation(&IDatabase::registerRangeLockOwner, ownerId, description);
+}
+
+ThreadFuture<Void> MultiVersionDatabase::removeRangeLockOwner(const KeyRef& ownerId) {
+	return executeOperation(&IDatabase::removeRangeLockOwner, ownerId);
+}
+
+ThreadFuture<std::vector<RangeLockOwnerInfo>> MultiVersionDatabase::listRangeLockOwners() {
+	return executeOperation(&IDatabase::listRangeLockOwners);
+}
+
+ThreadFuture<Void> MultiVersionDatabase::takeExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) {
+	return executeOperation(&IDatabase::takeExclusiveReadLock, keys, ownerId);
+}
+
+ThreadFuture<Void> MultiVersionDatabase::releaseExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) {
+	return executeOperation(&IDatabase::releaseExclusiveReadLock, keys, ownerId);
+}
+
+ThreadFuture<std::vector<RangeLockInfo>> MultiVersionDatabase::listExclusiveReadLocks(const KeyRangeRef& keys) {
+	return executeOperation(&IDatabase::listExclusiveReadLocks, keys);
+}
+
+ThreadFuture<Void> MultiVersionDatabase::releaseAllExclusiveReadLocks(const KeyRef& ownerId) {
+	return executeOperation(&IDatabase::releaseAllExclusiveReadLocks, ownerId);
 }
 
 ThreadFuture<CDCStreamId> MultiVersionDatabase::registerNativeCdcStream(const KeyRef& name, const KeyRangeRef& keys) {
@@ -2960,6 +3113,39 @@ std::string ClientInfo::getTraceFileIdentifier(const std::string& baseIdentifier
 }
 
 // UNIT TESTS
+TEST_CASE("/fdbclient/multiversionclient/RangeLocksUnsupported") {
+	auto api = makeReference<FdbCApi>();
+	auto db = makeReference<DLDatabase>(api, static_cast<FdbCApi::FDBDatabase*>(nullptr));
+	const KeyRef ownerId = "owner"_sr;
+	const KeyRangeRef keys("a"_sr, "z"_sr);
+	const auto expectUnsupported = [](auto result) {
+		ASSERT(result.isError());
+		ASSERT_EQ(result.getError().code(), error_code_unsupported_operation);
+	};
+
+	expectUnsupported(db->registerRangeLockOwner(ownerId, "description"_sr));
+	expectUnsupported(db->removeRangeLockOwner(ownerId));
+	expectUnsupported(db->listRangeLockOwners());
+	expectUnsupported(db->takeExclusiveReadLock(keys, ownerId));
+	expectUnsupported(db->releaseExclusiveReadLock(keys, ownerId));
+	expectUnsupported(db->listExclusiveReadLocks(keys));
+	expectUnsupported(db->releaseAllExclusiveReadLocks(ownerId));
+
+	api->databaseListRangeLockOwners = [](FdbCApi::FDBDatabase*) -> FdbCApi::FDBFuture* {
+		ASSERT(false);
+		return nullptr;
+	};
+	expectUnsupported(db->listRangeLockOwners());
+	api->databaseListExclusiveReadLocks =
+	    [](FdbCApi::FDBDatabase*, uint8_t const*, int, uint8_t const*, int) -> FdbCApi::FDBFuture* {
+		ASSERT(false);
+		return nullptr;
+	};
+	expectUnsupported(db->listExclusiveReadLocks(keys));
+
+	return Void();
+}
+
 TEST_CASE("/fdbclient/multiversionclient/EnvironmentVariableParsing") {
 	auto vals = parseOptionValues("a");
 	ASSERT(vals.size() == 1 && vals[0] == "a");

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -30,6 +30,7 @@
 #include "fdbclient/GenericManagementAPI.h"
 #include "fdbclient/NativeCdc.h"
 #include "fdbclient/NativeAPI.h"
+#include "fdbclient/RangeLock.h"
 #include "flow/Arena.h"
 #include "flow/ProtocolVersion.h"
 
@@ -38,6 +39,27 @@
 // of these functions.
 
 namespace {
+
+Future<std::vector<RangeLockOwnerInfo>> listRangeLockOwnersClient(Database db) {
+	const auto owners = co_await getAllRangeLockOwners(db);
+	std::vector<RangeLockOwnerInfo> result;
+	result.reserve(owners.size());
+	for (const auto& owner : owners) {
+		result.push_back(
+		    RangeLockOwnerInfo{ Key(StringRef(owner.getOwnerUniqueId())), Value(StringRef(owner.getDescription())) });
+	}
+	co_return result;
+}
+
+Future<std::vector<RangeLockInfo>> listExclusiveReadLocksClient(Database db, KeyRange keys) {
+	const auto locks = co_await findExclusiveReadLockOnRange(db, keys);
+	std::vector<RangeLockInfo> result;
+	result.reserve(locks.size());
+	for (const auto& [range, lock] : locks) {
+		result.push_back(RangeLockInfo{ range, lock.getRange(), Key(StringRef(lock.getOwnerUniqueId())) });
+	}
+	co_return result;
+}
 
 struct NativeCdcCursorState {
 	explicit NativeCdcCursorState(NativeCdcCursor cursor) : cursor(cursor) {}
@@ -218,6 +240,71 @@ ThreadFuture<Void> ThreadSafeDatabase::createSnapshot(const StringRef& uid, cons
 	return onMainThread([db, snapUID, cmd]() -> Future<Void> {
 		db->checkDeferredError();
 		return db->createSnapshot(snapUID, cmd);
+	});
+}
+
+ThreadFuture<Void> ThreadSafeDatabase::registerRangeLockOwner(const KeyRef& ownerId, const StringRef& description) {
+	DatabaseContext* db = this->db;
+	std::string ownerIdCopy = ownerId.toString();
+	std::string descriptionCopy = description.toString();
+	return onMainThread([db, ownerIdCopy, descriptionCopy]() -> Future<Void> {
+		db->checkDeferredError();
+		return ::registerRangeLockOwner(Database(Reference<DatabaseContext>::addRef(db)), ownerIdCopy, descriptionCopy);
+	});
+}
+
+ThreadFuture<Void> ThreadSafeDatabase::removeRangeLockOwner(const KeyRef& ownerId) {
+	DatabaseContext* db = this->db;
+	std::string ownerIdCopy = ownerId.toString();
+	return onMainThread([db, ownerIdCopy]() -> Future<Void> {
+		db->checkDeferredError();
+		return ::removeRangeLockOwner(Database(Reference<DatabaseContext>::addRef(db)), ownerIdCopy);
+	});
+}
+
+ThreadFuture<std::vector<RangeLockOwnerInfo>> ThreadSafeDatabase::listRangeLockOwners() {
+	DatabaseContext* db = this->db;
+	return onMainThread([db]() -> Future<std::vector<RangeLockOwnerInfo>> {
+		db->checkDeferredError();
+		return listRangeLockOwnersClient(Database(Reference<DatabaseContext>::addRef(db)));
+	});
+}
+
+ThreadFuture<Void> ThreadSafeDatabase::takeExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) {
+	DatabaseContext* db = this->db;
+	KeyRange keysCopy(keys);
+	std::string ownerIdCopy = ownerId.toString();
+	return onMainThread([db, keysCopy, ownerIdCopy]() -> Future<Void> {
+		db->checkDeferredError();
+		return takeExclusiveReadLockOnRange(Database(Reference<DatabaseContext>::addRef(db)), keysCopy, ownerIdCopy);
+	});
+}
+
+ThreadFuture<Void> ThreadSafeDatabase::releaseExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) {
+	DatabaseContext* db = this->db;
+	KeyRange keysCopy(keys);
+	std::string ownerIdCopy = ownerId.toString();
+	return onMainThread([db, keysCopy, ownerIdCopy]() -> Future<Void> {
+		db->checkDeferredError();
+		return releaseExclusiveReadLockOnRange(Database(Reference<DatabaseContext>::addRef(db)), keysCopy, ownerIdCopy);
+	});
+}
+
+ThreadFuture<std::vector<RangeLockInfo>> ThreadSafeDatabase::listExclusiveReadLocks(const KeyRangeRef& keys) {
+	DatabaseContext* db = this->db;
+	KeyRange keysCopy(keys);
+	return onMainThread([db, keysCopy]() -> Future<std::vector<RangeLockInfo>> {
+		db->checkDeferredError();
+		return listExclusiveReadLocksClient(Database(Reference<DatabaseContext>::addRef(db)), keysCopy);
+	});
+}
+
+ThreadFuture<Void> ThreadSafeDatabase::releaseAllExclusiveReadLocks(const KeyRef& ownerId) {
+	DatabaseContext* db = this->db;
+	std::string ownerIdCopy = ownerId.toString();
+	return onMainThread([db, ownerIdCopy]() -> Future<Void> {
+		db->checkDeferredError();
+		return releaseExclusiveReadLockByUser(Database(Reference<DatabaseContext>::addRef(db)), ownerIdCopy);
 	});
 }
 

--- a/fdbclient/include/fdbclient/IClientApi.h
+++ b/fdbclient/include/fdbclient/IClientApi.h
@@ -31,6 +31,17 @@
 
 struct VersionVector;
 
+struct RangeLockOwnerInfo {
+	Key ownerId;
+	Value description;
+};
+
+struct RangeLockInfo {
+	KeyRange keys; // Matching segment of the query range.
+	KeyRange lockedRange; // Original range identifying the lock.
+	Key ownerId;
+};
+
 // An interface that represents a transaction created by a client
 class ITransaction {
 public:
@@ -153,6 +164,14 @@ public:
 	virtual ThreadFuture<Void> forceRecoveryWithDataLoss(const StringRef& dcid) = 0;
 	// Management API, create snapshot
 	virtual ThreadFuture<Void> createSnapshot(const StringRef& uid, const StringRef& snapshot_command) = 0;
+
+	virtual ThreadFuture<Void> registerRangeLockOwner(const KeyRef& ownerId, const StringRef& description) = 0;
+	virtual ThreadFuture<Void> removeRangeLockOwner(const KeyRef& ownerId) = 0;
+	virtual ThreadFuture<std::vector<RangeLockOwnerInfo>> listRangeLockOwners() = 0;
+	virtual ThreadFuture<Void> takeExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) = 0;
+	virtual ThreadFuture<Void> releaseExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) = 0;
+	virtual ThreadFuture<std::vector<RangeLockInfo>> listExclusiveReadLocks(const KeyRangeRef& keys) = 0;
+	virtual ThreadFuture<Void> releaseAllExclusiveReadLocks(const KeyRef& ownerId) = 0;
 
 	// Native CDC operations. These values are intentionally independent from
 	// NativeAPI so multi-version client wrappers can forward them without

--- a/fdbclient/include/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/include/fdbclient/MultiVersionTransaction.h
@@ -92,6 +92,17 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 		int endKeyLength;
 	};
 
+	using FDBRangeLockOwner = struct range_lock_owner {
+		FDBKey ownerId;
+		FDBKey description;
+	};
+
+	using FDBRangeLock = struct range_lock {
+		FDBKeyRange keyRange;
+		FDBKeyRange lockedRange;
+		FDBKey ownerId;
+	};
+
 	using FDBNativeCdcStreamInfo = struct native_cdc_stream_info {
 		FDBKey name;
 		uint64_t streamId;
@@ -154,6 +165,37 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 	FDBFuture* (*databaseGetServerProtocol)(FDBDatabase* database, uint64_t expectedVersion);
 
 	FDBFuture* (*databaseGetClientStatus)(FDBDatabase* db);
+	FDBFuture* (*databaseRegisterRangeLockOwner)(FDBDatabase* database,
+	                                             uint8_t const* ownerId,
+	                                             int ownerIdLength,
+	                                             uint8_t const* description,
+	                                             int descriptionLength) = nullptr;
+	FDBFuture* (*databaseRemoveRangeLockOwner)(FDBDatabase* database,
+	                                           uint8_t const* ownerId,
+	                                           int ownerIdLength) = nullptr;
+	FDBFuture* (*databaseListRangeLockOwners)(FDBDatabase* database) = nullptr;
+	FDBFuture* (*databaseTakeExclusiveReadLock)(FDBDatabase* database,
+	                                            uint8_t const* beginKey,
+	                                            int beginKeyLength,
+	                                            uint8_t const* endKey,
+	                                            int endKeyLength,
+	                                            uint8_t const* ownerId,
+	                                            int ownerIdLength) = nullptr;
+	FDBFuture* (*databaseReleaseExclusiveReadLock)(FDBDatabase* database,
+	                                               uint8_t const* beginKey,
+	                                               int beginKeyLength,
+	                                               uint8_t const* endKey,
+	                                               int endKeyLength,
+	                                               uint8_t const* ownerId,
+	                                               int ownerIdLength) = nullptr;
+	FDBFuture* (*databaseListExclusiveReadLocks)(FDBDatabase* database,
+	                                             uint8_t const* beginKey,
+	                                             int beginKeyLength,
+	                                             uint8_t const* endKey,
+	                                             int endKeyLength) = nullptr;
+	FDBFuture* (*databaseReleaseAllExclusiveReadLocks)(FDBDatabase* database,
+	                                                   uint8_t const* ownerId,
+	                                                   int ownerIdLength) = nullptr;
 	FDBFuture* (*databaseRegisterNativeCdcStream)(FDBDatabase* database,
 	                                              uint8_t const* name,
 	                                              int nameLength,
@@ -299,6 +341,10 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 	                                            FDBMappedKeyValue const** outKVM,
 	                                            int* outCount,
 	                                            fdb_bool_t* outMore);
+	fdb_error_t (*futureGetRangeLockOwnerArray)(FDBFuture* f,
+	                                            FDBRangeLockOwner const** outOwners,
+	                                            int* outCount) = nullptr;
+	fdb_error_t (*futureGetRangeLockArray)(FDBFuture* f, FDBRangeLock const** outLocks, int* outCount) = nullptr;
 	fdb_error_t (*futureGetNativeCdcStreamInfoArray)(FDBFuture* f,
 	                                                 FDBNativeCdcStreamInfo const** outStreams,
 	                                                 int* outCount);
@@ -433,6 +479,13 @@ public:
 	ThreadFuture<int64_t> rebootWorker(const StringRef& address, bool check, int duration) override;
 	ThreadFuture<Void> forceRecoveryWithDataLoss(const StringRef& dcid) override;
 	ThreadFuture<Void> createSnapshot(const StringRef& uid, const StringRef& snapshot_command) override;
+	ThreadFuture<Void> registerRangeLockOwner(const KeyRef& ownerId, const StringRef& description) override;
+	ThreadFuture<Void> removeRangeLockOwner(const KeyRef& ownerId) override;
+	ThreadFuture<std::vector<RangeLockOwnerInfo>> listRangeLockOwners() override;
+	ThreadFuture<Void> takeExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) override;
+	ThreadFuture<Void> releaseExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) override;
+	ThreadFuture<std::vector<RangeLockInfo>> listExclusiveReadLocks(const KeyRangeRef& keys) override;
+	ThreadFuture<Void> releaseAllExclusiveReadLocks(const KeyRef& ownerId) override;
 	ThreadFuture<CDCStreamId> registerNativeCdcStream(const KeyRef& name, const KeyRangeRef& keys) override;
 	ThreadFuture<Void> removeNativeCdcStream(const KeyRef& name) override;
 	ThreadFuture<std::vector<NativeCdcStreamInfo>> listNativeCdcStreams() override;
@@ -751,6 +804,13 @@ public:
 	ThreadFuture<int64_t> rebootWorker(const StringRef& address, bool check, int duration) override;
 	ThreadFuture<Void> forceRecoveryWithDataLoss(const StringRef& dcid) override;
 	ThreadFuture<Void> createSnapshot(const StringRef& uid, const StringRef& snapshot_command) override;
+	ThreadFuture<Void> registerRangeLockOwner(const KeyRef& ownerId, const StringRef& description) override;
+	ThreadFuture<Void> removeRangeLockOwner(const KeyRef& ownerId) override;
+	ThreadFuture<std::vector<RangeLockOwnerInfo>> listRangeLockOwners() override;
+	ThreadFuture<Void> takeExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) override;
+	ThreadFuture<Void> releaseExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) override;
+	ThreadFuture<std::vector<RangeLockInfo>> listExclusiveReadLocks(const KeyRangeRef& keys) override;
+	ThreadFuture<Void> releaseAllExclusiveReadLocks(const KeyRef& ownerId) override;
 	ThreadFuture<CDCStreamId> registerNativeCdcStream(const KeyRef& name, const KeyRangeRef& keys) override;
 	ThreadFuture<Void> removeNativeCdcStream(const KeyRef& name) override;
 	ThreadFuture<std::vector<NativeCdcStreamInfo>> listNativeCdcStreams() override;

--- a/fdbclient/include/fdbclient/ThreadSafeTransaction.h
+++ b/fdbclient/include/fdbclient/ThreadSafeTransaction.h
@@ -58,6 +58,14 @@ public:
 	ThreadFuture<Void> forceRecoveryWithDataLoss(const StringRef& dcid) override;
 	ThreadFuture<Void> createSnapshot(const StringRef& uid, const StringRef& snapshot_command) override;
 
+	ThreadFuture<Void> registerRangeLockOwner(const KeyRef& ownerId, const StringRef& description) override;
+	ThreadFuture<Void> removeRangeLockOwner(const KeyRef& ownerId) override;
+	ThreadFuture<std::vector<RangeLockOwnerInfo>> listRangeLockOwners() override;
+	ThreadFuture<Void> takeExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) override;
+	ThreadFuture<Void> releaseExclusiveReadLock(const KeyRangeRef& keys, const KeyRef& ownerId) override;
+	ThreadFuture<std::vector<RangeLockInfo>> listExclusiveReadLocks(const KeyRangeRef& keys) override;
+	ThreadFuture<Void> releaseAllExclusiveReadLocks(const KeyRef& ownerId) override;
+
 	ThreadFuture<CDCStreamId> registerNativeCdcStream(const KeyRef& name, const KeyRangeRef& keys) override;
 	ThreadFuture<Void> removeNativeCdcStream(const KeyRef& name) override;
 	ThreadFuture<std::vector<NativeCdcStreamInfo>> listNativeCdcStreams() override;


### PR DESCRIPTION
## Summary

Expose the existing experimental range lock management operations through the C API:

- Register, remove, and list owners; acquire, release, and list exclusive read locks; release all exclusive read locks for an owner.
- Return owner and lock arrays whose memory belongs to the result future. Lock listings include both the queried segment and the original range needed to release the lock.
- Forward operations through local and external clients, returning `unsupported_operation` when an external library lacks the new symbols.

Document argument validation, byte and result lifetimes, ownership, cancellation uncertainty, and the non-atomic listing/release-all behavior. The native locking algorithm and persisted metadata formats are unchanged.

Range locks remain experimental. This change does not enable server enforcement: `enable_read_lock_on_range` must be enabled and incompatible version-vector modes disabled. Callers must coordinate owner cleanup and release locks before removing an owner.

## Validation

- `fdbclient_test`: 98 passed, 0 failed; focused missing-symbol regression: 1 passed.
- Full C unit suites: 80 tests and 603 assertions passed in each of the local and external-client modes.
- New range lock tests: 2 tests and 53 assertions passed in each of the local, external-client, and shim paths.
- `fdb_c90_test`: compiled and executed successfully.
- `git diff --check` passed.
