### PR TITLE
Fix SS+rocksdb crash for suspend call path

### DIFF
--- a/contrib/ithreadpool_reentrant_stop_repro/repro.sh
+++ b/contrib/ithreadpool_reentrant_stop_repro/repro.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# This script reproduces a ThreadPool::stop() reentrancy crash triggered by
+# running `suspend` from fdbcli against a real 2-region HA cluster under load.
+#
+# Basically here we build a small, real (non-simulated) 2-region HA cluster - a `double`
+# redundancy `ssd-rocksdb-v1` cluster with 3 coordinators + 2 storage
+# processes in a `primary` region, and 2 storage processes in a `remote`
+# region - because a single-process or single-region cluster does not
+# reliably trigger the race.
+# It then runs concurrent read/write load against the cluster while repeatedly calling
+# `suspend` on the remote storage processes, watching for a nonzero exit.
+# Empirically, an unfixed checkout crashes within the first ~100 suspend
+# cycles under load; a fixed checkout survives 1000+ cleanly.
+#
+# Usage:
+#   FDBSERVER_BIN=/path/to/fdbserver FDBCLI_BIN=/path/to/fdbcli ./repro.sh
+#
+# Exit code 0 = completed $ITERATIONS suspend cycles with no crash.
+# Exit code 1 = crash detected (or setup failed) - see $WORKDIR for evidence.
+#
+# Both `FDBSERVER_BIN` and `FDBCLI_BIN` default to `fdbserver`/`fdbcli` on
+# `PATH` if not set. Recommended: build with `-DUSE_ASAN=ON` so a crash is
+# unambiguous and immediately actionable (a stack trace pointing at
+# `~Thread()`/`ThreadPool::stop()`), though a plain build will also abort
+# via the assertion.
+#
+# Other environment variables (all optional):
+# | Variable        | Default             | Meaning                                                                |
+# |-----------------|---------------------|------------------------------------------------------------------------|
+# | `WORKDIR`       | a fresh `mktemp -d` | where cluster data/logs/state are written                              |
+# | `ITERATIONS`    | `1000`              | number of suspend cycles to attempt                                    |
+# | `SUSPEND_WAIT`  | `1`                 | seconds passed to `suspend <seconds> ...`                              |
+# | `SUSPEND_SLEEP` | `1`                 | seconds slept between suspend cycles                                   |
+# | `BASE_PORT`     | `4500`              | first port used; 9 ports are used starting here (5 primary + 4 remote) |
+
+# The script kills everything it started (via a `trap ... EXIT`) when it
+# exits, whether that's a clean finish, a detected crash, or `Ctrl-C`.
+# `$WORKDIR` is left behind for inspection either way - remove it yourself
+# once you're done.
+
+set -uo pipefail
+
+FDBSERVER_BIN="${FDBSERVER_BIN:-fdbserver}"
+FDBCLI_BIN="${FDBCLI_BIN:-fdbcli}"
+WORKDIR="${WORKDIR:-$(mktemp -d -t ithreadpool_repro.XXXXXX)}"
+ITERATIONS="${ITERATIONS:-1000}"
+SUSPEND_WAIT="${SUSPEND_WAIT:-1}"
+SUSPEND_SLEEP="${SUSPEND_SLEEP:-1}"
+BASE_PORT="${BASE_PORT:-4500}"
+
+mkdir -p "$WORKDIR"
+WORKDIR="$(cd "$WORKDIR" && pwd)" # make absolute: fdbcli does not expand ~ or relative paths itself
+CLUSTER_FILE="$WORKDIR/fdb.cluster"
+
+PRIMARY_PORTS=($((BASE_PORT)) $((BASE_PORT + 1)) $((BASE_PORT + 2)) $((BASE_PORT + 3)) $((BASE_PORT + 4)))
+REMOTE_PORTS=($((BASE_PORT + 100)) $((BASE_PORT + 101)) $((BASE_PORT + 102)) $((BASE_PORT + 103)))
+REMOTE_STORAGE_PORTS=("${REMOTE_PORTS[2]}" "${REMOTE_PORTS[3]}")
+
+log() { echo "[repro] $*" >&2; }
+
+ALL_PIDS=()
+cleanup() {
+    log "cleaning up (workdir kept at $WORKDIR for inspection)"
+    for pid in "${ALL_PIDS[@]:-}"; do
+        kill -9 "$pid" >/dev/null 2>&1
+    done
+    # generate_load()'s own fdbcli child processes aren't individually tracked
+    # in ALL_PIDS (only the shell function's PID is) - catch them, and anything
+    # else pointed at this run's cluster file, by pattern instead.
+    pkill -9 -f "$CLUSTER_FILE" >/dev/null 2>&1
+    wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+start_fdbserver() {
+    local port="$1" dc="$2" class="${3:-}"
+    mkdir -p "$WORKDIR/data_$port" "$WORKDIR/logs_$port"
+    local args=(-p "127.0.0.1:$port" -C "$CLUSTER_FILE" -d "$WORKDIR/data_$port" -L "$WORKDIR/logs_$port"
+        --listen_address "127.0.0.1:$port" --datacenter-id "$dc" --machine-id "zone-$port")
+    [ -n "$class" ] && args+=(--class "$class")
+    "$FDBSERVER_BIN" "${args[@]}" >>"$WORKDIR/stdout_$port.log" 2>>"$WORKDIR/stderr_$port.log" &
+    ALL_PIDS+=($!)
+}
+
+# Loops one fdbserver on $2 (storage class, "remote" dc) forever, restarting
+# it on a clean exit (that is what fdbcli> suspend produces on a real
+# cluster). Records $port to $WORKDIR/CRASHED and returns on any nonzero exit.
+supervise_remote_storage() {
+    local port="$1"
+    while true; do
+        mkdir -p "$WORKDIR/data_$port" "$WORKDIR/logs_$port"
+        "$FDBSERVER_BIN" -p "127.0.0.1:$port" -C "$CLUSTER_FILE" -d "$WORKDIR/data_$port" -L "$WORKDIR/logs_$port" \
+            --listen_address "127.0.0.1:$port" --datacenter-id remote --machine-id "zone-$port" --class storage \
+            >>"$WORKDIR/stdout_$port.log" 2>>"$WORKDIR/stderr_$port.log"
+        local code=$?
+        if [ "$code" -ne 0 ]; then
+            echo "$port exited with code $code" >>"$WORKDIR/CRASHED"
+            log "CRASH: port $port exited with code $code - see $WORKDIR/stderr_$port.log and $WORKDIR/logs_$port/"
+            return
+        fi
+        sleep 1
+    done
+}
+
+# Continuous read/write load so the storage engine's background reader/
+# writer threads have real work in flight when suspend lands.
+generate_load() {
+    local i=$RANDOM
+    while true; do
+        {
+            echo "writemode on"
+            for j in $(seq 1 500); do
+                i=$((i + 1))
+                echo "set loadkey$i loadvalue$i"
+                [ $((j % 3)) -eq 0 ] && echo "get loadkey$i"
+            done
+        } | "$FDBCLI_BIN" -C "$CLUSTER_FILE" >>"$WORKDIR/load.log" 2>&1
+    done
+}
+
+# Polls `status details` until the replication-health line ends exactly in
+# "Healthy" (not "Healthy (Repartitioning)"/"(Re)initializing...") on two
+# consecutive checks a few seconds apart - a single momentary "Healthy" can
+# appear right as a config change takes effect, before data distribution
+# has actually started the work that change implies, so one match alone is
+# not reliable enough to safely proceed past.
+wait_healthy() {
+    local timeout="${1:-180}" start consecutive=0
+    start=$(date +%s)
+    while true; do
+        if "$FDBCLI_BIN" -C "$CLUSTER_FILE" --exec "status details" 2>/dev/null |
+            grep -qE 'Replication health\s+-\s+Healthy$'; then
+            consecutive=$((consecutive + 1))
+            [ "$consecutive" -ge 2 ] && return 0
+        else
+            consecutive=0
+        fi
+        if [ $(($(date +%s) - start)) -ge "$timeout" ]; then
+            log "timed out after ${timeout}s waiting for Replication health: Healthy (stably)"
+            return 1
+        fi
+        sleep 5
+    done
+}
+
+fileconfigure() {
+    local json_path="$1"
+    "$FDBCLI_BIN" -C "$CLUSTER_FILE" --exec "fileconfigure $json_path"
+}
+
+main() {
+    log "workdir: $WORKDIR"
+    echo "repro:reprocluster1@127.0.0.1:${PRIMARY_PORTS[0]},127.0.0.1:${PRIMARY_PORTS[1]},127.0.0.1:${PRIMARY_PORTS[2]}" >"$CLUSTER_FILE"
+
+    log "starting primary region (3 coordinators + 2 storage) and the remote region's 2 generic processes"
+    start_fdbserver "${PRIMARY_PORTS[0]}" primary
+    start_fdbserver "${PRIMARY_PORTS[1]}" primary
+    start_fdbserver "${PRIMARY_PORTS[2]}" primary
+    start_fdbserver "${PRIMARY_PORTS[3]}" primary storage
+    start_fdbserver "${PRIMARY_PORTS[4]}" primary storage
+    start_fdbserver "${REMOTE_PORTS[0]}" remote
+    start_fdbserver "${REMOTE_PORTS[1]}" remote
+    sleep 5
+
+    log "bootstrapping: double redundancy, ssd-rocksdb-v1"
+    "$FDBCLI_BIN" -C "$CLUSTER_FILE" --exec "configure new double ssd-rocksdb-v1" || {
+        log "initial configure failed"
+        exit 1
+    }
+
+    cat >"$WORKDIR/region_apply.json" <<EOF
+{
+  "regions": [
+    {"datacenters": [{"id": "primary", "priority": 1}]},
+    {"datacenters": [{"id": "remote", "priority": -1}]}
+  ],
+  "log_routers": 1,
+  "remote_logs": 1
+}
+EOF
+    cat >"$WORKDIR/region_activate.json" <<EOF
+{
+  "regions": [
+    {"datacenters": [{"id": "primary", "priority": 1}]},
+    {"datacenters": [{"id": "remote", "priority": 0}]}
+  ]
+}
+EOF
+
+    log "starting remote storage processes (${REMOTE_STORAGE_PORTS[*]})"
+    start_fdbserver "${REMOTE_STORAGE_PORTS[0]}" remote storage
+    start_fdbserver "${REMOTE_STORAGE_PORTS[1]}" remote storage
+    sleep 3
+
+    log "applying region config (remote priority -1)"
+    fileconfigure "$WORKDIR/region_apply.json" || exit 1
+    wait_healthy || exit 1
+
+    log "enabling usable_regions=2"
+    "$FDBCLI_BIN" -C "$CLUSTER_FILE" --exec "configure usable_regions=2" || exit 1
+    wait_healthy || exit 1
+
+    log "promoting remote to priority 0 (fully active)"
+    fileconfigure "$WORKDIR/region_activate.json" || exit 1
+    wait_healthy || exit 1
+
+    log "cluster is up: $($FDBCLI_BIN -C "$CLUSTER_FILE" --exec 'status minimal' 2>&1 | tail -1)"
+
+    log "restarting remote storage under supervision + starting load generators"
+    kill -9 $(pgrep -f "127.0.0.1:${REMOTE_STORAGE_PORTS[0]}" || true) >/dev/null 2>&1
+    kill -9 $(pgrep -f "127.0.0.1:${REMOTE_STORAGE_PORTS[1]}" || true) >/dev/null 2>&1
+    sleep 2
+    supervise_remote_storage "${REMOTE_STORAGE_PORTS[0]}" &
+    ALL_PIDS+=($!)
+    supervise_remote_storage "${REMOTE_STORAGE_PORTS[1]}" &
+    ALL_PIDS+=($!)
+    for _ in 1 2 3 4 5 6; do
+        generate_load &
+        ALL_PIDS+=($!)
+    done
+    sleep 5
+
+    log "hammering suspend against 127.0.0.1:${REMOTE_STORAGE_PORTS[0]} and :${REMOTE_STORAGE_PORTS[1]} for up to $ITERATIONS iterations"
+    for ((i = 1; i <= ITERATIONS; i++)); do
+        if [ -f "$WORKDIR/CRASHED" ]; then
+            log "REPRODUCED after $i attempts: $(cat "$WORKDIR/CRASHED")"
+            exit 1
+        fi
+        printf 'suspend\nsuspend %s 127.0.0.1:%s 127.0.0.1:%s\n' \
+            "$SUSPEND_WAIT" "${REMOTE_STORAGE_PORTS[0]}" "${REMOTE_STORAGE_PORTS[1]}" |
+            timeout 10 "$FDBCLI_BIN" -C "$CLUSTER_FILE" >>"$WORKDIR/hammer_fdbcli.log" 2>&1
+        if [ $((i % 25)) -eq 0 ]; then
+            log "$i/$ITERATIONS attempts, no crash yet"
+        fi
+        sleep "$SUSPEND_SLEEP"
+    done
+
+    if [ -f "$WORKDIR/CRASHED" ]; then
+        log "REPRODUCED after $ITERATIONS attempts: $(cat "$WORKDIR/CRASHED")"
+        exit 1
+    fi
+    log "PASS: completed $ITERATIONS suspend cycles with no crash"
+    exit 0
+}
+
+main

--- a/flow/IThreadPool.cpp
+++ b/flow/IThreadPool.cpp
@@ -41,6 +41,11 @@ class ThreadPool final : public IThreadPool, public ReferenceCounted<ThreadPool>
 		ThreadPool* pool;
 		IThreadPoolReceiver* userObject;
 		THREAD_HANDLE handle; // Owned by main thread
+		// Set by stop() when it is called reentrantly from inside this very thread
+		// (see the comment in stop() below). This thread has not returned from
+		// run() yet at that point, so stop() cannot join or delete it there; it
+		// asks the thread to clean itself up instead, once it does return.
+		bool selfDestruct = false;
 		static thread_local IThreadPoolReceiver* threadUserObject;
 		explicit Thread(ThreadPool* pool, IThreadPoolReceiver* userObject) : pool(pool), userObject(userObject) {}
 		~Thread() { ASSERT_ABORT(!userObject); }
@@ -57,6 +62,14 @@ class ThreadPool final : public IThreadPool, public ReferenceCounted<ThreadPool>
 			}
 			delete userObject;
 			userObject = nullptr;
