### PR TITLE
Add mapped key conflict ranges to NativeAPI getRangeFinished for getMappedRange

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2504,8 +2504,8 @@ void getRangeFinished(Reference<TransactionState> trState,
 					const auto& reqAndResult = mappedKeyValue.reqAndResult;
 					if (std::holds_alternative<GetValueReqAndResultRef>(reqAndResult)) {
 						auto getValue = std::get<GetValueReqAndResultRef>(reqAndResult);
-						extraConflictRanges->push_back(Future<std::pair<Key, Key>>(
-						    std::make_pair(getValue.key, keyAfter(getValue.key))));
+						extraConflictRanges->push_back(
+						    Future<std::pair<Key, Key>>(std::make_pair(getValue.key, keyAfter(getValue.key))));
 					} else if (std::holds_alternative<GetRangeReqAndResultRef>(reqAndResult)) {
 						auto getRange = std::get<GetRangeReqAndResultRef>(reqAndResult);
 						Key crBegin = getRange.begin.getKey();
@@ -2516,8 +2516,7 @@ void getRangeFinished(Reference<TransactionState> trState,
 								crEnd = keyAfter(getRange.result.end()[-1].key);
 							}
 						}
-						extraConflictRanges->push_back(
-						    Future<std::pair<Key, Key>>(std::make_pair(crBegin, crEnd)));
+						extraConflictRanges->push_back(Future<std::pair<Key, Key>>(std::make_pair(crBegin, crEnd)));
 					}
 				}
 			}
@@ -2564,8 +2563,15 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 
 		loop {
 			if (end.getKey() == allKeys.begin && (end.offset < 1 || end.isFirstGreaterOrEqual())) {
-				getRangeFinished(
-				    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, extraConflictRanges, reverse, output);
+				getRangeFinished(trState,
+				                 startTime,
+				                 originalBegin,
+				                 originalEnd,
+				                 snapshot,
+				                 conflictRange,
+				                 extraConflictRanges,
+				                 reverse,
+				                 output);
 				return output;
 			}
 
@@ -2721,8 +2727,15 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 						output = copy;
 						output.more = true;
 
-						getRangeFinished(
-						    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, extraConflictRanges, reverse, output);
+						getRangeFinished(trState,
+						                 startTime,
+						                 originalBegin,
+						                 originalEnd,
+						                 snapshot,
+						                 conflictRange,
+						                 extraConflictRanges,
+						                 reverse,
+						                 output);
 						return output;
 					}
 
@@ -2734,8 +2747,15 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 						output.setReadThrough(reverse ? shard.begin : shard.end);
 					}
 
-					getRangeFinished(
-					    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, extraConflictRanges, reverse, output);
+					getRangeFinished(trState,
+					                 startTime,
+					                 originalBegin,
+					                 originalEnd,
+					                 snapshot,
+					                 conflictRange,
+					                 extraConflictRanges,
+					                 reverse,
+					                 output);
 					if (!output.more) {
 						ASSERT(!output.readThrough.present());
 					}
@@ -2752,8 +2772,15 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 						output.setReadThrough(reverse ? shard.begin : shard.end);
 					}
 
-					getRangeFinished(
-					    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, extraConflictRanges, reverse, output);
+					getRangeFinished(trState,
+					                 startTime,
+					                 originalBegin,
+					                 originalEnd,
+					                 snapshot,
+					                 conflictRange,
+					                 extraConflictRanges,
+					                 reverse,
+					                 output);
 					if (!output.more) {
 						ASSERT(!output.readThrough.present());
 					}
@@ -2768,8 +2795,15 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 						RangeResultFamily result = wait(
 						    getRangeFallback<GetKeyValuesFamilyRequest, GetKeyValuesFamilyReply, RangeResultFamily>(
 						        trState, originalBegin, originalEnd, mapper, originalLimits, reverse));
-						getRangeFinished(
-						    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, extraConflictRanges, reverse, result);
+						getRangeFinished(trState,
+						                 startTime,
+						                 originalBegin,
+						                 originalEnd,
+						                 snapshot,
+						                 conflictRange,
+						                 extraConflictRanges,
+						                 reverse,
+						                 result);
 						return result;
 					}
 
@@ -2798,8 +2832,15 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 						RangeResultFamily result = wait(
 						    getRangeFallback<GetKeyValuesFamilyRequest, GetKeyValuesFamilyReply, RangeResultFamily>(
 						        trState, originalBegin, originalEnd, mapper, originalLimits, reverse));
-						getRangeFinished(
-						    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, extraConflictRanges, reverse, result);
+						getRangeFinished(trState,
+						                 startTime,
+						                 originalBegin,
+						                 originalEnd,
+						                 snapshot,
+						                 conflictRange,
+						                 extraConflictRanges,
+						                 reverse,
+						                 result);
 						return result;
 					}
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2444,7 +2444,6 @@ int64_t inline getRangeResultFamilyBytes(MappedRangeResultRef result) {
 	return bytes;
 }
 
