### PR TITLE
Fix RYW AppendIfFits coalescing under value-size truncation

### DIFF
--- a/fdbclient/RYWIterator.cpp
+++ b/fdbclient/RYWIterator.cpp
@@ -21,6 +21,7 @@
 #include "RYWIterator.h"
 #include "fdbclient/RandomTestUtils.h"
 #include "fdbclient/KeyRangeMap.h"
+#include "fdbclient/Knobs.h"
 #include "flow/UnitTest.h"
 
 const RYWIterator::SEGMENT_TYPE RYWIterator::typeMap[12] = {
@@ -628,6 +629,46 @@ TEST_CASE("/fdbclient/WriteMap/addValue") {
 
 	writes.mutate("apple123"_sr, MutationRef::AddValue, "1"_sr, true);
 	ASSERT(getWriteMapCount(&writes) == 3);
+
+	return Void();
+}
+
+// AppendIfFits is not associative under truncation. Two equal-sized appends must stay
+// on the OperationStack and be applied sequentially against the base value; coalescing
+// the operands first can reject work that would have succeeded one-at-a-time (#13828).
+TEST_CASE("/fdbclient/WriteMap/appendIfFitsNonAssociative") {
+	Arena arena = Arena();
+	const int baseSize = 70000;
+	const int appendSize = 20000;
+	ASSERT(baseSize + appendSize <= CLIENT_KNOBS->VALUE_SIZE_LIMIT);
+	ASSERT(baseSize + 2 * appendSize > CLIENT_KNOBS->VALUE_SIZE_LIMIT);
+
+	ValueRef firstAppend = StringRef(arena, std::string(appendSize, 'b'));
+	ValueRef secondAppend = StringRef(arena, std::string(appendSize, 'b'));
+	ValueRef base = StringRef(arena, std::string(baseSize, 'a'));
+
+	OperationStack stack(RYWMutation(firstAppend, MutationRef::AppendIfFits));
+	WriteMap::coalesceOver(stack, RYWMutation(secondAppend, MutationRef::AppendIfFits), arena);
+	ASSERT(stack.size() == 2);
+	ASSERT(stack.at(0).type == MutationRef::AppendIfFits);
+	ASSERT(stack.at(1).type == MutationRef::AppendIfFits);
+
+	RYWMutation under = WriteMap::coalesceUnder(stack, base, arena);
+	ASSERT(under.type == MutationRef::SetValue);
+	ASSERT(under.value.present());
+	ASSERT(under.value.get().size() == baseSize + appendSize);
+
+	// Dependent writes (no prior SetValue in the transaction): RYW must still yield 90KB.
+	WriteMap writes = WriteMap(&arena);
+	writes.mutate("k"_sr, MutationRef::AppendIfFits, firstAppend, true);
+	writes.mutate("k"_sr, MutationRef::AppendIfFits, secondAppend, true);
+	WriteMap::iterator it(&writes);
+	it.skip("k"_sr);
+	ASSERT(it.is_operation());
+	ASSERT(it.op().size() == 2);
+	RYWMutation visible = WriteMap::coalesceUnder(it.op(), base, arena);
+	ASSERT(visible.value.present());
+	ASSERT(visible.value.get().size() == baseSize + appendSize);
 
 	return Void();
 }

--- a/fdbclient/WriteMap.cpp
+++ b/fdbclient/WriteMap.cpp
@@ -520,8 +520,14 @@ RYWMutation WriteMap::coalesce(RYWMutation existingEntry, RYWMutation newEntry, 
 void WriteMap::coalesceOver(OperationStack& stack, RYWMutation newEntry, Arena& arena) {
 	RYWMutation existingEntry = stack.top();
 	if (existingEntry.type == newEntry.type && newEntry.type != MutationRef::CompareAndClear) {
-		if (isNonAssociativeOp(existingEntry.type) && existingEntry.value.present() &&
-		    existingEntry.value.get().size() != newEntry.value.get().size()) {
+		// AppendIfFits is not associative under truncation: merging operands before the
+		// base value is known can reject appends that would succeed if applied one at a
+		// time (e.g. 70KB base + 20KB + 20KB should yield 90KB when VALUE_SIZE_LIMIT is
+		// 100KB, but a coalesced 40KB operand is rejected against the 70KB base).
+		if (newEntry.type == MutationRef::AppendIfFits) {
+			stack.push(newEntry);
+		} else if (isNonAssociativeOp(existingEntry.type) && existingEntry.value.present() &&
+		           existingEntry.value.get().size() != newEntry.value.get().size()) {
 			stack.push(newEntry);
 		} else {
 			stack.poppush(coalesce(existingEntry, newEntry, arena));

--- a/fdbserver/workloads/AtomicOpsApiCorrectness.cpp
+++ b/fdbserver/workloads/AtomicOpsApiCorrectness.cpp
@@ -131,6 +131,27 @@ public:
 		    });
 		ASSERT(visible.present());
 		ASSERT(visible.get() == full);
+
+		// Regression for #13828: two AppendIfFits against a committed base must be applied
+		// sequentially. Coalescing the operands first truncates incorrectly when each append
+		// alone would fit but the concatenated operand would not.
+		const Value largeBase(std::string(70000, 'a'));
+		const Value chunk(std::string(20000, 'b'));
+		ASSERT(largeBase.size() + chunk.size() <= CLIENT_KNOBS->VALUE_SIZE_LIMIT);
+		ASSERT(largeBase.size() + 2 * chunk.size() > CLIENT_KNOBS->VALUE_SIZE_LIMIT);
+
+		co_await runRYWTransactionVoid(cx, [key, largeBase](Reference<ReadYourWritesTransaction> tr) -> Future<Void> {
+			tr->set(key, largeBase);
+			return Void();
+		});
+		Optional<Value> sequential = co_await runRYWTransaction(
+		    cx, [key, chunk](Reference<ReadYourWritesTransaction> tr) -> Future<Optional<Value>> {
+			    tr->atomicOp(key, chunk, MutationRef::AppendIfFits);
+			    tr->atomicOp(key, chunk, MutationRef::AppendIfFits);
+			    return tr->get(key);
+		    });
+		ASSERT(sequential.present());
+		ASSERT(sequential.get().size() == largeBase.size() + chunk.size());
 	}
 
 	// Test Atomic ops on non existing keys that results in a set


### PR DESCRIPTION
## Problem

Fixes #13828.

`WriteMap::coalesceOver` eagerly merged consecutive `AppendIfFits` operands via `doAppendIfFits`. That is incorrect under truncation: whether an append fits depends on the **current** accumulated value, not on the concatenation of the operands alone.

Repro from the issue (`VALUE_SIZE_LIMIT = 100000`):

- Committed base: 70KB
- Two `append_if_fits` of 20KB each in one RYW transaction
- **Expected** RYW read: 90KB (first append fits; second truncates)
- **Actual** before this fix: 70KB (operands coalesced to 40KB, then `70+40` exceeds the limit so both are dropped)

Same-transaction `set` + two appends already behaved correctly because the first append coalesced into a `SetValue`, so the second saw the true intermediate size.

## Solution

In `WriteMap::coalesceOver`, never merge `AppendIfFits` + `AppendIfFits`. Push the new op onto the `OperationStack` so `coalesceUnder` applies them one at a time against the known base (`SetValue` path of `coalesce`).

Commit packing already iterates the full stack and emits each atomic op separately, so committed behavior stays consistent with RYW reads.

## Testing

Added `/fdbclient/WriteMap/appendIfFitsNonAssociative`:

- Asserts two equal-sized `AppendIfFits` ops remain as stack size 2
- Asserts `coalesceUnder` against a 70KB base yields 90KB
- Asserts the same via `WriteMap::mutate` (dependent-write path)

Extended `AtomicOpsApiCorrectness::testAppendIfFits` with the committed-base + two-chunk RYW regression from the issue report.

Built and ran locally (`fdbclient_test` on macOS arm64):

```text
./bin/fdbclient_test -f "/fdbclient/WriteMap/appendIfFitsNonAssociative"
1 tests passed; 0 tests failed.

./bin/fdbclient_test -f "/fdbclient/WriteMap/"
8 tests passed; 0 tests failed.

./bin/fdbclient_test -f "/Atomic/DoAppendIfFits"
1 tests passed; 0 tests failed.
```