+			if (selfDestruct) {
+				TraceEvent(SevInfo, "ThreadPoolReentrantSelfDestruct");
+				// Nobody will ever waitThread() this handle (stop() skipped it, see
+				// below), so release its OS-level resources directly instead of
+				// leaving them until process exit.
+				detachThread(handle);
+				delete this; // userObject is null now, so ~Thread()'s assertion holds; nothing after this touches `this`.
+			}
 		}
 		static void dispatch(PThreadAction action) { (*action)(threadUserObject); }
 	};
@@ -101,6 +114,23 @@ public:
 		ios.stop(); // doesn't work?
 		mode = Shutdown;
 		for (int i = 0; i < threads.size(); i++) {
+			if (threads[i]->userObject == Thread::threadUserObject) {
+				// "Reentrant" here means: this call to ThreadPool::stop() is
+				// executing on one of this pool's own worker threads (identified by
+				// comparing that thread's Thread::threadUserObject against
+				// threads[i]->userObject), instead of on the main thread that
+				// normally owns and destroys the pool. Concretely: a
+				// ThreadReturnPromise::send() completing an action right as the
+				// network was told to stop, whose g_network->onMainThread() call
+				// silently dropped the hand-off (Net2::onMainThread() no-ops once
+				// stopped), causing the caller's abandoned signal promise to
+				// synthesize a broken_promise() inline on this thread and cascade
+				// into code that closed this IThreadPool - all still on this same
+				// worker thread's call stack. We cannot join or delete ourselves
+				// here; mark for self-cleanup instead (see Thread::run()).
+				threads[i]->selfDestruct = true;
+				continue;
+			}
 			waitThread(threads[i]->handle);
 			delete threads[i];
 		}

