### PR TITLE
Fix Python tuple packing treating __eq__-None objects as NULL

### DIFF
--- a/bindings/python/fdb/tuple.py
+++ b/bindings/python/fdb/tuple.py
@@ -362,11 +362,23 @@ def _bit_length(x):
     return x.bit_length()
 
 
+def _is_null(value):
+    """Return True for None and for fdb.impl.Value objects that wrap None.
+
+    ``fdb.impl.Value`` overrides ``__class__`` to ``bytes``, so
+    ``isinstance(value, bytes)`` is true for Values. Real ``bytes`` instances
+    are never equal to None, so the second clause only matches Values that
+    wrap None. Objects that merely override ``__eq__`` to match None must not
+    be treated as null (that would silently corrupt packed keys).
+    """
+    return value is None or (isinstance(value, bytes) and value == None)
+
+
 def _encode(value, nested=False):
     # returns [code][data] (code != 0xFF)
     # encoded values are self-terminating
     # sorting need to work too!
-    if value == None:  # ==, not is, because some fdb.impl.Value are equal to None
+    if _is_null(value):
         if nested:
             return b"".join([int2byte(NULL_CODE), int2byte(0xFF)]), -1
         else:
@@ -538,7 +550,7 @@ def range(t):
 
 
 def _code_for(value):
-    if value == None:
+    if _is_null(value):
         return NULL_CODE
     elif isinstance(value, bytes):
         return BYTES_CODE

--- a/bindings/python/tests/tuple_tests.py
+++ b/bindings/python/tests/tuple_tests.py
@@ -140,7 +140,58 @@ def equalEnough(t1, t2):
     return True
 
 
+def test_none_packs_as_null():
+    assert pack((None,)) == b"\x00"
+    assert unpack(pack((None,))) == (None,)
+    assert unpack(pack(((None,),))) == ((None,),)
+
+
+def test_eq_none_object_rejected():
+    """Objects that override __eq__ to match None must not pack as NULL."""
+
+    class EqNone(object):
+        def __eq__(self, other):
+            return other is None
+
+        def __hash__(self):
+            return hash(id(self))
+
+    try:
+        pack((EqNone(),))
+    except ValueError:
+        return True
+    raise AssertionError(
+        "object equal to None via __eq__ was packed as NULL instead of raising"
+    )
+
+
+def test_value_like_none_still_null():
+    """Stand-in for fdb.impl.Value wrapping None (__class__ masquerades as bytes)."""
+
+    class ValueLikeNone(object):
+        def __init__(self):
+            self.value = None
+
+        @property
+        def __class__(self):
+            return bytes
+
+        def __eq__(self, other):
+            return self.value == other
+
+        def __hash__(self):
+            return hash(None)
+
+    assert pack((ValueLikeNone(),)) == b"\x00"
+    assert fdb.tuple._code_for(ValueLikeNone()) == fdb.tuple.NULL_CODE
+
+
 def tupleTest(N=10000):
+    test_none_packs_as_null()
+    test_eq_none_object_rejected()
+    test_value_like_none_still_null()
+    print("Null / __eq__ None checks OK")
+
     someTuples = [randomTuple() for i in range(N)]
     a = sorted(someTuples, cmp=compare)
     b = sorted(someTuples, key=pack)


### PR DESCRIPTION
## Problem

Fixes #13267.

In `bindings/python/fdb/tuple.py`, `_encode` (and `_code_for`) used `value == None` to detect null tuple elements. That was intentional for `fdb.impl.Value` objects that wrap `None` (they override equality), but it also meant any user-defined object whose `__eq__` returns true for `None` was **silently packed as NULL** (`\x00`) instead of raising `ValueError`. That is a silent key-corruption bug.

## Solution

Introduce `_is_null()` that:

1. Treats real `None` with identity (`is None`).
2. Still treats `fdb.impl.Value` wrapping `None` as null. Those objects override `__class__` to `bytes`, so `isinstance(value, bytes) and value == None` matches them; real `bytes` are never equal to `None`.
3. Rejects other objects that only override `__eq__` to match `None` (they fall through to the existing `ValueError`).

`_encode` and `_code_for` both use this helper so packing and comparison stay consistent.

## Testing

Added regression coverage in `bindings/python/tests/tuple_tests.py`:

- `None` still packs/unpacks as NULL (including nested).
- Objects with `__eq__` matching `None` raise `ValueError` (no silent NULL).
- Value-like stand-in (`__class__` → `bytes`, wraps `None`) still packs as NULL.

Ran locally (with a generated `apiversion.py` stub for import):

```text
test_none_packs_as_null OK
test_eq_none_object_rejected OK
test_value_like_none_still_null OK
flake8 OK on changed files
```

Also verified Value-like non-None bytes still pack identically to real `bytes`, and `compare` with `None` still works.