-// TODO: Client should add mapped keys to conflict ranges.
 template <class RangeResultFamily> // RangeResult or MappedRangeResult
 void getRangeFinished(Reference<TransactionState> trState,
                       double startTime,
@@ -2452,6 +2451,7 @@ void getRangeFinished(Reference<TransactionState> trState,
                       KeySelector end,
                       Snapshot snapshot,
                       Promise<std::pair<Key, Key>> conflictRange,
+                      std::vector<Future<std::pair<Key, Key>>>* extraConflictRanges,
                       Reverse reverse,
                       RangeResultFamily result) {
 	int64_t bytes = getRangeResultFamilyBytes(result);
@@ -2494,6 +2494,34 @@ void getRangeFinished(Reference<TransactionState> trState,
 		}
 
 		conflictRange.send(std::make_pair(rangeBegin, rangeEnd));
+
+		// For MappedRangeResult, add conflict ranges covering the secondary lookups
+		// (the keys/ranges the storage server fetched via the mapper). Without these,
+		// concurrent writes to mapped keys would not cause conflicts.
+		if constexpr (std::is_same_v<RangeResultFamily, MappedRangeResult>) {
+			if (extraConflictRanges) {
+				for (const auto& mappedKeyValue : result) {
+					const auto& reqAndResult = mappedKeyValue.reqAndResult;
+					if (std::holds_alternative<GetValueReqAndResultRef>(reqAndResult)) {
+						auto getValue = std::get<GetValueReqAndResultRef>(reqAndResult);
+						extraConflictRanges->push_back(Future<std::pair<Key, Key>>(
+						    std::make_pair(getValue.key, keyAfter(getValue.key))));
+					} else if (std::holds_alternative<GetRangeReqAndResultRef>(reqAndResult)) {
+						auto getRange = std::get<GetRangeReqAndResultRef>(reqAndResult);
+						Key crBegin = getRange.begin.getKey();
+						Key crEnd = getRange.end.getKey();
+						if (getRange.result.size() > 0) {
+							crBegin = std::min(crBegin, getRange.result[0].key);
+							if (crEnd <= getRange.result.end()[-1].key) {
+								crEnd = keyAfter(getRange.result.end()[-1].key);
+							}
+						}
+						extraConflictRanges->push_back(
+						    Future<std::pair<Key, Key>>(std::make_pair(crBegin, crEnd)));
+					}
+				}
+			}
+		}
 	}
 }
 
@@ -2509,6 +2537,7 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
                                    Key mapper,
                                    GetRangeLimits limits,
                                    Promise<std::pair<Key, Key>> conflictRange,
+                                   std::vector<Future<std::pair<Key, Key>>>* extraConflictRanges,
                                    Snapshot snapshot,
                                    Reverse reverse) {
 	//	state using RangeResultRefFamily = typename RangeResultFamily::RefType;
@@ -2536,7 +2565,7 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 		loop {
 			if (end.getKey() == allKeys.begin && (end.offset < 1 || end.isFirstGreaterOrEqual())) {
 				getRangeFinished(
-				    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, reverse, output);
+				    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, extraConflictRanges, reverse, output);
 				return output;
 			}
 
@@ -2693,7 +2722,7 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 						output.more = true;
 
 						getRangeFinished(
-						    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, reverse, output);
+						    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, extraConflictRanges, reverse, output);
 						return output;
 					}
 
@@ -2706,7 +2735,7 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 					}
 
 					getRangeFinished(
-					    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, reverse, output);
+					    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, extraConflictRanges, reverse, output);
 					if (!output.more) {
 						ASSERT(!output.readThrough.present());
 					}
@@ -2724,7 +2753,7 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 					}
 
 					getRangeFinished(
-					    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, reverse, output);
+					    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, extraConflictRanges, reverse, output);
 					if (!output.more) {
 						ASSERT(!output.readThrough.present());
 					}
@@ -2740,7 +2769,7 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 						    getRangeFallback<GetKeyValuesFamilyRequest, GetKeyValuesFamilyReply, RangeResultFamily>(
 						        trState, originalBegin, originalEnd, mapper, originalLimits, reverse));
 						getRangeFinished(
-						    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, reverse, result);
+						    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, extraConflictRanges, reverse, result);
 						return result;
 					}
 
@@ -2770,7 +2799,7 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 						    getRangeFallback<GetKeyValuesFamilyRequest, GetKeyValuesFamilyReply, RangeResultFamily>(
 						        trState, originalBegin, originalEnd, mapper, originalLimits, reverse));
 						getRangeFinished(
-						    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, reverse, result);
+						    trState, startTime, originalBegin, originalEnd, snapshot, conflictRange, extraConflictRanges, reverse, result);
 						return result;
 					}
 
@@ -3653,7 +3682,7 @@ Future<RangeResultFamily> Transaction::getRangeInternal(const KeySelector& begin
 	}
 
 	return ::getRange<GetKeyValuesFamilyRequest, GetKeyValuesFamilyReply, RangeResultFamily>(
-	    trState, b, e, mapper, limits, conflictRange, snapshot, reverse);
+	    trState, b, e, mapper, limits, conflictRange, &extraConflictRanges, snapshot, reverse);
 }
 
 Future<RangeResult> Transaction::getRange(const KeySelector& begin,


### PR DESCRIPTION
### Problem

In `NativeAPI.actor.cpp`, `getRangeFinished` only registered conflict ranges for the primary scan range. For mapped range queries (`MappedRangeResult`), the secondary keys/ranges retrieved via the mapper were not being added to read conflict ranges at the NativeAPI layer (addressing the TODO on `getRangeFinished`).

### Solution

- Updated `getRangeFinished` to accept `extraConflictRanges` and inspect `MappedRangeResult` when `!snapshot`.
- For each mapped key-value in the result, add read conflict ranges for the secondary operations:
  - Single-key lookups (`GetValueReqAndResultRef`): adds `[key, keyAfter(key))`.
  - Sub-range lookups (`GetRangeReqAndResultRef`): adds `[begin, end)` bounded by returned records.
- Threaded `extraConflictRanges` through `Transaction::getRangeInternal`, `::getRange`, and all `getRangeFinished` call sites.
- This mirrors the conflict range logic already implemented in `ReadYourWrites.cpp` (`addConflictRangeAndMustUnmodified`).
