### PR TITLE
Annotate rolled tracked-latest trace events so they carry LogGroup/Ma…

### DIFF
--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -505,6 +505,14 @@ public:
 						}
 					}
 
+					// Tracked-latest events first logged before the trace file was opened (e.g. an early
+					// ProgramStart in backup_agent) were cached without the universal annotation fields
+					// (LogGroup, Machine, Roles). Now that the log is open, annotate the rolled copy so it
+					// carries them. Already-annotated cached copies already have those fields (copied
+					// above), so skip them to avoid duplicating fields.
+					if (!events[idx].isAnnotated())
+						annotateEvent(rolledFields);
+
 					eventBuffer.push_back(rolledFields);
 				}
 			}


### PR DESCRIPTION
cherry-pick of #13955
Tracked-latest events (e.g., ProgramStart) first logged before the trace file is opened—as fdbbackup/backup_agent does—are cached un-annotated. The roll path re-emits cached tracked-latest events as TrackLatestType=Rolled by copying their fields verbatim, so those Rolled copies were missing the universal annotation fields (LogGroup, Machine, Roles). Annotate the rolled copy when its source was cached un-annotated; already-annotated sources keep their copied fields and are skipped to avoid duplicating them.

Joshua run (passed 100K):
20260827-173706-neethu_7.4.7_rolledtrace-10e5c059790b01d6 compressed=True data_size=60609921 duration=3342739 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:28:18 sanity=False started=100000 stopped=20260827-180524 submitted=20260827-173706 timeout=5400 username=neethu_7.4.7_rolledtrace