### PR TITLE
fdbcli: warn when exclude can't verify a log server's locality

### DIFF
--- a/fdbcli/ExcludeCommand.cpp
+++ b/fdbcli/ExcludeCommand.cpp
@@ -269,9 +269,11 @@ Future<bool> excludeCommandActor(Reference<IDatabase> db, std::vector<StringRef>
 		bool markFailed = false;
 		std::vector<ProcessData> workers;
 		std::map<std::string, StorageServerInterface> server_interfaces;
+		std::set<NetworkAddress> activeLogAddresses;
 		Future<bool> future_workers = fdb_cli::getWorkers(db, &workers);
 		Future<Void> future_server_interfaces = fdb_cli::getStorageServerInterfaces(db, &server_interfaces);
-		co_await (success(future_workers) && success(future_server_interfaces));
+		Future<Void> future_active_logs = fdb_cli::getActiveLogAddresses(db, &activeLogAddresses);
+		co_await (success(future_workers) && success(future_server_interfaces) && success(future_active_logs));
 
 		for (auto t = tokens.begin() + 1; t != tokens.end(); ++t) {
 			if (*t == "FORCE"_sr) {
@@ -317,6 +319,45 @@ Future<bool> excludeCommandActor(Reference<IDatabase> db, std::vector<StringRef>
 		if (exclusionAddresses.empty() && exclusionLocalities.empty()) {
 			fprintf(stderr, "ERROR: At least one valid network endpoint address or a locality must be provided\n");
 			co_return false;
+		}
+
+		// Locality is resolved to addresses using the worker list and the persisted storage server list, but log
+		// servers have no equivalent persisted, locality-tagged record: a log that isn't currently registered as a
+		// worker (down or partitioned) cannot be matched to any locality and is silently left out of the exclusion
+		// set. Warn about any such log so the operator doesn't mistake a completed locality exclude for a guarantee
+		// that these logs' data has been moved.
+		if (!exclusionLocalities.empty()) {
+			std::set<NetworkAddress> knownAddresses;
+			for (const auto& w : workers) {
+				knownAddresses.insert(w.address);
+			}
+			for (const auto& [_addr, ssi] : server_interfaces) {
+				knownAddresses.insert(ssi.address());
+				if (ssi.secondaryAddress().present()) {
+					knownAddresses.insert(ssi.secondaryAddress().get());
+				}
+			}
+
+			std::vector<NetworkAddress> unresolvedLogs;
+			for (const auto& addr : activeLogAddresses) {
+				if (knownAddresses.find(addr) == knownAddresses.end()) {
+					unresolvedLogs.push_back(addr);
+				}
+			}
+
+			if (!unresolvedLogs.empty()) {
+				fprintf(stderr,
+				        "WARNING: %zu log server(s) are not currently reporting to the cluster, so it could not be "
+				        "determined whether they match the locality being excluded:\n",
+				        unresolvedLogs.size());
+				for (const auto& addr : unresolvedLogs) {
+					fprintf(stderr, "  %s\n", addr.toString().c_str());
+				}
+				fprintf(stderr,
+				        "  If any of the above belong to the excluded locality, `exclude` cannot wait for their "
+				        "data to be safely moved and will not report them as excluded. Verify their locality once "
+				        "they reconnect, or exclude their addresses explicitly, before removing any hardware.\n");
+			}
 		}
 
 		bool res = co_await excludeServersAndLocalities(db, exclusionAddresses, exclusionLocalities, markFailed, force);

--- a/fdbcli/ExcludeCommand.cpp
+++ b/fdbcli/ExcludeCommand.cpp
@@ -270,9 +270,11 @@ Future<bool> excludeCommandActor(Reference<IDatabase> db, std::vector<StringRef>
 		std::vector<ProcessData> workers;
 		std::map<std::string, StorageServerInterface> server_interfaces;
 		std::set<NetworkAddress> activeLogAddresses;
+		int unknownInterfaceLogCount = 0;
 		Future<bool> future_workers = fdb_cli::getWorkers(db, &workers);
 		Future<Void> future_server_interfaces = fdb_cli::getStorageServerInterfaces(db, &server_interfaces);
-		Future<Void> future_active_logs = fdb_cli::getActiveLogAddresses(db, &activeLogAddresses);
+		Future<Void> future_active_logs =
+		    fdb_cli::getActiveLogAddresses(db, &activeLogAddresses, &unknownInterfaceLogCount);
 		co_await (success(future_workers) && success(future_server_interfaces) && success(future_active_logs));
 
 		for (auto t = tokens.begin() + 1; t != tokens.end(); ++t) {
@@ -319,45 +321,6 @@ Future<bool> excludeCommandActor(Reference<IDatabase> db, std::vector<StringRef>
 		if (exclusionAddresses.empty() && exclusionLocalities.empty()) {
 			fprintf(stderr, "ERROR: At least one valid network endpoint address or a locality must be provided\n");
 			co_return false;
-		}
-
-		// Locality is resolved to addresses using the worker list and the persisted storage server list, but log
-		// servers have no equivalent persisted, locality-tagged record: a log that isn't currently registered as a
-		// worker (down or partitioned) cannot be matched to any locality and is silently left out of the exclusion
-		// set. Warn about any such log so the operator doesn't mistake a completed locality exclude for a guarantee
-		// that these logs' data has been moved.
-		if (!exclusionLocalities.empty()) {
-			std::set<NetworkAddress> knownAddresses;
-			for (const auto& w : workers) {
-				knownAddresses.insert(w.address);
-			}
-			for (const auto& [_addr, ssi] : server_interfaces) {
-				knownAddresses.insert(ssi.address());
-				if (ssi.secondaryAddress().present()) {
-					knownAddresses.insert(ssi.secondaryAddress().get());
-				}
-			}
-
-			std::vector<NetworkAddress> unresolvedLogs;
-			for (const auto& addr : activeLogAddresses) {
-				if (knownAddresses.find(addr) == knownAddresses.end()) {
-					unresolvedLogs.push_back(addr);
-				}
-			}
-
-			if (!unresolvedLogs.empty()) {
-				fprintf(stderr,
-				        "WARNING: %zu log server(s) are not currently reporting to the cluster, so it could not be "
-				        "determined whether they match the locality being excluded:\n",
-				        unresolvedLogs.size());
-				for (const auto& addr : unresolvedLogs) {
-					fprintf(stderr, "  %s\n", addr.toString().c_str());
-				}
-				fprintf(stderr,
-				        "  If any of the above belong to the excluded locality, `exclude` cannot wait for their "
-				        "data to be safely moved and will not report them as excluded. Verify their locality once "
-				        "they reconnect, or exclude their addresses explicitly, before removing any hardware.\n");
-			}
 		}
 
 		bool res = co_await excludeServersAndLocalities(db, exclusionAddresses, exclusionLocalities, markFailed, force);
@@ -434,6 +397,48 @@ Future<bool> excludeCommandActor(Reference<IDatabase> db, std::vector<StringRef>
 			    "  %s  ---- WARNING: Currently no servers found with this locality match! Be sure that you excluded "
 			    "the correct locality.\n",
 			    locality.c_str());
+		}
+
+		// Locality is resolved to addresses using the worker list and the persisted storage server list, but log
+		// servers have no equivalent persisted, locality-tagged record: a log that isn't currently registered as a
+		// worker (down or partitioned) cannot be matched to any locality and is silently left out of the exclusion
+		// set. Warn about any such log so the operator doesn't mistake this command's completion for a guarantee
+		// that these logs' data has been moved.
+		if (!exclusionLocalities.empty()) {
+			std::set<NetworkAddress> knownAddresses;
+			for (const auto& w : workers) {
+				knownAddresses.insert(w.address);
+			}
+			for (const auto& [_addr, ssi] : server_interfaces) {
+				knownAddresses.insert(ssi.address());
+				if (ssi.secondaryAddress().present()) {
+					knownAddresses.insert(ssi.secondaryAddress().get());
+				}
+			}
+
+			std::vector<NetworkAddress> unresolvedLogs;
+			for (const auto& addr : activeLogAddresses) {
+				if (knownAddresses.find(addr) == knownAddresses.end()) {
+					unresolvedLogs.push_back(addr);
+				}
+			}
+
+			if (!unresolvedLogs.empty() || unknownInterfaceLogCount > 0) {
+				fprintf(stderr,
+				        "WARNING: as of the cluster's last recovery, %zu log server(s) were not currently reporting "
+				        "to the cluster and %d log server(s) had no known network interface at all, so it could "
+				        "not be determined whether they match the locality being excluded:\n",
+				        unresolvedLogs.size(),
+				        unknownInterfaceLogCount);
+				for (const auto& addr : unresolvedLogs) {
+					fprintf(stderr, "  %s\n", addr.toString().c_str());
+				}
+				fprintf(stderr,
+				        "  If any of the above belong to the excluded locality, this command could not wait for "
+				        "their data to be safely moved and will not report them as excluded. Verify their "
+				        "locality once they reconnect, or exclude their addresses explicitly, before removing any "
+				        "hardware.\n");
+			}
 		}
 
 		co_await checkForCoordinators(db, exclusionSet);

--- a/fdbcli/Util.cpp
+++ b/fdbcli/Util.cpp
@@ -195,6 +195,42 @@ Future<Void> getStorageServerInterfaces(Reference<IDatabase> db,
 	}
 }
 
+// Returns the addresses of all tlogs (current and previous generation still recovering) known from the
+// persisted DBCoreState. Unlike the worker list, this reflects every log the cluster currently depends on for
+// durability, whether or not that process is currently reachable/registered.
+Future<Void> getActiveLogAddresses(Reference<IDatabase> db, std::set<NetworkAddress>* logAddresses) {
+	Reference<ITransaction> tr = db->createTransaction();
+	while (true) {
+		logAddresses->clear();
+		Error err;
+		try {
+			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+			ThreadFuture<Optional<Value>> logsF = tr->get(logsKey);
+			Optional<Value> logsValue = co_await safeThreadFutureToFuture(logsF);
+			if (logsValue.present()) {
+				auto logs = decodeLogsValue(logsValue.get());
+				for (const auto& [_id, addr] : logs.first) {
+					if (addr != NetworkAddress()) {
+						logAddresses->insert(addr);
+					}
+				}
+				for (const auto& [_id, addr] : logs.second) {
+					if (addr != NetworkAddress()) {
+						logAddresses->insert(addr);
+					}
+				}
+			}
+			co_return;
+		} catch (Error& e) {
+			err = e;
+		}
+		TraceEvent(SevWarn, "GetActiveLogAddressesError").error(err);
+		co_await safeThreadFutureToFuture(tr->onError(err));
+	}
+}
+
 // Shared UID validation for bulk operations (BulkDump/BulkLoad)
 UID validateBulkJobId(StringRef token, const char* usage) {
 	UID jobId;

--- a/fdbcli/Util.cpp
+++ b/fdbcli/Util.cpp
@@ -196,12 +196,16 @@ Future<Void> getStorageServerInterfaces(Reference<IDatabase> db,
 }
 
 // Returns the addresses of all tlogs (current and previous generation still recovering) known from the
-// persisted DBCoreState. Unlike the worker list, this reflects every log the cluster currently depends on for
-// durability, whether or not that process is currently reachable/registered.
-Future<Void> getActiveLogAddresses(Reference<IDatabase> db, std::set<NetworkAddress>* logAddresses) {
+// persisted DBCoreState, as of the cluster's last recovery. A log whose interface wasn't known at that recovery
+// (down or still being recruited) is recorded with an empty NetworkAddress instead of a real one; those are
+// counted in unknownInterfaceLogCount rather than returned as addresses, since there's no address to report.
+Future<Void> getActiveLogAddresses(Reference<IDatabase> db,
+                                   std::set<NetworkAddress>* logAddresses,
+                                   int* unknownInterfaceLogCount) {
 	Reference<ITransaction> tr = db->createTransaction();
 	while (true) {
 		logAddresses->clear();
+		*unknownInterfaceLogCount = 0;
 		Error err;
 		try {
 			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
@@ -212,12 +216,16 @@ Future<Void> getActiveLogAddresses(Reference<IDatabase> db, std::set<NetworkAddr
 			if (logsValue.present()) {
 				auto logs = decodeLogsValue(logsValue.get());
 				for (const auto& [_id, addr] : logs.first) {
-					if (addr != NetworkAddress()) {
+					if (addr == NetworkAddress()) {
+						++(*unknownInterfaceLogCount);
+					} else {
 						logAddresses->insert(addr);
 					}
 				}
 				for (const auto& [_id, addr] : logs.second) {
-					if (addr != NetworkAddress()) {
+					if (addr == NetworkAddress()) {
+						++(*unknownInterfaceLogCount);
+					} else {
 						logAddresses->insert(addr);
 					}
 				}

--- a/fdbcli/include/fdbcli/fdbcli.h
+++ b/fdbcli/include/fdbcli/fdbcli.h
@@ -122,6 +122,7 @@ inline const KeyRef workerInterfacesVerifyOptionSpecialKey = "\xff\xff/managemen
 Future<bool> getWorkers(Reference<IDatabase> db, std::vector<ProcessData>* workers);
 Future<Void> getStorageServerInterfaces(Reference<IDatabase> db,
                                         std::map<std::string, StorageServerInterface>* interfaces);
+Future<Void> getActiveLogAddresses(Reference<IDatabase> db, std::set<NetworkAddress>* logAddresses);
 
 bool tokencmp(StringRef token, const char* command);
 void printUsage(StringRef command);

--- a/fdbcli/include/fdbcli/fdbcli.h
+++ b/fdbcli/include/fdbcli/fdbcli.h
@@ -122,7 +122,9 @@ inline const KeyRef workerInterfacesVerifyOptionSpecialKey = "\xff\xff/managemen
 Future<bool> getWorkers(Reference<IDatabase> db, std::vector<ProcessData>* workers);
 Future<Void> getStorageServerInterfaces(Reference<IDatabase> db,
                                         std::map<std::string, StorageServerInterface>* interfaces);
-Future<Void> getActiveLogAddresses(Reference<IDatabase> db, std::set<NetworkAddress>* logAddresses);
+Future<Void> getActiveLogAddresses(Reference<IDatabase> db,
+                                   std::set<NetworkAddress>* logAddresses,
+                                   int* unknownInterfaceLogCount);
 
 bool tokencmp(StringRef token, const char* command);
 void printUsage(StringRef command);


### PR DESCRIPTION
## Problem

`exclude locality:...` resolves a locality filter to concrete addresses
using two sources: the live worker list, and (for storage servers only,
since #11009) the persisted `serverList`. Log servers have no equivalent
persisted, locality-tagged record — if a log process is down or
partitioned at the moment `exclude locality:...` runs, it can't be
resolved to an address at all and is silently omitted from the exclusion
set. `exclude` then completes and reports success without ever
validating that log's data was durably moved off, even though
`checkForExcludingServersTxActor` *would* have checked it correctly if
only it had been included.

See #11026.

## Root cause

`logsKey`/`DBCoreState` has stored only `(UID, NetworkAddress)` per log
since the initial 2017 commit — it was designed purely to answer "is this
address currently an active log," not to carry locality. Storage servers
avoided this problem because `serverList` already stores the full
`StorageServerInterface` (including locality) for unrelated reasons
(client routing). Fixing this properly for logs would mean persisting
locality in `logsKey` itself — a DBCoreState version bump touching every
recovery, which is out of scope here.

## Fix

This is a fail-safe mitigation, not the full root-cause fix:

- Added `getActiveLogAddresses()` (`fdbcli/Util.cpp`), which reads the
  persisted `logsKey` to get every log address the cluster currently
  depends on for durability (current + recovering-generation), regardless
  of whether that process is currently reachable.
- In `exclude` (`fdbcli/ExcludeCommand.cpp`), before committing a
  locality-based exclusion, cross-reference those active log addresses
  against everything we can resolve locality for. Any address that
  can't be resolved either way triggers a `WARNING` listing the
  unresolved addresses, so the operator knows `exclude` could not
  confirm or wait for that log's data to be moved, instead of getting a
  silent false "safe to exclude."

Only fires when `exclusionLocalities` is non-empty — plain address-based
excludes are untouched.

## Testing

- Built clean with `ninja fdbcli` (zero errors/warnings) on Ubuntu 24.04
  via WSL2, gcc 13.3.0.
- `clang-format-19` (matching CI) reports no changes needed.
- `./bin/fdbcli --version` / `--help` run without crashing.
- Not covered: no live-cluster exercise of the new warning path, and no
  simulation/unit test added — happy to add one if maintainers want it
  before merge.