--- a/flow/IThreadPoolTest.cpp
+++ b/flow/IThreadPoolTest.cpp
@@ -231,6 +231,39 @@ TEST_CASE("/flow/IThreadPool/ImplicitStop") {
 	co_await future;
 }
 
+// Under some failure scenarios, a worker thread in IThreadPool can call stop() on
+// the thread pool. Previously, this deleted the thread object while that same
+// thread was still running inside it, causing a crash. Now we detect the reentrant
+// case and let the thread clean itself up instead - see the comment in
+// ThreadPool::stop() for more details. The code below acts as a regression test
+// for this behavior.
+struct ReentrantStopTask final : public ThreadAction {
+	Reference<IThreadPool> pool;
+	ThreadReturnPromise<Void> promise;
+
+	explicit ReentrantStopTask(Reference<IThreadPool> pool) : pool(pool) {}
+
+	void operator()(IThreadPoolReceiver*) final {
+		pool->stop();
+		promise.send(Void());
+		delete this;
+	}
+
+	void cancel() final {}
+
+	double getTimeEstimate() const final { return 0; }
+};
+
+TEST_CASE("/flow/IThreadPool/ReentrantStop") {
+	noUnseed = true;
+
+	Reference<IThreadPool> pool = initTestPool();
+	auto task = new ReentrantStopTask(pool);
+	auto future = task->promise.getFuture();
+	pool->post(task);
+	co_await future;
+}
+
 #else
 void forceLinkIThreadPoolTests() {}
 #endif

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -2961,6 +2961,16 @@ void waitThread(THREAD_HANDLE thread) {
 #endif
 }
 
