### PR TITLE
Annotate rolled tracked-latest trace events so they carry LogGroup/Machine/Roles always

### DIFF
--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -503,6 +503,14 @@ public:
 						}
 					}
 
+					// Tracked-latest events first logged before the trace file was opened (e.g. an early
+					// ProgramStart in backup_agent) were cached without the universal annotation fields
+					// (LogGroup, Machine, Roles). Now that the log is open, annotate the rolled copy so it
+					// carries them. Already-annotated cached copies already have those fields (copied
+					// above), so skip them to avoid duplicating fields.
+					if (!events[idx].isAnnotated())
+						annotateEvent(rolledFields);
+
 					eventBuffer.push_back(rolledFields);
 				}
 			}


### PR DESCRIPTION
Tracked-latest events (e.g., ProgramStart) first logged before the trace file is opened—as fdbbackup/backup_agent does—are cached un-annotated. The roll path re-emits cached tracked-latest events as TrackLatestType=Rolled by copying their fields verbatim, so those Rolled copies were missing the universal annotation fields (LogGroup, Machine, Roles). Annotate the rolled copy when its source was cached un-annotated; already-annotated sources keep their copied fields and are skipped to avoid duplicating them.

Joshua run (passed 100K):
20260826-215527-neethuhaneeshabingi-d1109e84e0b9e2b8 compressed=True data_size=41736995 duration=3871629 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:04:31 sanity=False started=100000 stopped=20260826-225958 submitted=20260826-215527 timeout=5400 username=neethuhaneeshabingi

Logs when running a local cluster:
Before:
```
trace.127.0.0.1.30552.1787849994.aJD9af.0.1.xml:<Event Severity="10" Time="1787849994.273785" DateTime="2026-08-27T16:59:54Z" Type="ProgramStart" ID="0000000000000000" SourceVersion="d5c4e034b5570e8a44a121dbd3a9492c09d4f4d0" Version="8.0.0" PackageName="8.0" ActualTime="1787849994" CommandLine="/root/build_output/bin/backup_agent -C ./loopback-cluster-1/fdb.cluster --log --logdir ./loopback-cluster-1/backup-agent --loggroup backupagent1 --trace-format xml" MemoryLimit="8589934592" Proxy="http://proxy.config.pcp.local:3128" ThreadID="17214260581966918016" TrackLatestType="Original" Machine="127.0.0.1:30552" LogGroup="backupagent1" ClientDescription="primary-8.0.0-15976480952026891309" />
trace.127.0.0.1.30552.1787849994.aJD9af.0.2.xml:<Event Severity="10" Time="1787850044.278407" OriginalTime="1787849994.273785" DateTime="2026-08-27T17:00:44Z" OriginalDateTime="2026-08-27T16:59:54Z" Type="ProgramStart" ID="0000000000000000" SourceVersion="d5c4e034b5570e8a44a121dbd3a9492c09d4f4d0" Version="8.0.0" PackageName="8.0" ActualTime="1787849994" CommandLine="/root/build_output/bin/backup_agent -C ./loopback-cluster-1/fdb.cluster --log --logdir ./loopback-cluster-1/backup-agent --loggroup backupagent1 --trace-format xml" MemoryLimit="8589934592" Proxy="http://proxy.config.pcp.local:3128" ThreadID="17214260581966918016" TrackLatestType="Rolled" />
```

After:
```
trace.127.0.0.1.29921.1787849616.KpbA9F.0.1.xml:<Event Severity="10" Time="1787849616.678261" DateTime="2026-08-27T16:53:36Z" Type="ProgramStart" ID="0000000000000000" SourceVersion="d5c4e034b5570e8a44a121dbd3a9492c09d4f4d0" Version="8.0.0" PackageName="8.0" ActualTime="1787849616" CommandLine="/root/build_output/bin/backup_agent -C ./loopback-cluster-1/fdb.cluster --log --logdir ./loopback-cluster-1/backup-agent --loggroup backupagent1 --trace-format xml" MemoryLimit="8589934592" Proxy="http://proxy.config.pcp.local:3128" ThreadID="6227454279627864402" TrackLatestType="Original" Machine="127.0.0.1:29921" LogGroup="backupagent1" ClientDescription="primary-8.0.0-6270713899673036362" />
trace.127.0.0.1.29921.1787849616.KpbA9F.0.2.xml:<Event Severity="10" Time="1787849666.682954" OriginalTime="1787849616.678261" DateTime="2026-08-27T16:54:26Z" OriginalDateTime="2026-08-27T16:53:36Z" Type="ProgramStart" ID="0000000000000000" SourceVersion="d5c4e034b5570e8a44a121dbd3a9492c09d4f4d0" Version="8.0.0" PackageName="8.0" ActualTime="1787849616" CommandLine="/root/build_output/bin/backup_agent -C ./loopback-cluster-1/fdb.cluster --log --logdir ./loopback-cluster-1/backup-agent --loggroup backupagent1 --trace-format xml" MemoryLimit="8589934592" Proxy="http://proxy.config.pcp.local:3128" ThreadID="6227454279627864402" TrackLatestType="Rolled" **Machine="127.0.0.1:29921" LogGroup="backupagent1"** ClientDescription="primary-8.0.0-6270713899673036362" />
```




