### PR TITLE
Simplify Reference declarations and pager initialization awaits

### DIFF
--- a/fdbserver/datadistributor/DDTeamCollection.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.cpp
@@ -3049,7 +3049,7 @@ public:
 		PromiseStream<Future<Void>> addTSSInProgress;
 		Future<Void> inProgressTSS =
 		    actorCollection(addTSSInProgress.getFuture(), &inProgressTSSCount, nullptr, nullptr, nullptr);
-		Reference<TSSPairState> tssState = makeReference<TSSPairState>();
+		auto tssState = makeReference<TSSPairState>();
 		Future<Void> checkTss = self->initialFailureReactionDelay;
 		bool pendingTSSCheck = false;
 
@@ -3487,7 +3487,7 @@ public:
 			TxnCounters* counters = updateStorageMetadataCounters();
 			KeyBackedObjectMap<UID, StorageMetadataType, decltype(IncludeVersion())> metadataMap(
 			    serverMetadataKeys.begin, IncludeVersion());
-			Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(self->dbContext());
+			auto tr = makeReference<ReadYourWritesTransaction>(self->dbContext());
 
 			bool isTss = server->getLastKnownInterface().isTss();
 			// Update server's storeType, especially when it was created
@@ -7623,7 +7623,7 @@ TEST_CASE("/DataDistribution/GetTeam/DeprioritizeWigglePausedTeam") {
 }
 
 TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithMinAge") {
-	Reference<StorageWiggler> wiggler = makeReference<StorageWiggler>(nullptr);
+	auto wiggler = makeReference<StorageWiggler>(nullptr);
 	double startTime = now();
 	wiggler->addServer(UID(1, 0),
 	                   StorageMetadataType(startTime - SERVER_KNOBS->DD_STORAGE_WIGGLE_MIN_SS_AGE_SEC + 5.0,
@@ -7675,7 +7675,7 @@ TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithMinAge") {
 TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithTSS") {
 	std::unique_ptr<DDTeamCollection> collection =
 	    DDTeamCollectionUnitTest::testMachineTeamCollection(1, makeReference<PolicyOne>(), 5);
-	Reference<StorageWiggler> wiggler = makeReference<StorageWiggler>(collection.get());
+	auto wiggler = makeReference<StorageWiggler>(collection.get());
 
 	std::cout << "Test when need TSS ... \n";
 	collection->configuration.usableRegions = 1;

--- a/fdbserver/kvstore/VersionedBTree.cpp
+++ b/fdbserver/kvstore/VersionedBTree.cpp
@@ -10405,7 +10405,7 @@ TEST_CASE(":/redwood/performance/extentQueue") {
 	if (reload) {
 		pager = new DWALPager(
 		    pageSize, extentSize, fileName, cacheSizeBytes, remapCleanupWindowBytes, concurrentExtentReads, false);
-		co_await success(pager->init());
+		co_await pager->init();
 
 		LogicalPageID extID = pager->newLastExtentID();
 		m_extentQueue.create(pager, extID, "ExtentQueue", pager->newLastQueueID(), true);
@@ -10455,7 +10455,7 @@ TEST_CASE(":/redwood/performance/extentQueue") {
 	printf("Reopening pager file from disk.\n");
 	pager = new DWALPager(
 	    pageSize, extentSize, fileName, cacheSizeBytes, remapCleanupWindowBytes, concurrentExtentReads, false);
-	co_await success(pager->init());
+	co_await pager->init();
 
 	printf("Starting ExtentQueue FastPath Recovery from Disk.\n");
 


### PR DESCRIPTION
## Summary

- Use `auto` for four declarations whose types are already given by `makeReference<T>()`.
- Await `pager->init()` directly at both initialization points in the Redwood extent-queue performance test.

The declaration types stay unchanged. The await cleanup removes a forwarding coroutine in test code only.

## Validation

- AST-grep rule/snapshot tests: 11 passed; both affected files have no enabled-rule findings.
- `fdbserver_datadistributor_test --seed 1`: 54 passed, 0 failed.
- `fdbserver_kvstore_test -f ':/redwood/performance/extentQueue' --max-test-cases 1 --seed 1`: 1 passed, 0 failed, with the default 10 million entries and both recovery paths exercised.

Both test executables compiled and linked. The build wrapper returned a nonzero status after linking; binary freshness and source hashes were verified before running the passing tests directly. A stale compiler-cache path encountered between builds was cleared without changing source.