+void detachThread(THREAD_HANDLE thread) {
+#ifdef _WIN32
+	CloseHandle(thread);
+#elif (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__))
+	pthread_detach(thread);
+#else
+#error Port me!
+#endif
+}
+
 void setThreadPriority(int pri) {
 #ifdef __linux__
 	int tid = syscall(SYS_gettid);

--- a/flow/include/flow/Platform.h
+++ b/flow/include/flow/Platform.h
@@ -211,6 +211,12 @@ THREAD_HANDLE startThread(void*(func)(void*), void* arg, int stackSize = 0, cons
 
 void waitThread(THREAD_HANDLE thread);
 
+// Releases the OS resources associated with a thread that will never be
+// waitThread()'d - either because it has already exited, or because it is
+// detaching itself right before returning. Unlike waitThread(), this does
+// not block.
+void detachThread(THREAD_HANDLE thread);
+
 // Linux-only for now.  Set thread priority.
 void setThreadPriority(int pri);
 


### PR DESCRIPTION
Problem: suspend cli command exposes a race condition where SS can crash. The concurrent events are shown in the diagram below.

<img width="484" height="769" alt="Screenshot 2026-08-25 at 7 05 47 PM" src="https://github.com/user-attachments/assets/7fdafd50-6af5-4f30-b84b-0f18a5e5e7a9" />

Solution: at its core, the issue is that thread pool stop is called from the worker thread, which leads to thread deadlock and eventually a crash. The fix is to detect and gracefully exit in this case. In future, we can think how to strictly enforce the invariant that this never happens. 

Testing: 
- 100K joshua: <TODO: add id and summary>
- added unit test
- the issue only happens in prod/non-sim clusters, so setup a script to create an HA cluster and induce high read/write load on it. That exposed the race, which was also used to root cause and fix the bug. I thought to check this test in since it can be useful for future similar issues. 