### PR TITLE
Replace legacy explicit receivers with member methods

### DIFF
--- a/fdbbackup/FileConverter.cpp
+++ b/fdbbackup/FileConverter.cpp
@@ -274,28 +274,26 @@ struct MutationFilesReadProgress : public ReferenceCounted<MutationFilesReadProg
 
 	// Requires hasMutations() return true before calling this function.
 	// The caller must hold on the the arena associated with the mutation.
-	Future<VersionedData> getNextMutation() { return getMutationImpl(this); }
+	Future<VersionedData> getNextMutation() {
+		ASSERT(!fileProgress.empty() && !fileProgress[0]->mutations.empty());
 
-	static Future<VersionedData> getMutationImpl(MutationFilesReadProgress* self) {
-		ASSERT(!self->fileProgress.empty() && !self->fileProgress[0]->mutations.empty());
-
-		Reference<FileProgress> fp = self->fileProgress[0];
+		Reference<FileProgress> fp = fileProgress[0];
 		VersionedData data = fp->mutations[0];
 		fp->mutations.erase(fp->mutations.begin());
 		if (fp->mutations.empty()) {
 			// decode one more block
-			co_await decodeToVersion(fp, /*version=*/0, self->endVersion, self->getLogFile(fp->idx));
+			co_await decodeToVersion(fp, /*version=*/0, endVersion, getLogFile(fp->idx));
 		}
 
 		if (fp->empty()) {
-			self->fileProgress.erase(self->fileProgress.begin());
+			fileProgress.erase(fileProgress.begin());
 		} else {
 			// Keep fileProgress sorted
-			for (int i = 1; i < self->fileProgress.size(); i++) {
-				if (*self->fileProgress[i - 1] <= *self->fileProgress[i]) {
+			for (int i = 1; i < fileProgress.size(); i++) {
+				if (*fileProgress[i - 1] <= *fileProgress[i]) {
 					break;
 				}
-				std::swap(self->fileProgress[i - 1], self->fileProgress[i]);
+				std::swap(fileProgress[i - 1], fileProgress[i]);
 			}
 		}
 		co_return data;
@@ -303,12 +301,10 @@ struct MutationFilesReadProgress : public ReferenceCounted<MutationFilesReadProg
 
 	LogFile& getLogFile(int index) { return files[index]; }
 
-	Future<Void> openLogFiles(Reference<IBackupContainer> container) { return openLogFilesImpl(this, container); }
-
 	// Opens log files in the progress and starts decoding until the beginVersion is seen.
-	static Future<Void> openLogFilesImpl(MutationFilesReadProgress* progress, Reference<IBackupContainer> container) {
+	Future<Void> openLogFiles(Reference<IBackupContainer> container) {
 		std::vector<Future<Reference<IAsyncFile>>> asyncFiles;
-		for (const auto& file : progress->files) {
+		for (const auto& file : files) {
 			asyncFiles.push_back(container->readFile(file.fileName));
 		}
 		co_await waitForAll(asyncFiles); // open all files
@@ -317,14 +313,13 @@ struct MutationFilesReadProgress : public ReferenceCounted<MutationFilesReadProg
 		std::vector<Future<Void>> fileDecodes;
 		for (int i = 0; i < asyncFiles.size(); i++) {
 			auto fp = makeReference<FileProgress>(asyncFiles[i].get(), i);
-			progress->fileProgress.push_back(fp);
-			fileDecodes.push_back(
-			    decodeToVersion(fp, progress->beginVersion, progress->endVersion, progress->getLogFile(i)));
+			fileProgress.push_back(fp);
+			fileDecodes.push_back(decodeToVersion(fp, beginVersion, endVersion, getLogFile(i)));
 		}
 
 		co_await waitForAll(fileDecodes);
 
-		progress->sortAndRemoveEmpty();
+		sortAndRemoveEmpty();
 	}
 
 	// Decodes the file until EOF or an mutation >= minVersion and saves these mutations.

--- a/fdbbackup/FileConverter.cpp
+++ b/fdbbackup/FileConverter.cpp
@@ -392,37 +392,35 @@ struct LogFileWriter {
 	}
 
 	// Start a new block if needed, then write the key and value
-	static Future<Void> writeKV_impl(LogFileWriter* self, Key k, Value v) {
+	Future<Void> writeKV(Key k, Value v) {
 		// If key and value do not fit in this block, end it and start a new one
 		int toWrite = sizeof(int32_t) + k.size() + sizeof(int32_t) + v.size();
-		if (self->file->size() + toWrite > self->blockEnd) {
+		if (file->size() + toWrite > blockEnd) {
 			// Write padding if needed
-			int bytesLeft = self->blockEnd - self->file->size();
+			int bytesLeft = blockEnd - file->size();
 			if (bytesLeft > 0) {
 				Value paddingFFs = fileBackup::makePadding(bytesLeft);
-				co_await self->file->append(paddingFFs.begin(), bytesLeft);
+				co_await file->append(paddingFFs.begin(), bytesLeft);
 			}
 
 			// Set new blockEnd
-			self->blockEnd += self->blockSize;
+			blockEnd += blockSize;
 
 			// write Header
-			co_await self->file->append((uint8_t*)&BACKUP_AGENT_MLOG_VERSION, sizeof(BACKUP_AGENT_MLOG_VERSION));
+			co_await file->append((uint8_t*)&BACKUP_AGENT_MLOG_VERSION, sizeof(BACKUP_AGENT_MLOG_VERSION));
 		}
 
-		co_await self->file->appendStringRefWithLen(k);
-		co_await self->file->appendStringRefWithLen(v);
+		co_await file->appendStringRefWithLen(k);
+		co_await file->appendStringRefWithLen(v);
 
 		// At this point we should be in whatever the current block is or the block size is too small
-		if (self->file->size() > self->blockEnd)
+		if (file->size() > blockEnd)
 			throw backup_bad_block_size();
 	}
 
-	Future<Void> writeKV(Key k, Value v) { return writeKV_impl(this, k, v); }
-
 	// Adds a new mutation to an internal buffer and writes out when encountering
 	// a new commitVersion or exceeding the block size.
-	static Future<Void> addMutation(LogFileWriter* self, Version commitVersion, MutationListRef mutations) {
+	Future<Void> addMutation(Version commitVersion, MutationListRef mutations) {
 		Standalone<StringRef> value = BinaryWriter::toValue(mutations, IncludeVersion());
 
 		int part = 0;
@@ -431,7 +429,7 @@ struct LogFileWriter {
 			    part * CLIENT_KNOBS->MUTATION_BLOCK_SIZE,
 			    std::min(value.size() - part * CLIENT_KNOBS->MUTATION_BLOCK_SIZE, CLIENT_KNOBS->MUTATION_BLOCK_SIZE));
 			Standalone<StringRef> key = getBlockKey(commitVersion, part);
-			co_await writeKV_impl(self, key, partBuf);
+			co_await writeKV(key, partBuf);
 		}
 	}
 
@@ -472,7 +470,7 @@ Future<Void> convert(ConvertParams params) {
 
 		// emit a mutation batch to file when encounter a new version
 		if (list.totalSize() > 0 && version != data.version.version) {
-			co_await LogFileWriter::addMutation(&logFile, version, list);
+			co_await logFile.addMutation(version, list);
 			list = MutationList();
 			arena = Arena();
 		}
@@ -487,7 +485,7 @@ Future<Void> convert(ConvertParams params) {
 		version = data.version.version;
 	}
 	if (list.totalSize() > 0) {
-		co_await LogFileWriter::addMutation(&logFile, version, list);
+		co_await logFile.addMutation(version, list);
 	}
 
 	co_await outFile->finish();

--- a/fdbbackup/FileDecoder.cpp
+++ b/fdbbackup/FileDecoder.cpp
@@ -277,7 +277,7 @@ std::vector<std::string> parsePrefixesLine(const std::string& line, bool& err) {
 }
 
 std::vector<std::string> parsePrefixFile(const std::string& filename, bool& err) {
-	std::string line = readFileBytes(filename, 64 * 1024 * 1024);
+	std::string line = readFileBytes(filename, size_t{ 64 } * 1024 * 1024);
 	return parsePrefixesLine(line, err);
 }
 
@@ -688,7 +688,7 @@ public:
 // convert a StringRef to Hex string
 std::string hexStringRef(const StringRef& s) {
 	std::string result;
-	result.reserve(s.size() * 2);
+	result.reserve(static_cast<size_t>(s.size()) * 2);
 	for (int i = 0; i < s.size(); i++) {
 		result.append(format("%02x", s[i]));
 	}

--- a/fdbbackup/FileDecoder.cpp
+++ b/fdbbackup/FileDecoder.cpp
@@ -505,7 +505,38 @@ public:
 	}
 
 	// Open and loads file into memory
-	Future<Void> openFile(Reference<IBackupContainer> container) { return openFileImpl(this, container); }
+	Future<Void> openFile(Reference<IBackupContainer> container) {
+		fd = co_await container->readFile(file.fileName);
+		Standalone<StringRef> buf = makeString(file.fileSize);
+		int rLen = co_await fd->read(mutateString(buf), file.fileSize, 0);
+		if (rLen != file.fileSize) {
+			throw restore_bad_read();
+		}
+
+		if (save) {
+			std::string dir = file.fileName;
+			std::size_t found = file.fileName.find_last_of('/');
+			if (found != std::string::npos) {
+				std::string path = file.fileName.substr(0, found);
+				if (!directoryExists(path)) {
+					platform::createDirectory(path);
+				}
+			}
+			lfd = open(file.fileName.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+			if (lfd == -1) {
+				TraceEvent(SevError, "OpenLocalFileFailed").detail("File", file.fileName);
+				throw platform_error();
+			}
+			int wlen = write(lfd, buf.begin(), file.fileSize);
+			if (wlen != file.fileSize) {
+				TraceEvent(SevError, "WriteLocalFileFailed").detail("File", file.fileName).detail("Len", file.fileSize);
+				throw platform_error();
+			}
+			TraceEvent("WriteLocalFile").detail("Name", file.fileName).detail("Len", file.fileSize);
+		}
+
+		decodeFile(buf);
+	}
 
 	// The following are private APIs:
 
@@ -530,41 +561,6 @@ public:
 			TraceEvent(SevWarn, "UnfishedBlocks").detail("NumberOfVersions", mutationBlocksByVersion.size());
 		}
 		return Optional<VersionedMutations>();
-	}
-
-	static Future<Void> openFileImpl(DecodeProgress* self, Reference<IBackupContainer> container) {
-		self->fd = co_await container->readFile(self->file.fileName);
-		Standalone<StringRef> buf = makeString(self->file.fileSize);
-		int rLen = co_await self->fd->read(mutateString(buf), self->file.fileSize, 0);
-		if (rLen != self->file.fileSize) {
-			throw restore_bad_read();
-		}
-
-		if (self->save) {
-			std::string dir = self->file.fileName;
-			std::size_t found = self->file.fileName.find_last_of('/');
-			if (found != std::string::npos) {
-				std::string path = self->file.fileName.substr(0, found);
-				if (!directoryExists(path)) {
-					platform::createDirectory(path);
-				}
-			}
-			self->lfd = open(self->file.fileName.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
-			if (self->lfd == -1) {
-				TraceEvent(SevError, "OpenLocalFileFailed").detail("File", self->file.fileName);
-				throw platform_error();
-			}
-			int wlen = write(self->lfd, buf.begin(), self->file.fileSize);
-			if (wlen != self->file.fileSize) {
-				TraceEvent(SevError, "WriteLocalFileFailed")
-				    .detail("File", self->file.fileName)
-				    .detail("Len", self->file.fileSize);
-				throw platform_error();
-			}
-			TraceEvent("WriteLocalFile").detail("Name", self->file.fileName).detail("Len", self->file.fileSize);
-		}
-
-		self->decodeFile(buf);
 	}
 
 	// Add chunks to mutationBlocksByVersion

--- a/fdbbackup/FileDecoder.cpp
+++ b/fdbbackup/FileDecoder.cpp
@@ -618,44 +618,40 @@ public:
 	}
 
 	// Open and loads file into memory
-	Future<Void> openFile(Reference<IBackupContainer> container) { return openFileImpl(this, container); }
+	Future<Void> openFile(Reference<IBackupContainer> container) {
+		TraceEvent("ReadFile").detail("Name", file.fileName).detail("Len", file.fileSize);
 
-	static Future<Void> openFileImpl(DecodeRangeProgress* self, Reference<IBackupContainer> container) {
-		TraceEvent("ReadFile").detail("Name", self->file.fileName).detail("Len", self->file.fileSize);
-
-		self->fd = co_await container->readFile(self->file.fileName);
-		Standalone<StringRef> buf = makeString(self->file.fileSize);
-		int rLen = co_await self->fd->read(mutateString(buf), self->file.fileSize, 0);
-		if (rLen != self->file.fileSize) {
+		fd = co_await container->readFile(file.fileName);
+		Standalone<StringRef> buf = makeString(file.fileSize);
+		int rLen = co_await fd->read(mutateString(buf), file.fileSize, 0);
+		if (rLen != file.fileSize) {
 			throw restore_bad_read();
 		}
 
-		if (self->save) {
-			std::string dir = self->file.fileName;
-			std::size_t found = self->file.fileName.find_last_of('/');
+		if (save) {
+			std::string dir = file.fileName;
+			std::size_t found = file.fileName.find_last_of('/');
 			if (found != std::string::npos) {
-				std::string path = self->file.fileName.substr(0, found);
+				std::string path = file.fileName.substr(0, found);
 				if (!directoryExists(path)) {
 					platform::createDirectory(path);
 				}
 			}
 
-			self->lfd = open(self->file.fileName.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
-			if (self->lfd == -1) {
-				TraceEvent(SevError, "OpenLocalFileFailed").detail("File", self->file.fileName);
+			lfd = open(file.fileName.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+			if (lfd == -1) {
+				TraceEvent(SevError, "OpenLocalFileFailed").detail("File", file.fileName);
 				throw platform_error();
 			}
-			int wlen = write(self->lfd, buf.begin(), self->file.fileSize);
-			if (wlen != self->file.fileSize) {
-				TraceEvent(SevError, "WriteLocalFileFailed")
-				    .detail("File", self->file.fileName)
-				    .detail("Len", self->file.fileSize);
+			int wlen = write(lfd, buf.begin(), file.fileSize);
+			if (wlen != file.fileSize) {
+				TraceEvent(SevError, "WriteLocalFileFailed").detail("File", file.fileName).detail("Len", file.fileSize);
 				throw platform_error();
 			}
-			TraceEvent("WriteLocalFile").detail("Name", self->file.fileName).detail("Len", self->file.fileSize);
+			TraceEvent("WriteLocalFile").detail("Name", file.fileName).detail("Len", file.fileSize);
 		}
 
-		self->decodeFile(buf);
+		decodeFile(buf);
 	}
 
 	// Reads a file content in the buffer, decodes it into key/value pairs, and stores these pairs.

--- a/fdbclient/AsyncFileBlobStore.h
+++ b/fdbclient/AsyncFileBlobStore.h
@@ -125,7 +125,7 @@ public:
 			data = (const uint8_t*)data + finishlen;
 
 			// End current part (and start new one)
-			co_await f->endCurrentPart(f.getPtr(), true);
+			co_await f->endCurrentPart(true);
 			p = f->m_parts.back().getPtr();
 		}
 
@@ -147,33 +147,33 @@ public:
 		return Void();
 	}
 
-	static Future<std::string> doPartUpload(AsyncFileBlobStoreWrite* f, Part* p) {
+	Future<std::string> doPartUpload(Part* p) {
 		p->finalizeChecksum();
-		std::string upload_id = co_await f->getUploadID();
-		std::string etag = co_await f->m_bstore->uploadPart(
-		    f->m_bucket, f->m_object, upload_id, p->number, &p->content, p->length, p->checksumString);
+		std::string upload_id = co_await getUploadID();
+		std::string etag = co_await m_bstore->uploadPart(
+		    m_bucket, m_object, upload_id, p->number, &p->content, p->length, p->checksumString);
 		co_return etag;
 	}
 
-	static Future<Void> doFinishUpload(AsyncFileBlobStoreWrite* f) {
+	Future<Void> doFinishUpload() {
 		// If there is only 1 part then it has not yet been uploaded so just write the whole file at once.
-		if (f->m_parts.size() == 1) {
-			Reference<Part> part = f->m_parts.back();
+		if (m_parts.size() == 1) {
+			Reference<Part> part = m_parts.back();
 			part->finalizeChecksum();
-			co_await f->m_bstore->writeEntireFileFromBuffer(
-			    f->m_bucket, f->m_object, &part->content, part->length, part->checksumString);
+			co_await m_bstore->writeEntireFileFromBuffer(
+			    m_bucket, m_object, &part->content, part->length, part->checksumString);
 			co_return;
 		}
 
 		// There are at least 2 parts.  End the last part (which could be empty)
-		co_await f->endCurrentPart(f);
+		co_await endCurrentPart();
 
 		IBlobStoreEndpoint::MultiPartSetT partSet;
 		std::vector<Reference<Part>>::iterator p;
 
 		// Wait for all the parts to be done to get their ETags, populate the partSet required to finish the object
 		// upload.
-		for (p = f->m_parts.begin(); p != f->m_parts.end(); ++p) {
+		for (p = m_parts.begin(); p != m_parts.end(); ++p) {
 			std::string tag = co_await (*p)->etag;
 			if ((*p)->length > 0) { // The last part might be empty and has to be omitted.
 				partSet[(*p)->number] = IBlobStoreEndpoint::PartInfo(tag, (*p)->checksumString);
@@ -182,14 +182,14 @@ public:
 
 		// No need to wait for the upload ID here because the above loop waited for all the parts and each part required
 		// the upload ID so it is ready
-		Optional<std::string> checksumSHA256 = co_await f->m_bstore->finishMultiPartUpload(
-		    f->m_bucket, f->m_object, f->m_upload_id.get(), partSet, f->m_cursor);
+		Optional<std::string> checksumSHA256 =
+		    co_await m_bstore->finishMultiPartUpload(m_bucket, m_object, m_upload_id.get(), partSet, m_cursor);
 
 		// Log the checksum if present - this is just a hash of the multipart structure, not the object content
 		if (checksumSHA256.present()) {
 			TraceEvent(SevDebug, "AsyncFileBlobStoreMultipartUploadChecksum")
-			    .detail("Bucket", f->m_bucket)
-			    .detail("Object", f->m_object)
+			    .detail("Bucket", m_bucket)
+			    .detail("Object", m_object)
 			    .detail("ChecksumSHA256", checksumSHA256.get())
 			    .detail("Note", "This is a hash of the multipart structure, not object content");
 		}
@@ -199,7 +199,7 @@ public:
 	Future<Void> sync() override {
 		// Only initiate the finish operation once, and also prevent further writing.
 		if (!m_finished.isValid()) {
-			m_finished = doFinishUpload(this);
+			m_finished = doFinishUpload();
 			m_cursor = -1; // Cause future write attempts to fail
 		}
 
@@ -247,24 +247,23 @@ private:
 	FlowLock m_concurrentUploads;
 
 	// End the current part and start uploading it, but also wait for a part to finish if too many are in transit.
-	static Future<Void> endCurrentPart(AsyncFileBlobStoreWrite* f, bool startNew = false) {
-		if (f->m_parts.back()->length == 0)
+	Future<Void> endCurrentPart(bool startNew = false) {
+		if (m_parts.back()->length == 0)
 			co_return;
 
 		// Wait for an upload slot to be available
-		co_await f->m_concurrentUploads.take();
+		co_await m_concurrentUploads.take();
 
 		// Do the upload, and if it fails forward errors to m_error and also stop if anything else sends an error to
 		// m_error Also, hold a releaser for the concurrent upload slot while all that is going on.
-		auto releaser = std::make_shared<FlowLock::Releaser>(f->m_concurrentUploads, 1);
-		f->m_parts.back()->etag =
-		    holdWhile(releaser, joinErrorGroup(doPartUpload(f, f->m_parts.back().getPtr()), f->m_error));
+		auto releaser = std::make_shared<FlowLock::Releaser>(m_concurrentUploads, 1);
+		m_parts.back()->etag = holdWhile(releaser, joinErrorGroup(doPartUpload(m_parts.back().getPtr()), m_error));
 
 		// Make a new part to write to
 		if (startNew) {
-			f->m_parts.push_back(makeReference<Part>(f->m_parts.size() + 1,
-			                                         f->m_bstore->knobs.multipart_min_part_size,
-			                                         f->m_bstore->knobs.enable_object_integrity_check));
+			m_parts.push_back(makeReference<Part>(m_parts.size() + 1,
+			                                      m_bstore->knobs.multipart_min_part_size,
+			                                      m_bstore->knobs.enable_object_integrity_check));
 		}
 	}
 

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -395,18 +395,13 @@ public:
 	KeyBackedBinaryValue<int64_t> bulkLoadTotalTasks() { return configSpace.pack(__FUNCTION__sr); }
 
 	Future<std::vector<KeyRange>> getRestoreRangesOrDefault(Reference<ReadYourWritesTransaction> tr) {
-		return getRestoreRangesOrDefault_impl(this, tr);
-	}
-
-	static Future<std::vector<KeyRange>> getRestoreRangesOrDefault_impl(RestoreConfig* self,
-	                                                                    Reference<ReadYourWritesTransaction> tr) {
 		std::vector<KeyRange> ranges;
 		int batchSize = buggify() ? 1 : CLIENT_KNOBS->RESTORE_RANGES_READ_BATCH;
 		Optional<KeyRange> begin;
 		Arena arena;
 		while (true) {
 			KeyBackedSet<KeyRange>::RangeResultType rangeResult =
-			    co_await self->restoreRangeSet().getRange(tr, begin, {}, batchSize);
+			    co_await restoreRangeSet().getRange(tr, begin, {}, batchSize);
 			ranges.insert(ranges.end(), rangeResult.results.begin(), rangeResult.results.end());
 			if (!rangeResult.more) {
 				break;
@@ -417,10 +412,10 @@ public:
 
 		// fall back to original fields if the new field is empty
 		if (ranges.empty()) {
-			std::vector<KeyRange> _ranges = co_await self->restoreRanges().getD(tr);
+			std::vector<KeyRange> _ranges = co_await restoreRanges().getD(tr);
 			ranges = _ranges;
 			if (ranges.empty()) {
-				KeyRange range = co_await self->restoreRange().getD(tr);
+				KeyRange range = co_await restoreRange().getD(tr);
 				ranges.push_back(range);
 			}
 		}
@@ -571,19 +566,15 @@ public:
 		           });
 	}
 
-	static Future<Version> getCurrentVersion_impl(RestoreConfig* self, Reference<ReadYourWritesTransaction> tr) {
-		ERestoreState status = co_await self->stateEnum().getD(tr);
+	Future<Version> getCurrentVersion(Reference<ReadYourWritesTransaction> tr) {
+		ERestoreState status = co_await stateEnum().getD(tr);
 		Version version = -1;
 		if (status == ERestoreState::RUNNING) {
-			version = co_await self->getApplyBeginVersion(tr);
+			version = co_await getApplyBeginVersion(tr);
 		} else if (status == ERestoreState::COMPLETED) {
-			version = co_await self->restoreVersion().getD(tr);
+			version = co_await restoreVersion().getD(tr);
 		}
 		co_return version;
-	}
-
-	Future<Version> getCurrentVersion(Reference<ReadYourWritesTransaction> tr) {
-		return getCurrentVersion_impl(this, tr);
 	}
 
 	static Future<std::string> getProgress_impl(RestoreConfig restore, Reference<ReadYourWritesTransaction> tr);

--- a/fdbclient/include/fdbclient/HighContentionPrefixAllocator.h
+++ b/fdbclient/include/fdbclient/HighContentionPrefixAllocator.h
@@ -32,52 +32,32 @@ public:
 
 	template <class TransactionT>
 	Future<Standalone<StringRef>> allocate(Reference<TransactionT> tr) {
-		return allocate(this, tr);
-	}
-
-	static int64_t windowSize(int64_t start) {
-		if (start < 255) {
-			return 64;
-		}
-		if (start < 65535) {
-			return 1024;
-		}
-
-		return 8192;
-	}
-
-private:
-	Subspace counters;
-	Subspace recent;
-
-	template <class TransactionT>
-	Future<Standalone<StringRef>> allocate(HighContentionPrefixAllocator* self, Reference<TransactionT> tr) {
 		int64_t start = 0;
 		int64_t window = 0;
 
 		while (true) {
 			typename TransactionT::template FutureT<RangeResult> rangeFuture =
-			    tr->getRange(self->counters.range(), 1, Snapshot::True, Reverse::True);
+			    tr->getRange(counters.range(), 1, Snapshot::True, Reverse::True);
 			RangeResult range = co_await safeThreadFutureToFuture(rangeFuture);
 
 			if (!range.empty()) {
-				start = self->counters.unpack(range[0].key).getInt(0);
+				start = counters.unpack(range[0].key).getInt(0);
 			}
 
 			bool windowAdvanced = false;
 			while (true) {
 				// if thread safety is needed, this should be locked {
 				if (windowAdvanced) {
-					tr->clear(KeyRangeRef(self->counters.key(), self->counters.get(start).key()));
+					tr->clear(KeyRangeRef(counters.key(), counters.get(start).key()));
 					tr->setOption(FDBTransactionOptions::NEXT_WRITE_NO_WRITE_CONFLICT_RANGE);
-					tr->clear(KeyRangeRef(self->recent.key(), self->recent.get(start).key()));
+					tr->clear(KeyRangeRef(recent.key(), recent.get(start).key()));
 				}
 
 				int64_t inc = 1;
-				tr->atomicOp(self->counters.get(start).key(), StringRef((uint8_t*)&inc, 8), MutationRef::AddValue);
+				tr->atomicOp(counters.get(start).key(), StringRef((uint8_t*)&inc, 8), MutationRef::AddValue);
 
 				typename TransactionT::template FutureT<Optional<Value>> countFuture =
-				    tr->get(self->counters.get(start).key(), Snapshot::True);
+				    tr->get(counters.get(start).key(), Snapshot::True);
 				// }
 
 				Optional<Value> countValue = co_await safeThreadFutureToFuture(countFuture);
@@ -104,11 +84,11 @@ private:
 
 				// if thread safety is needed, this should be locked {
 				typename TransactionT::template FutureT<RangeResult> latestCounterFuture =
-				    tr->getRange(self->counters.range(), 1, Snapshot::True, Reverse::True);
+				    tr->getRange(counters.range(), 1, Snapshot::True, Reverse::True);
 				typename TransactionT::template FutureT<Optional<Value>> candidateValueFuture =
-				    tr->get(self->recent.get(candidate).key());
+				    tr->get(recent.get(candidate).key());
 				tr->setOption(FDBTransactionOptions::NEXT_WRITE_NO_WRITE_CONFLICT_RANGE);
-				tr->set(self->recent.get(candidate).key(), ValueRef());
+				tr->set(recent.get(candidate).key(), ValueRef());
 				// }
 
 				co_await (success(safeThreadFutureToFuture(latestCounterFuture)) &&
@@ -116,7 +96,7 @@ private:
 
 				int64_t currentWindowStart = 0;
 				if (latestCounterFuture.get().size() > 0) {
-					currentWindowStart = self->counters.unpack(latestCounterFuture.get()[0].key).getInt(0);
+					currentWindowStart = counters.unpack(latestCounterFuture.get()[0].key).getInt(0);
 				}
 
 				if (currentWindowStart > start) {
@@ -124,10 +104,25 @@ private:
 				}
 
 				if (!candidateValueFuture.get().present()) {
-					tr->addWriteConflictRange(singleKeyRange(self->recent.get(candidate).key()));
+					tr->addWriteConflictRange(singleKeyRange(recent.get(candidate).key()));
 					co_return Tuple::makeTuple(candidate).pack();
 				}
 			}
 		}
 	}
+
+	static int64_t windowSize(int64_t start) {
+		if (start < 255) {
+			return 64;
+		}
+		if (start < 65535) {
+			return 1024;
+		}
+
+		return 8192;
+	}
+
+private:
+	Subspace counters;
+	Subspace recent;
 };

--- a/fdbrpc/AsyncFileCached.cpp
+++ b/fdbrpc/AsyncFileCached.cpp
@@ -84,34 +84,33 @@ Future<Reference<IAsyncFile>> AsyncFileCached::open_impl(std::string filename, i
 }
 
 template <bool writing>
-Future<Void> AsyncFileCached::read_write_impl(AsyncFileCached* self,
-                                              typename std::conditional_t<writing, const uint8_t*, uint8_t*> data,
+Future<Void> AsyncFileCached::read_write_impl(typename std::conditional_t<writing, const uint8_t*, uint8_t*> data,
                                               int length,
                                               int64_t offset) {
 	if constexpr (writing) {
-		if (offset + length > self->length)
-			self->length = offset + length;
+		if (offset + length > this->length)
+			this->length = offset + length;
 	}
 
 	std::vector<Future<Void>> actors;
 
-	int offsetInPage = offset % self->pageCache->pageSize;
+	int offsetInPage = offset % pageCache->pageSize;
 	int64_t pageOffset = offset - offsetInPage;
 
 	int remaining = length;
 
 	while (remaining) {
-		++self->countFileCacheFinds;
-		++self->countCacheFinds;
-		auto p = self->pages.find(pageOffset);
-		if (p == self->pages.end()) {
-			AFCPage* page = new AFCPage(self, pageOffset);
-			p = self->pages.insert(std::make_pair(pageOffset, page)).first;
+		++countFileCacheFinds;
+		++countCacheFinds;
+		auto p = pages.find(pageOffset);
+		if (p == pages.end()) {
+			AFCPage* page = new AFCPage(this, pageOffset);
+			p = pages.insert(std::make_pair(pageOffset, page)).first;
 		} else {
-			self->pageCache->updateHit(p->second);
+			pageCache->updateHit(p->second);
 		}
 
-		int bytesInPage = std::min(self->pageCache->pageSize - offsetInPage, remaining);
+		int bytesInPage = std::min(pageCache->pageSize - offsetInPage, remaining);
 
 		Future<Void> w;
 		if constexpr (writing) {
@@ -123,7 +122,7 @@ Future<Void> AsyncFileCached::read_write_impl(AsyncFileCached* self,
 			actors.push_back(w);
 
 		data += bytesInPage;
-		pageOffset += self->pageCache->pageSize;
+		pageOffset += pageCache->pageSize;
 		offsetInPage = 0;
 
 		remaining -= bytesInPage;
@@ -131,7 +130,7 @@ Future<Void> AsyncFileCached::read_write_impl(AsyncFileCached* self,
 
 	// This is susceptible to the introduction of waits on the read/write path: no wait can occur prior to
 	// AFCPage::readThrough or prevLength will be set prematurely
-	self->prevLength = self->length;
+	prevLength = this->length;
 
 	return waitForAll(actors);
 }

--- a/fdbrpc/include/fdbrpc/AsyncFileCached.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileCached.h
@@ -164,7 +164,7 @@ public:
 			length = int(this->length - offset);
 			ASSERT(length >= 0);
 		}
-		auto f = read_write_impl<false>(this, static_cast<uint8_t*>(data), length, offset);
+		auto f = read_write_impl<false>(static_cast<uint8_t*>(data), length, offset);
 		if (f.isReady() && !f.isError())
 			return length;
 		++countFileCacheReadsBlocked;
@@ -172,48 +172,41 @@ public:
 		return tag(f, length);
 	}
 
-	static Future<Void> write_impl(AsyncFileCached* self, void const* data, int length, int64_t offset) {
+	Future<Void> write(void const* data, int length, int64_t offset) override {
 		// If there is a truncate in progress before the the write position then we must
 		// wait for it to complete.
-		if (length + offset > self->currentTruncateSize) {
-			Future<Void> currentTruncate = self->currentTruncate;
+		if (length + offset > currentTruncateSize) {
+			Future<Void> currentTruncate = this->currentTruncate;
 			co_await currentTruncate;
 		}
-		++self->countFileCacheWrites;
-		++self->countCacheWrites;
-		Future<Void> f = read_write_impl<true>(self, static_cast<const uint8_t*>(data), length, offset);
+		++countFileCacheWrites;
+		++countCacheWrites;
+		Future<Void> f = read_write_impl<true>(static_cast<const uint8_t*>(data), length, offset);
 		if (!f.isReady()) {
-			++self->countFileCacheWritesBlocked;
-			++self->countCacheWritesBlocked;
+			++countFileCacheWritesBlocked;
+			++countCacheWritesBlocked;
 		}
 		co_await f;
-	}
-
-	Future<Void> write(void const* data, int length, int64_t offset) override {
-		return write_impl(this, data, length, offset);
 	}
 
 	Future<Void> readZeroCopy(void** data, int* length, int64_t offset) override;
 	void releaseZeroCopy(void* data, int length, int64_t offset) override;
 
-	// This waits for previously started truncates to finish and then truncates
-	Future<Void> truncate(int64_t size) override { return truncate_impl(this, size); }
+	// This wrapper for the actual truncation operation enforces ordering of truncates.
+	// It maintains currentTruncate and currentTruncateSize so writers can wait behind truncates that would affect them.
+	Future<Void> truncate(int64_t size) override {
+		Future<Void> previousTruncate = currentTruncate;
+		co_await previousTruncate;
+		currentTruncateSize = size;
+		currentTruncate = changeFileSize(size);
+		Future<Void> currentTruncate = this->currentTruncate;
+		co_await currentTruncate;
+	}
 
 	// This is the 'real' truncate that does the actual removal of cache blocks and then shortens the file
 	Future<Void> changeFileSize(int64_t size);
 
-	// This wrapper for the actual truncation operation enforces ordering of truncates.
-	// It maintains currentTruncate and currentTruncateSize so writers can wait behind truncates that would affect them.
-	static Future<Void> truncate_impl(AsyncFileCached* self, int64_t size) {
-		Future<Void> previousTruncate = self->currentTruncate;
-		co_await previousTruncate;
-		self->currentTruncateSize = size;
-		self->currentTruncate = self->changeFileSize(size);
-		Future<Void> currentTruncate = self->currentTruncate;
-		co_await currentTruncate;
-	}
-
-	Future<Void> sync() override { return waitAndSync(this, flush()); }
+	Future<Void> sync() override { return waitAndSync(flush()); }
 
 	Future<int64_t> size() const override { return length; }
 
@@ -353,16 +346,15 @@ private:
 
 	Future<Void> quiesce();
 
-	static Future<Void> waitAndSync(AsyncFileCached* self, Future<Void> flush) {
+	Future<Void> waitAndSync(Future<Void> flush) {
 		co_await flush;
-		co_await self->uncached->sync();
+		co_await uncached->sync();
 	}
 
 	template <bool writing>
-	static Future<Void> read_write_impl(AsyncFileCached* self,
-	                                    typename std::conditional_t<writing, const uint8_t*, uint8_t*> data,
-	                                    int length,
-	                                    int64_t offset);
+	Future<Void> read_write_impl(typename std::conditional_t<writing, const uint8_t*, uint8_t*> data,
+	                             int length,
+	                             int64_t offset);
 
 	void remove_page(AFCPage* page);
 };

--- a/fdbrpc/include/fdbrpc/AsyncFileCached.h
+++ b/fdbrpc/include/fdbrpc/AsyncFileCached.h
@@ -410,18 +410,18 @@ struct AFCPage : public EvictablePage, public FastAllocated<AFCPage> {
 
 		// If data is not valid but no read is in progress, start reading
 		if (notReading.isReady()) {
-			notReading = readThrough(this);
+			notReading = readThrough();
 		}
 
-		notReading = waitAndWrite(this, data, length, offset);
+		notReading = waitAndWrite(data, length, offset);
 
 		return notReading;
 	}
 
-	static Future<Void> waitAndWrite(AFCPage* self, void const* data, int length, int offset) {
-		Future<Void> notReading = self->notReading;
+	Future<Void> waitAndWrite(void const* data, int length, int offset) {
+		Future<Void> notReading = this->notReading;
 		co_await notReading;
-		memcpy(static_cast<uint8_t*>(self->data) + offset, data, length);
+		memcpy(static_cast<uint8_t*>(this->data) + offset, data, length);
 	}
 
 	Future<Void> readZeroCopy() {
@@ -436,7 +436,7 @@ struct AFCPage : public EvictablePage, public FastAllocated<AFCPage> {
 		++owner->countCachePageReadsMissed;
 
 		if (notReading.isReady()) {
-			notReading = readThrough(this);
+			notReading = readThrough();
 		} else {
 			++owner->countFileCachePageReadsMerged;
 			++owner->countCachePageReadsMerged;
@@ -463,94 +463,94 @@ struct AFCPage : public EvictablePage, public FastAllocated<AFCPage> {
 		++owner->countCachePageReadsMissed;
 
 		if (notReading.isReady()) {
-			notReading = readThrough(this);
+			notReading = readThrough();
 		} else {
 			++owner->countFileCachePageReadsMerged;
 			++owner->countCachePageReadsMerged;
 		}
 
-		notReading = waitAndRead(this, data, length, offset);
+		notReading = waitAndRead(data, length, offset);
 
 		return notReading;
 	}
 
-	static Future<Void> waitAndRead(AFCPage* self, void* data, int length, int offset) {
-		Future<Void> notReading = self->notReading;
+	Future<Void> waitAndRead(void* data, int length, int offset) {
+		Future<Void> notReading = this->notReading;
 		co_await notReading;
-		memcpy(data, static_cast<uint8_t const*>(self->data) + offset, length);
+		memcpy(data, static_cast<uint8_t const*>(this->data) + offset, length);
 	}
 
-	static Future<Void> readThrough(AFCPage* self) {
-		ASSERT(!self->valid);
-		void* dst = self->data;
-		if (self->pageOffset < self->owner->prevLength) {
+	Future<Void> readThrough() {
+		ASSERT(!valid);
+		void* dst = data;
+		if (pageOffset < owner->prevLength) {
 			try {
-				int _ = co_await self->owner->uncached->read(dst, self->pageCache->pageSize, self->pageOffset);
-				if (_ != self->pageCache->pageSize) {
+				int _ = co_await owner->uncached->read(dst, pageCache->pageSize, pageOffset);
+				if (_ != pageCache->pageSize) {
 					TraceEvent("ReadThroughShortRead")
 					    .detail("ReadAmount", _)
-					    .detail("PageSize", self->pageCache->pageSize)
-					    .detail("PageOffset", self->pageOffset);
+					    .detail("PageSize", pageCache->pageSize)
+					    .detail("PageOffset", pageOffset);
 				}
 			} catch (Error& e) {
-				self->zeroCopyRefCount = 0;
+				zeroCopyRefCount = 0;
 				TraceEvent("ReadThroughFailed").error(e);
 				throw;
 			}
 		}
 		// If the memory we read into wasn't orphaned while we were waiting on the read then set valid to true
-		if (dst == self->data)
-			self->valid = true;
+		if (dst == data)
+			valid = true;
 	}
 
-	static Future<Void> writeThrough(AFCPage* self, Promise<Void> writing) {
+	Future<Void> writeThrough(Promise<Void> writing) {
 		// writeThrough can be called on a page that is not dirty, just to wait for a previous writeThrough to finish.
 		// In that case we don't want to do any disk I/O
 		try {
-			bool dirty = self->dirty;
-			++self->writeThroughCount;
-			self->updateFlushableIndex();
+			bool dirty = this->dirty;
+			++writeThroughCount;
+			updateFlushableIndex();
 
-			Future<Void> readyToWrite = self->notReading && self->notFlushing;
+			Future<Void> readyToWrite = notReading && notFlushing;
 			co_await readyToWrite;
 
 			if (dirty) {
 				// Wait for rate control if it is set
-				if (self->owner->getRateControl()) {
+				if (owner->getRateControl()) {
 					int allowance = 1;
 					// If I/O size is defined, wait for the calculated I/O quota
 					if (FLOW_KNOBS->FLOW_CACHEDFILE_WRITE_IO_SIZE > 0) {
-						allowance = (self->pageCache->pageSize + FLOW_KNOBS->FLOW_CACHEDFILE_WRITE_IO_SIZE - 1) /
+						allowance = (pageCache->pageSize + FLOW_KNOBS->FLOW_CACHEDFILE_WRITE_IO_SIZE - 1) /
 						            FLOW_KNOBS->FLOW_CACHEDFILE_WRITE_IO_SIZE; // round up
 						ASSERT(allowance > 0);
 					}
-					co_await self->owner->getRateControl()->getAllowance(allowance);
+					co_await owner->getRateControl()->getAllowance(allowance);
 				}
 
-				if (self->pageOffset + self->pageCache->pageSize > self->owner->length) {
-					ASSERT(self->pageOffset < self->owner->length);
-					memset(static_cast<uint8_t*>(self->data) + self->owner->length - self->pageOffset,
+				if (pageOffset + pageCache->pageSize > owner->length) {
+					ASSERT(pageOffset < owner->length);
+					memset(static_cast<uint8_t*>(data) + owner->length - pageOffset,
 					       0,
-					       self->pageCache->pageSize - (self->owner->length - self->pageOffset));
+					       pageCache->pageSize - (owner->length - pageOffset));
 				}
 
-				auto f = self->owner->uncached->write(self->data, self->pageCache->pageSize, self->pageOffset);
+				auto f = owner->uncached->write(data, pageCache->pageSize, pageOffset);
 
 				co_await f;
 			}
 		} catch (Error& e) {
-			--self->writeThroughCount;
-			self->setDirty();
+			--writeThroughCount;
+			setDirty();
 			writing.sendError(e);
 			throw;
 		}
-		--self->writeThroughCount;
-		self->updateFlushableIndex();
+		--writeThroughCount;
+		updateFlushableIndex();
 
 		writing.send(Void()); // FIXME: This could happen before the wait if AsyncFileKAIO dealt properly with
 		                      // overlapping write and sync operations
 
-		self->pageCache->try_evict();
+		pageCache->try_evict();
 	}
 
 	Future<Void> flush() {
@@ -561,7 +561,7 @@ struct AFCPage : public EvictablePage, public FastAllocated<AFCPage> {
 
 		Promise<Void> writing;
 
-		notFlushing = writeThrough(this, writing);
+		notFlushing = writeThrough(writing);
 
 		clearDirty(); // Do this last so that if writeThrough immediately calls try_evict, we can't be evicted before
 		              // assigning notFlushing
@@ -590,13 +590,13 @@ struct AFCPage : public EvictablePage, public FastAllocated<AFCPage> {
 		if (zeroCopyRefCount != 0)
 			orphan();
 		truncated = true;
-		return truncate_impl(this);
+		return truncate_impl();
 	}
 
-	static Future<Void> truncate_impl(AFCPage* self) {
-		Future<Void> readyToTruncate = self->notReading && self->notFlushing && yield();
+	Future<Void> truncate_impl() {
+		Future<Void> readyToTruncate = notReading && notFlushing && yield();
 		co_await readyToTruncate;
-		delete self;
+		delete this;
 	}
 
 	AFCPage(AsyncFileCached* owner, int64_t offset)

--- a/fdbserver/coordinator/Coordination.cpp
+++ b/fdbserver/coordinator/Coordination.cpp
@@ -581,10 +581,10 @@ struct LeaderRegisterCollection {
 
 	explicit LeaderRegisterCollection(OnDemandStore* pStore) : actors(false), pStore(pStore) {}
 
-	static Future<Void> init(LeaderRegisterCollection* self) {
-		if (!self->pStore->exists())
+	Future<Void> init() {
+		if (!pStore->exists())
 			co_return;
-		OnDemandStore& store = *self->pStore;
+		OnDemandStore& store = *pStore;
 		Future<Standalone<RangeResultRef>> forwardingInfoF = store->readRange(fwdKeys);
 		Future<Standalone<RangeResultRef>> forwardingTimeF = store->readRange(fwdTimeKeys);
 		co_await (success(forwardingInfoF) && success(forwardingTimeF));
@@ -594,11 +594,11 @@ struct LeaderRegisterCollection {
 			LeaderInfo forwardInfo;
 			forwardInfo.forward = true;
 			forwardInfo.serializedInfo = forwardingInfo[i].value;
-			self->forward[forwardingInfo[i].key.removePrefix(fwdKeys.begin)] = forwardInfo;
+			forward[forwardingInfo[i].key.removePrefix(fwdKeys.begin)] = forwardInfo;
 		}
 		for (int i = 0; i < forwardingTime.size(); i++) {
 			double time = BinaryReader::fromStringRef<double>(forwardingTime[i].value, Unversioned());
-			self->forwardStartTime[forwardingTime[i].key.removePrefix(fwdTimeKeys.begin)] = time;
+			forwardStartTime[forwardingTime[i].key.removePrefix(fwdTimeKeys.begin)] = time;
 		}
 	}
 
@@ -626,31 +626,26 @@ struct LeaderRegisterCollection {
 	// When the lead coordinator changes, store the new connection ID in the "fwd" keyspace.
 	// If a request arrives using an old connection id, resend it to the new coordinator using the stored connection id.
 	// Store when this change took place in the fwdTime keyspace.
-	static Future<Void> setForward(LeaderRegisterCollection* self,
-	                               KeyRef key,
-	                               ClusterConnectionString conn,
-	                               ForwardRequest req,
-	                               UID id) {
+	Future<Void> setForward(KeyRef key, ClusterConnectionString conn, ForwardRequest req, UID id) {
 		double forwardTime = now();
 		LeaderInfo forwardInfo;
 		forwardInfo.forward = true;
 		forwardInfo.serializedInfo = conn.toString();
-		self->forward[key] = forwardInfo;
-		self->forwardStartTime[key] = forwardTime;
-		OnDemandStore& store = *self->pStore;
+		forward[key] = forwardInfo;
+		forwardStartTime[key] = forwardTime;
+		OnDemandStore& store = *pStore;
 		store->set(KeyValueRef(key.withPrefix(fwdKeys.begin), conn.toString()));
 		store->set(KeyValueRef(key.withPrefix(fwdTimeKeys.begin), BinaryWriter::toValue(forwardTime, Unversioned())));
 		co_await store->commit();
 		// Do not process a forwarding request until after it has been made durable in case the coordinator restarts
-		self->getInterface(req.key, id).forward.send(req);
+		getInterface(req.key, id).forward.send(req);
 	}
 
 	LeaderElectionRegInterface& getInterface(KeyRef key, UID id) {
 		auto i = registerInterfaces.find(key);
 		if (i == registerInterfaces.end()) {
 			Key k = key;
-			Future<Void> a =
-			    wrap(this, k, LeaderRegister::run(makeReference<LeaderRegister>(registerInterfaces[k], k)), id);
+			Future<Void> a = wrap(k, LeaderRegister::run(makeReference<LeaderRegister>(registerInterfaces[k], k)), id);
 			if (a.isError())
 				throw a.getError();
 			ASSERT(!a.isReady());
@@ -661,7 +656,7 @@ struct LeaderRegisterCollection {
 		return i->value;
 	}
 
-	static Future<Void> wrap(LeaderRegisterCollection* self, Key key, Future<Void> actor, UID id) {
+	Future<Void> wrap(Key key, Future<Void> actor, UID id) {
 		Error e;
 		try {
 			// FIXME: Get worker ID here
@@ -674,7 +669,7 @@ struct LeaderRegisterCollection {
 				throw;
 			e = err;
 		}
-		self->registerInterfaces.erase(key);
+		registerInterfaces.erase(key);
 		if (e.code() != invalid_error_code)
 			throw e;
 	}
@@ -831,8 +826,7 @@ class LeaderServer {
 					    .detail("IncomingClusterKey", req.key);
 					req.reply.sendError(wrong_connection_file());
 				} else {
-					forwarders.add(LeaderRegisterCollection::setForward(
-					    &regs, req.key, ClusterConnectionString(req.conn.toString()), req, id));
+					forwarders.add(regs.setForward(req.key, ClusterConnectionString(req.conn.toString()), req, id));
 				}
 			}
 		}
@@ -852,7 +846,7 @@ public:
 	  : interf(interf), id(id), ccr(ccr), regs(pStore), forwarders(false) {}
 
 	Future<Void> run() {
-		co_await LeaderRegisterCollection::init(&regs);
+		co_await regs.init();
 		co_await race(serveCheckDescriptorMutableRequests(),
 		              serveOpenDatabaseRequests(),
 		              serveElectionResultRequests(),

--- a/fdbserver/core/CoordinatedState.cpp
+++ b/fdbserver/core/CoordinatedState.cpp
@@ -255,9 +255,9 @@ struct MovableCoordinatedStateImpl {
 
 	explicit MovableCoordinatedStateImpl(ServerCoordinators const& c) : coordinators(c), cs(c) {}
 
-	static Future<Value> read(MovableCoordinatedStateImpl* self) {
+	Future<Value> read() {
 		MovableValue moveState;
-		Value rawValue = co_await self->cs.read();
+		Value rawValue = co_await cs.read();
 		if (!rawValue.empty()) {
 			BinaryReader r(rawValue, IncludeVersion());
 			if (!r.protocolVersion().hasMovableCoordinatedState()) {
@@ -272,8 +272,7 @@ struct MovableCoordinatedStateImpl {
 		if (moveState.mode == MovableValue::MaybeTo) {
 			CODE_PROBE(true, "Maybe moveto state");
 			ASSERT(moveState.other.present());
-			co_await moveTo(
-			    self, &self->cs, ClusterConnectionString(moveState.other.get().toString()), moveState.value);
+			co_await moveTo(&cs, ClusterConnectionString(moveState.other.get().toString()), moveState.value);
 		}
 		co_return moveState.value;
 	}
@@ -287,15 +286,15 @@ struct MovableCoordinatedStateImpl {
 		return cs.setExclusive(lastCSValue.get());
 	}
 
-	static Future<Void> move(MovableCoordinatedStateImpl* self, ClusterConnectionString nc) {
+	Future<Void> move(ClusterConnectionString nc) {
 		// Call only after setExclusive returns.  Attempts to move the coordinated state
 		// permanently to the new ServerCoordinators, which must be uninitialized.  Returns when the process has
 		// reached the point where a leader elected by the new coordinators should be doing the rest of the work
 		// (and therefore the caller should die).
-		CoordinatedState cs(self->coordinators);
+		CoordinatedState cs(coordinators);
 		CoordinatedState nccs(ServerCoordinators(makeReference<ClusterConnectionMemoryRecord>(nc)));
 		Future<Void> creationTimeout = delay(30);
-		ASSERT(self->lastValue.present() && self->lastCSValue.present());
+		ASSERT(lastValue.present() && lastCSValue.present());
 		TraceEvent("StartMove").detail("ConnectionString", nc.toString());
 		{
 			auto res = co_await race(creationTimeout, nccs.read());
@@ -309,12 +308,12 @@ struct MovableCoordinatedStateImpl {
 		TraceEvent("FinishedRead").detail("ConnectionString", nc.toString());
 
 		{
-			auto res = co_await race(creationTimeout,
-			                         nccs.setExclusive(BinaryWriter::toValue(
-			                             MovableValue(self->lastValue.get(),
-			                                          MovableValue::MovingFrom,
-			                                          self->coordinators.ccr->getConnectionString().toString()),
-			                             IncludeVersion(ProtocolVersion::withMovableCoordinatedStateV2()))));
+			auto res = co_await race(
+			    creationTimeout,
+			    nccs.setExclusive(BinaryWriter::toValue(
+			        MovableValue(
+			            lastValue.get(), MovableValue::MovingFrom, coordinators.ccr->getConnectionString().toString()),
+			        IncludeVersion(ProtocolVersion::withMovableCoordinatedStateV2()))));
 			if (res.index() == 0) {
 				throw new_coordinators_timed_out();
 			}
@@ -325,22 +324,19 @@ struct MovableCoordinatedStateImpl {
 			co_await delay(5);
 
 		Value oldQuorumState = co_await cs.read();
-		if (oldQuorumState != self->lastCSValue.get()) {
+		if (oldQuorumState != lastCSValue.get()) {
 			CODE_PROBE(
 			    true, "Quorum change aborted by concurrent write to old coordination state", probe::decoration::rare);
 			TraceEvent("QuorumChangeAbortedByConcurrency").log();
 			throw coordinated_state_conflict();
 		}
 
-		co_await moveTo(self, &cs, nc, self->lastValue.get());
+		co_await moveTo(&cs, nc, lastValue.get());
 
 		throw coordinators_changed();
 	}
 
-	static Future<Void> moveTo(MovableCoordinatedStateImpl* self,
-	                           CoordinatedState* coordinatedState,
-	                           ClusterConnectionString nc,
-	                           Value value) {
+	Future<Void> moveTo(CoordinatedState* coordinatedState, ClusterConnectionString nc, Value value) {
 		co_await coordinatedState->setExclusive(
 		    BinaryWriter::toValue(MovableValue(value, MovableValue::MaybeTo, nc.toString()),
 		                          IncludeVersion(ProtocolVersion::withMovableCoordinatedStateV2())));
@@ -351,7 +347,7 @@ struct MovableCoordinatedStateImpl {
 		// SOMEDAY: If we are worried about someone magically getting the new cluster ID and interfering, do a second
 		// cs.setExclusive( encode( ReallyTo, ... ) )
 		TraceEvent("ChangingQuorum").detail("ConnectionString", nc.toString());
-		co_await changeLeaderCoordinators(self->coordinators, StringRef(nc.toString()));
+		co_await changeLeaderCoordinators(coordinators, StringRef(nc.toString()));
 		TraceEvent("ChangedQuorum").detail("ConnectionString", nc.toString());
 		throw coordinators_changed();
 	}
@@ -362,7 +358,7 @@ MovableCoordinatedState::MovableCoordinatedState(class ServerCoordinators const&
   : impl(PImpl<MovableCoordinatedStateImpl>::create(coord)) {}
 MovableCoordinatedState::~MovableCoordinatedState() = default;
 Future<Value> MovableCoordinatedState::read() {
-	return MovableCoordinatedStateImpl::read(impl.get());
+	return impl->read();
 }
 Future<Void> MovableCoordinatedState::onConflict() {
 	return impl->onConflict();
@@ -371,7 +367,7 @@ Future<Void> MovableCoordinatedState::setExclusive(Value v) {
 	return impl->setExclusive(v);
 }
 Future<Void> MovableCoordinatedState::move(ClusterConnectionString const& nc) {
-	return MovableCoordinatedStateImpl::move(impl.get(), nc);
+	return impl->move(nc);
 }
 
 Optional<Value> updateCCSInMovableValue(ValueRef movableVal, KeyRef oldClusterKey, KeyRef newClusterKey) {

--- a/fdbserver/core/CoordinatedState.cpp
+++ b/fdbserver/core/CoordinatedState.cpp
@@ -88,70 +88,70 @@ struct CoordinatedStateImpl {
 		// || rep.rgen > gen // setExclusive isn't absolutely doomed, but it may/probably will fail
 	}
 
-	static Future<Value> read(CoordinatedStateImpl* self) {
-		ASSERT(self->stage == 0);
+	Future<Value> read() {
+		ASSERT(stage == 0);
 
 		{
-			self->stage = 1;
-			GenerationRegReadReply rep = co_await self->replicatedRead(
-			    self, GenerationRegReadRequest(self->coordinators.clusterKey, UniqueGeneration()));
-			self->conflictGen = std::max(self->conflictGen, std::max(rep.gen.generation, rep.rgen.generation)) + 1;
-			self->gen = UniqueGeneration(self->conflictGen, deterministicRandom()->randomUniqueID());
+			stage = 1;
+			GenerationRegReadReply rep =
+			    co_await replicatedRead(GenerationRegReadRequest(coordinators.clusterKey, UniqueGeneration()));
+			conflictGen = std::max(conflictGen, std::max(rep.gen.generation, rep.rgen.generation)) + 1;
+			gen = UniqueGeneration(conflictGen, deterministicRandom()->randomUniqueID());
 		}
 
 		{
-			self->stage = 2;
+			stage = 2;
 			GenerationRegReadReply rep =
-			    co_await self->replicatedRead(self, GenerationRegReadRequest(self->coordinators.clusterKey, self->gen));
-			self->stage = 3;
-			self->conflictGen = std::max(self->conflictGen, std::max(rep.gen.generation, rep.rgen.generation));
-			if (self->isDoomed(rep))
-				self->doomed = true;
-			self->initial = rep.gen.generation == 0;
+			    co_await replicatedRead(GenerationRegReadRequest(coordinators.clusterKey, gen));
+			stage = 3;
+			conflictGen = std::max(conflictGen, std::max(rep.gen.generation, rep.rgen.generation));
+			if (isDoomed(rep))
+				doomed = true;
+			initial = rep.gen.generation == 0;
 
-			self->stage = 4;
+			stage = 4;
 			co_return rep.value.present() ? rep.value.get() : Value();
 		}
 	}
-	static Future<Void> onConflict(CoordinatedStateImpl* self) {
-		ASSERT(self->stage == 4);
-		if (self->doomed)
+	Future<Void> onConflict() {
+		ASSERT(stage == 4);
+		if (doomed)
 			co_return;
 		while (true) {
 			co_await delay(SERVER_KNOBS->COORDINATED_STATE_ONCONFLICT_POLL_INTERVAL);
-			GenerationRegReadReply rep = co_await self->replicatedRead(
-			    self, GenerationRegReadRequest(self->coordinators.clusterKey, UniqueGeneration()));
-			if (self->stage > 4)
+			GenerationRegReadReply rep =
+			    co_await replicatedRead(GenerationRegReadRequest(coordinators.clusterKey, UniqueGeneration()));
+			if (stage > 4)
 				break;
-			self->conflictGen = std::max(self->conflictGen, std::max(rep.gen.generation, rep.rgen.generation));
-			if (self->isDoomed(rep))
+			conflictGen = std::max(conflictGen, std::max(rep.gen.generation, rep.rgen.generation));
+			if (isDoomed(rep))
 				co_return;
 		}
 		co_await Future<Void>(Never());
 	}
-	static Future<Void> setExclusive(CoordinatedStateImpl* self, Value v) {
-		ASSERT(self->stage == 4);
-		self->stage = 5;
+	Future<Void> setExclusive(Value v) {
+		ASSERT(stage == 4);
+		stage = 5;
 
-		UniqueGeneration wgen = co_await self->replicatedWrite(
-		    self, GenerationRegWriteRequest(KeyValueRef(self->coordinators.clusterKey, v), self->gen));
-		self->stage = 6;
+		UniqueGeneration wgen =
+		    co_await replicatedWrite(GenerationRegWriteRequest(KeyValueRef(coordinators.clusterKey, v), gen));
+		stage = 6;
 
 		TraceEvent("CoordinatedStateSet")
-		    .detail("Gen", self->gen.generation)
+		    .detail("Gen", gen.generation)
 		    .detail("Wgen", wgen.generation)
-		    .detail("Genu", self->gen.uid)
+		    .detail("Genu", gen.uid)
 		    .detail("Wgenu", wgen.uid)
-		    .detail("Cgen", self->conflictGen);
+		    .detail("Cgen", conflictGen);
 
-		if (wgen != self->gen) {
-			self->conflictGen = std::max(self->conflictGen, wgen.generation);
+		if (wgen != gen) {
+			conflictGen = std::max(conflictGen, wgen.generation);
 			throw coordinated_state_conflict();
 		}
 	}
 
-	static Future<GenerationRegReadReply> replicatedRead(CoordinatedStateImpl* self, GenerationRegReadRequest req) {
-		std::vector<GenerationRegInterface>& replicas = self->coordinators.stateServers;
+	Future<GenerationRegReadReply> replicatedRead(GenerationRegReadRequest req) {
+		std::vector<GenerationRegInterface>& replicas = coordinators.stateServers;
 		std::vector<Future<GenerationRegReadReply>> rep_empty_reply;
 		std::vector<Future<GenerationRegReadReply>> rep_reply;
 		for (int i = 0; i < replicas.size(); i++) {
@@ -159,7 +159,7 @@ struct CoordinatedStateImpl {
 			    waitAndSendRead(replicas[i], GenerationRegReadRequest(req.key, req.gen));
 			rep_empty_reply.push_back(nonemptyToNever(reply));
 			rep_reply.push_back(emptyToNever(reply));
-			self->ac.add(success(reply));
+			ac.add(success(reply));
 		}
 
 		Future<Void> majorityEmpty =
@@ -192,16 +192,16 @@ struct CoordinatedStateImpl {
 		}
 	}
 
-	static Future<UniqueGeneration> replicatedWrite(CoordinatedStateImpl* self, GenerationRegWriteRequest req) {
-		std::vector<GenerationRegInterface>& replicas = self->coordinators.stateServers;
+	Future<UniqueGeneration> replicatedWrite(GenerationRegWriteRequest req) {
+		std::vector<GenerationRegInterface>& replicas = coordinators.stateServers;
 		std::vector<Future<UniqueGeneration>> wrep_reply;
 		for (int i = 0; i < replicas.size(); i++) {
 			Future<UniqueGeneration> reply = waitAndSendWrite(replicas[i], GenerationRegWriteRequest(req.kv, req.gen));
 			wrep_reply.push_back(reply);
-			self->ac.add(success(reply));
+			ac.add(success(reply));
 		}
 
-		co_await quorum(wrep_reply, self->initial ? replicas.size() : replicas.size() / 2 + 1);
+		co_await quorum(wrep_reply, initial ? replicas.size() : replicas.size() / 2 + 1);
 
 		UniqueGeneration maxGen;
 		for (int i = 0; i < wrep_reply.size(); i++)
@@ -215,13 +215,13 @@ CoordinatedState::CoordinatedState(ServerCoordinators const& coord)
   : impl(PImpl<CoordinatedStateImpl>::create(coord)) {}
 CoordinatedState::~CoordinatedState() = default;
 Future<Value> CoordinatedState::read() {
-	return CoordinatedStateImpl::read(impl.get());
+	return impl->read();
 }
 Future<Void> CoordinatedState::onConflict() {
-	return CoordinatedStateImpl::onConflict(impl.get());
+	return impl->onConflict();
 }
 Future<Void> CoordinatedState::setExclusive(Value v) {
-	return CoordinatedStateImpl::setExclusive(impl.get(), v);
+	return impl->setExclusive(v);
 }
 uint64_t CoordinatedState::getConflict() const {
 	return impl->getConflict();

--- a/fdbserver/kvstore/KeyValueStoreMemory.cpp
+++ b/fdbserver/kvstore/KeyValueStoreMemory.cpp
@@ -155,7 +155,7 @@ public:
 		if (recovering.isError())
 			throw recovering.getError();
 		if (!recovering.isReady())
-			return waitAndCommit(this, sequential);
+			return waitAndCommit(sequential);
 
 		if (!disableSnapshot && replaceContent && !firstCommitWithSnapshot) {
 			transactionSize += SERVER_KNOBS->REPLACE_CONTENTS_BYTES;
@@ -197,7 +197,7 @@ public:
 		transactionIsLarge = false;
 		firstCommitWithSnapshot = false;
 
-		addActor.send(commitAndUpdateVersions(this, c, previousSnapshotEnd));
+		addActor.send(commitAndUpdateVersions(c, previousSnapshotEnd));
 		return c;
 	}
 
@@ -205,7 +205,7 @@ public:
 		if (recovering.isError())
 			throw recovering.getError();
 		if (!recovering.isReady())
-			return waitAndReadValue(this, key, options);
+			return waitAndReadValue(key, options);
 
 		auto it = data.find(key);
 		if (it == data.end())
@@ -217,7 +217,7 @@ public:
 		if (recovering.isError())
 			throw recovering.getError();
 		if (!recovering.isReady())
-			return waitAndReadValuePrefix(this, key, maxLength, options);
+			return waitAndReadValuePrefix(key, maxLength, options);
 
 		auto it = data.find(key);
 		if (it == data.end())
@@ -239,7 +239,7 @@ public:
 		if (recovering.isError())
 			throw recovering.getError();
 		if (!recovering.isReady())
-			return waitAndReadRange(this, keys, rowLimit, byteLimit, options);
+			return waitAndReadRange(keys, rowLimit, byteLimit, options);
 
 		RangeResult result;
 		if (rowLimit == 0) {
@@ -465,12 +465,9 @@ private:
 		return loc;
 	}
 
-	static Future<Standalone<StringRef>> readOpData(KeyValueStoreMemory* self,
-	                                                OpHeader h,
-	                                                bool* isZeroFilled,
-	                                                int* zeroFillSize) {
+	Future<Standalone<StringRef>> readOpData(OpHeader h, bool* isZeroFilled, int* zeroFillSize) {
 		int remainingBytes = h.len1 + h.len2 + 1;
-		Standalone<StringRef> data = co_await self->log->readNext(remainingBytes);
+		Standalone<StringRef> data = co_await this->log->readNext(remainingBytes);
 		ASSERT(data.size() <= remainingBytes);
 		*zeroFillSize = remainingBytes - data.size();
 		if (*zeroFillSize == 0) {
@@ -479,16 +476,16 @@ private:
 		co_return data;
 	}
 
-	static Future<Void> recover(KeyValueStoreMemory* self, bool exactRecovery) {
+	Future<Void> recover(bool exactRecovery) {
 		while (true) {
 			// 'uncommitted' variables track something that might be rolled back by an OpRollback, and are copied into
-			// permanent variables (in self) in OpCommit.  OpRollback does the reverse (copying the permanent versions
+			// permanent variables in OpCommit.  OpRollback does the reverse (copying the permanent versions
 			// over the uncommitted versions) the uncommitted and committed variables should be equal initially (to
 			// whatever makes sense if there are no committed transactions recovered)
-			Key uncommittedNextKey = self->recoveredSnapshotKey;
-			IDiskQueue::location uncommittedPrevSnapshotEnd = self->previousSnapshotEnd =
-			    self->log->getNextReadLocation(); // not really, but popping up to here does nothing
-			IDiskQueue::location uncommittedSnapshotEnd = self->currentSnapshotEnd = uncommittedPrevSnapshotEnd;
+			Key uncommittedNextKey = this->recoveredSnapshotKey;
+			IDiskQueue::location uncommittedPrevSnapshotEnd = this->previousSnapshotEnd =
+			    this->log->getNextReadLocation(); // not really, but popping up to here does nothing
+			IDiskQueue::location uncommittedSnapshotEnd = this->currentSnapshotEnd = uncommittedPrevSnapshotEnd;
 
 			int zeroFillSize = 0;
 			int dbgSnapshotItemCount = 0;
@@ -496,7 +493,7 @@ private:
 			int dbgMutationCount = 0;
 			int dbgCommitCount = 0;
 			double startt = now();
-			UID dbgid = self->id;
+			UID dbgid = this->id;
 
 			Future<Void> loggingDelay = delay(1.0);
 
@@ -505,12 +502,12 @@ private:
 			Standalone<StringRef> lastSnapshotKey;
 			bool isZeroFilled{ false };
 
-			TraceEvent("KVSMemRecoveryStarted", self->id).detail("SnapshotEndLocation", uncommittedSnapshotEnd);
+			TraceEvent("KVSMemRecoveryStarted", this->id).detail("SnapshotEndLocation", uncommittedSnapshotEnd);
 
 			try {
 				while (true) {
 					{
-						Standalone<StringRef> data = co_await self->log->readNext(sizeof(OpHeader));
+						Standalone<StringRef> data = co_await this->log->readNext(sizeof(OpHeader));
 						if (data.size() != sizeof(OpHeader)) {
 							if (!data.empty()) {
 								CODE_PROBE(
@@ -519,26 +516,26 @@ private:
 								memcpy(&h, data.begin(), data.size());
 								zeroFillSize = sizeof(OpHeader) - data.size() + h.len1 + h.len2 + 1;
 							}
-							TraceEvent("KVSMemRecoveryComplete", self->id)
+							TraceEvent("KVSMemRecoveryComplete", this->id)
 							    .detail("Reason", "Non-header sized data read")
 							    .detail("DataSize", data.size())
 							    .detail("ZeroFillSize", zeroFillSize)
 							    .detail("SnapshotEndLocation", uncommittedSnapshotEnd)
-							    .detail("NextReadLoc", self->log->getNextReadLocation());
+							    .detail("NextReadLoc", this->log->getNextReadLocation());
 							break;
 						}
 						h = *(OpHeader*)data.begin();
 						ASSERT(h.op != OpEncrypted_Deprecated);
 					}
-					Standalone<StringRef> data = co_await readOpData(self, h, &isZeroFilled, &zeroFillSize);
+					Standalone<StringRef> data = co_await readOpData(h, &isZeroFilled, &zeroFillSize);
 					if (zeroFillSize > 0) {
-						TraceEvent("KVSMemRecoveryComplete", self->id)
+						TraceEvent("KVSMemRecoveryComplete", this->id)
 						    .detail("Reason", "data specified by header does not exist")
 						    .detail("DataSize", data.size())
 						    .detail("ZeroFillSize", zeroFillSize)
 						    .detail("SnapshotEndLocation", uncommittedSnapshotEnd)
 						    .detail("OpCode", h.op)
-						    .detail("NextReadLoc", self->log->getNextReadLocation());
+						    .detail("NextReadLoc", this->log->getNextReadLocation());
 						break;
 					}
 
@@ -546,14 +543,14 @@ private:
 						StringRef p1 = data.substr(0, h.len1);
 						StringRef p2 = data.substr(h.len1, h.len2);
 
-						DEBUG_TRANSACTION_STATE_STORE("Recover", p1, self->id);
+						DEBUG_TRANSACTION_STATE_STORE("Recover", p1, this->id);
 
 						if (h.op == OpSnapshotItem || h.op == OpSnapshotItemDelta) { // snapshot data item
 							/*if (p1 < uncommittedNextKey) {
-							    TraceEvent(SevError, "RecSnapshotBack", self->id)
+							    TraceEvent(SevError, "RecSnapshotBack", this->id)
 							        .detail("NextKey", uncommittedNextKey)
 							        .detail("P1", p1)
-							        .detail("Nextlocation", self->log->getNextReadLocation());
+							        .detail("Nextlocation", this->log->getNextReadLocation());
 							}
 							ASSERT( p1 >= uncommittedNextKey );*/
 							if (h.op == OpSnapshotItemDelta) {
@@ -582,14 +579,14 @@ private:
 							++dbgSnapshotItemCount;
 							lastSnapshotKey = Key(p1, data.arena());
 						} else if (h.op == OpSnapshotEnd || h.op == OpSnapshotAbort) { // snapshot complete
-							TraceEvent("RecSnapshotEnd", self->id)
+							TraceEvent("RecSnapshotEnd", this->id)
 							    .detail("NextKey", uncommittedNextKey)
-							    .detail("Nextlocation", self->log->getNextReadLocation())
+							    .detail("Nextlocation", this->log->getNextReadLocation())
 							    .detail("IsSnapshotEnd", h.op == OpSnapshotEnd);
 
 							if (h.op == OpSnapshotEnd) {
 								uncommittedPrevSnapshotEnd = uncommittedSnapshotEnd;
-								uncommittedSnapshotEnd = self->log->getNextReadLocation();
+								uncommittedSnapshotEnd = this->log->getNextReadLocation();
 								recoveryQueue.clear_to_end(uncommittedNextKey, &uncommittedNextKey.arena());
 							}
 
@@ -605,35 +602,35 @@ private:
 						} else if (h.op == OpClearToEnd) { // clear all data from begin key to end
 							recoveryQueue.clear_to_end(p1, &data.arena());
 						} else if (h.op == OpCommit) { // commit previous transaction
-							self->commit_queue(recoveryQueue, false);
+							this->commit_queue(recoveryQueue, false);
 							++dbgCommitCount;
-							self->recoveredSnapshotKey = uncommittedNextKey;
-							self->previousSnapshotEnd = uncommittedPrevSnapshotEnd;
-							self->currentSnapshotEnd = uncommittedSnapshotEnd;
+							this->recoveredSnapshotKey = uncommittedNextKey;
+							this->previousSnapshotEnd = uncommittedPrevSnapshotEnd;
+							this->currentSnapshotEnd = uncommittedSnapshotEnd;
 						} else if (h.op == OpRollback) { // rollback previous transaction
 							recoveryQueue.rollback();
-							TraceEvent("KVSMemRecSnapshotRollback", self->id).detail("NextKey", uncommittedNextKey);
-							uncommittedNextKey = self->recoveredSnapshotKey;
-							uncommittedPrevSnapshotEnd = self->previousSnapshotEnd;
-							uncommittedSnapshotEnd = self->currentSnapshotEnd;
+							TraceEvent("KVSMemRecSnapshotRollback", this->id).detail("NextKey", uncommittedNextKey);
+							uncommittedNextKey = this->recoveredSnapshotKey;
+							uncommittedPrevSnapshotEnd = this->previousSnapshotEnd;
+							uncommittedSnapshotEnd = this->currentSnapshotEnd;
 						} else {
 							ASSERT(false);
 						}
 					} else {
-						TraceEvent("KVSMemRecoverySkippedZeroFill", self->id)
+						TraceEvent("KVSMemRecoverySkippedZeroFill", this->id)
 						    .detail("PayloadSize", data.size())
 						    .detail("ExpectedSize", h.len1 + h.len2 + 1)
 						    .detail("OpCode", h.op)
-						    .detail("EndsAt", self->log->getNextReadLocation());
+						    .detail("EndsAt", this->log->getNextReadLocation());
 					}
 
 					if (loggingDelay.isReady()) {
-						TraceEvent("KVSMemRecoveryLogSnap", self->id)
+						TraceEvent("KVSMemRecoveryLogSnap", this->id)
 						    .detail("SnapshotItems", dbgSnapshotItemCount)
 						    .detail("SnapshotEnd", dbgSnapshotEndCount)
 						    .detail("Mutations", dbgMutationCount)
 						    .detail("Commits", dbgCommitCount)
-						    .detail("EndsAt", self->log->getNextReadLocation());
+						    .detail("EndsAt", this->log->getNextReadLocation());
 						loggingDelay = delay(1.0);
 					}
 
@@ -642,30 +639,30 @@ private:
 
 				if (zeroFillSize) {
 					if (exactRecovery) {
-						TraceEvent(SevError, "KVSMemExpectedExact", self->id).log();
+						TraceEvent(SevError, "KVSMemExpectedExact", this->id).log();
 						ASSERT(false);
 					}
 
 					CODE_PROBE(true, "Fixing a partial commit at the end of the KeyValueStoreMemory log");
 					for (int i = 0; i < zeroFillSize; i++)
-						self->log->push(StringRef((const uint8_t*)"", 1));
+						this->log->push(StringRef((const uint8_t*)"", 1));
 				}
-				// self->rollback(); not needed, since we are about to discard anything left in the recoveryQueue
-				//TraceEvent("KVSMemRecRollback", self->id).detail("QueueEmpty", data.size() == 0);
+				// this->rollback(); not needed, since we are about to discard anything left in the recoveryQueue
+				//TraceEvent("KVSMemRecRollback", this->id).detail("QueueEmpty", data.size() == 0);
 				// make sure that before any new operations are added to the log that all uncommitted operations are
 				// "rolled back"
-				self->log_op(OpRollback, StringRef(), StringRef()); // rollback previous transaction
+				this->log_op(OpRollback, StringRef(), StringRef()); // rollback previous transaction
 
-				self->committedDataSize = self->data.sumTo(self->data.end());
+				this->committedDataSize = this->data.sumTo(this->data.end());
 
-				TraceEvent("KVSMemRecovered", self->id)
+				TraceEvent("KVSMemRecovered", this->id)
 				    .detail("SnapshotItems", dbgSnapshotItemCount)
 				    .detail("SnapshotEnd", dbgSnapshotEndCount)
 				    .detail("Mutations", dbgMutationCount)
 				    .detail("Commits", dbgCommitCount)
 				    .detail("TimeTaken", now() - startt);
 
-				self->semiCommit();
+				this->semiCommit();
 
 				co_return;
 			} catch (Error& e) {
@@ -675,8 +672,8 @@ private:
 				if (e.code() != error_code_disk_adapter_reset) {
 					throw e;
 				}
-				self->data.clear();
-				self->dataSets.clear();
+				this->data.clear();
+				this->dataSets.clear();
 			}
 		}
 	}
@@ -707,10 +704,10 @@ private:
 		currentSnapshotEnd = log_op(OpSnapshotEnd, StringRef(), StringRef());
 	}
 
-	static Future<Void> snapshot(KeyValueStoreMemory* self) {
-		co_await self->recovering;
+	Future<Void> snapshot() {
+		co_await this->recovering;
 
-		Key nextKey = self->recoveredSnapshotKey;
+		Key nextKey = this->recoveredSnapshotKey;
 		bool nextKeyAfter = false; // setting this to true is equilvent to setting nextKey = keyAfter(nextKey)
 		uint64_t snapshotTotalWrittenBytes = 0;
 		int lastDiff = 0;
@@ -724,24 +721,24 @@ private:
 		Key lastSnapshotKeyB = makeString(CLIENT_KNOBS->SYSTEM_KEY_SIZE_LIMIT);
 		bool lastSnapshotKeyUsingA = true;
 
-		TraceEvent("KVSMemStartingSnapshot", self->id).detail("StartKey", nextKey);
+		TraceEvent("KVSMemStartingSnapshot", this->id).detail("StartKey", nextKey);
 
 		while (true) {
-			co_await self->notifiedCommittedWriteBytes.whenAtLeast(snapshotTotalWrittenBytes + 1);
+			co_await this->notifiedCommittedWriteBytes.whenAtLeast(snapshotTotalWrittenBytes + 1);
 
-			if (self->resetSnapshot) {
+			if (this->resetSnapshot) {
 				nextKey = Key();
 				nextKeyAfter = false;
 				snapItems = 0;
 				snapshotBytes = 0;
-				self->resetSnapshot = false;
+				this->resetSnapshot = false;
 			}
 
-			auto next = nextKeyAfter ? self->data.upper_bound(nextKey) : self->data.lower_bound(nextKey);
-			int diff = self->notifiedCommittedWriteBytes.get() - snapshotTotalWrittenBytes;
+			auto next = nextKeyAfter ? this->data.upper_bound(nextKey) : this->data.lower_bound(nextKey);
+			int diff = this->notifiedCommittedWriteBytes.get() - snapshotTotalWrittenBytes;
 			if (diff > lastDiff && diff > 5e7) {
-				TraceEvent(SevWarnAlways, "ManyWritesAtOnce", self->id)
-				    .detail("CommittedWrites", self->notifiedCommittedWriteBytes.get())
+				TraceEvent(SevWarnAlways, "ManyWritesAtOnce", this->id)
+				    .detail("CommittedWrites", this->notifiedCommittedWriteBytes.get())
 				    .detail("SnapshotWrites", snapshotTotalWrittenBytes)
 				    .detail("Diff", diff)
 				    .detail("LastOperationWasASnapshot", nextKey.empty() && !nextKeyAfter);
@@ -756,26 +753,26 @@ private:
 			// Write snapshot items until the wait above would block because we've used up all of the byte budget
 			while (true) {
 
-				if (next == self->data.end()) {
+				if (next == this->data.end()) {
 					// After a snapshot end is logged, recovery may not see the last snapshot item logged before it so
 					// the next snapshot item logged cannot be a delta.
 					useDelta = false;
 
-					auto thisSnapshotEnd = self->log_op(OpSnapshotEnd, StringRef(), StringRef());
-					DisabledTraceEvent("SnapshotEnd", self->id)
-					    .detail("CurrentSnapshotEndLoc", self->currentSnapshotEnd)
-					    .detail("PreviousSnapshotEndLoc", self->previousSnapshotEnd)
+					auto thisSnapshotEnd = this->log_op(OpSnapshotEnd, StringRef(), StringRef());
+					DisabledTraceEvent("SnapshotEnd", this->id)
+					    .detail("CurrentSnapshotEndLoc", this->currentSnapshotEnd)
+					    .detail("PreviousSnapshotEndLoc", this->previousSnapshotEnd)
 					    .detail("ThisSnapshotEnd", thisSnapshotEnd)
 					    .detail("Items", snapItems)
-					    .detail("CommittedWrites", self->notifiedCommittedWriteBytes.get())
+					    .detail("CommittedWrites", this->notifiedCommittedWriteBytes.get())
 					    .detail("SnapshotSize", snapshotBytes);
 
-					ASSERT(thisSnapshotEnd >= self->currentSnapshotEnd);
-					self->previousSnapshotEnd = self->currentSnapshotEnd;
-					self->currentSnapshotEnd = thisSnapshotEnd;
+					ASSERT(thisSnapshotEnd >= this->currentSnapshotEnd);
+					this->previousSnapshotEnd = this->currentSnapshotEnd;
+					this->currentSnapshotEnd = thisSnapshotEnd;
 
-					if (++self->snapshotCount == 2) {
-						self->replaceContent = false;
+					if (++this->snapshotCount == 2) {
+						this->replaceContent = false;
 					}
 
 					snapItems = 0;
@@ -783,8 +780,8 @@ private:
 					snapshotTotalWrittenBytes += OP_DISK_OVERHEAD;
 
 					// If we're not stopping now, reset next
-					if (snapshotTotalWrittenBytes < self->notifiedCommittedWriteBytes.get()) {
-						next = self->data.begin();
+					if (snapshotTotalWrittenBytes < this->notifiedCommittedWriteBytes.get()) {
+						next = this->data.begin();
 					} else {
 						// Otherwise, save state for continuing after the next wait and stop
 						nextKey = Key();
@@ -812,7 +809,7 @@ private:
 					// anything into it.
 					destKey.contents() = KeyRef(destKey.begin(), tempKey.size());
 
-					DEBUG_TRANSACTION_STATE_STORE("SnapshotItem", destKey.toString(), self->id);
+					DEBUG_TRANSACTION_STATE_STORE("SnapshotItem", destKey.toString(), this->id);
 
 					// Get the common prefix between this key and the previous one, or 0 if there was no previous one.
 					int commonPrefix;
@@ -837,12 +834,12 @@ private:
 
 						opKeySize = opKeySize - commonPrefix + 1;
 						KeyRef opKey(&prefixLength, opKeySize);
-						self->log_op(OpSnapshotItemDelta, opKey, next.getValue());
+						this->log_op(OpSnapshotItemDelta, opKey, next.getValue());
 
 						// Restore the overwritten byte
 						prefixLength = backupByte;
 					} else {
-						self->log_op(OpSnapshotItem, tempKey, next.getValue());
+						this->log_op(OpSnapshotItem, tempKey, next.getValue());
 					}
 
 					snapItems++;
@@ -852,7 +849,7 @@ private:
 					lastSnapshotKeyUsingA = !lastSnapshotKeyUsingA;
 
 					// If we're not stopping now, increment next
-					if (snapshotTotalWrittenBytes < self->notifiedCommittedWriteBytes.get()) {
+					if (snapshotTotalWrittenBytes < this->notifiedCommittedWriteBytes.get()) {
 						++next;
 					} else {
 						// Otherwise, save state for continuing after the next wait and stop
@@ -865,34 +862,25 @@ private:
 		}
 	}
 
-	static Future<Optional<Value>> waitAndReadValue(KeyValueStoreMemory* self, Key key, Optional<ReadOptions> options) {
-		co_await self->recovering;
-		co_return static_cast<IKeyValueStore*>(self)->readValue(key, options).get();
+	Future<Optional<Value>> waitAndReadValue(Key key, Optional<ReadOptions> options) {
+		co_await this->recovering;
+		co_return static_cast<IKeyValueStore*>(this)->readValue(key, options).get();
 	}
-	static Future<Optional<Value>> waitAndReadValuePrefix(KeyValueStoreMemory* self,
-	                                                      Key key,
-	                                                      int maxLength,
-	                                                      Optional<ReadOptions> options) {
-		co_await self->recovering;
-		co_return static_cast<IKeyValueStore*>(self)->readValuePrefix(key, maxLength, options).get();
+	Future<Optional<Value>> waitAndReadValuePrefix(Key key, int maxLength, Optional<ReadOptions> options) {
+		co_await this->recovering;
+		co_return static_cast<IKeyValueStore*>(this)->readValuePrefix(key, maxLength, options).get();
 	}
-	static Future<RangeResult> waitAndReadRange(KeyValueStoreMemory* self,
-	                                            KeyRange keys,
-	                                            int rowLimit,
-	                                            int byteLimit,
-	                                            Optional<ReadOptions> options) {
-		co_await self->recovering;
-		co_return static_cast<IKeyValueStore*>(self)->readRange(keys, rowLimit, byteLimit, options).get();
+	Future<RangeResult> waitAndReadRange(KeyRange keys, int rowLimit, int byteLimit, Optional<ReadOptions> options) {
+		co_await this->recovering;
+		co_return static_cast<IKeyValueStore*>(this)->readRange(keys, rowLimit, byteLimit, options).get();
 	}
-	static Future<Void> waitAndCommit(KeyValueStoreMemory* self, bool sequential) {
-		co_await self->recovering;
-		co_await self->commit(sequential);
+	Future<Void> waitAndCommit(bool sequential) {
+		co_await this->recovering;
+		co_await this->commit(sequential);
 	}
-	static Future<Void> commitAndUpdateVersions(KeyValueStoreMemory* self,
-	                                            Future<Void> commit,
-	                                            IDiskQueue::location location) {
+	Future<Void> commitAndUpdateVersions(Future<Void> commit, IDiskQueue::location location) {
 		co_await commit;
-		self->log->pop(location);
+		this->log->pop(location);
 	}
 };
 
@@ -915,8 +903,8 @@ KeyValueStoreMemory<Container>::KeyValueStoreMemory(IDiskQueue* log,
 	if (this->reserved_buffer != nullptr)
 		memset(this->reserved_buffer, 0, CLIENT_KNOBS->SYSTEM_KEY_SIZE_LIMIT);
 
-	recovering = recover(this, exactRecovery);
-	snapshotting = snapshot(this);
+	recovering = recover(exactRecovery);
+	snapshotting = snapshot();
 	commitActors = actorCollection(addActor.getFuture());
 }
 

--- a/fdbserver/kvstore/VersionedBTree.cpp
+++ b/fdbserver/kvstore/VersionedBTree.cpp
@@ -1869,25 +1869,23 @@ public:
 	}
 
 	// Clears the cache, saving the entries to second cache, then waits for each item to be evictable and evicts it.
-	static Future<Void> clear_impl(ObjectCache* self, bool waitForSafeEviction) {
+	Future<Void> clear(bool waitForSafeEviction = false) {
 		// Claim ownership of all of our cached items, removing them from the evictor's control and quota.
-		for (auto& ie : self->cache) {
-			self->pEvictor->reclaim(ie.second);
+		for (auto& ie : this->cache) {
+			this->pEvictor->reclaim(ie.second);
 		}
 
 		// All items are in the cache so we don't need the prioritized eviction order anymore, and the cache is about
 		// to be destroyed so the prioritizedEvictions head/tail will become invalid.
-		self->prioritizedEvictions.clear();
+		this->prioritizedEvictions.clear();
 
-		auto i = self->cache.begin();
-		while (i != self->cache.end()) {
+		auto i = this->cache.begin();
+		while (i != this->cache.end()) {
 			co_await (waitForSafeEviction ? i->second.item.onEvictable() : i->second.item.cancel());
 			++i;
 		}
-		self->cache.clear();
+		this->cache.clear();
 	}
-
-	Future<Void> clear(bool waitForSafeEviction = false) { return clear_impl(this, waitForSafeEviction); }
 
 	// Move the prioritized evictions queued to the front of the eviction order
 	void flushPrioritizedEvictions() { pEvictor->moveIn(prioritizedEvictions); }

--- a/fdbserver/tlog/TLogServer.cpp
+++ b/fdbserver/tlog/TLogServer.cpp
@@ -129,7 +129,51 @@ public:
 
 	// Before calling push, pop, or commit, the user must call readNext() until it throws
 	//    end_of_stream(). It may not be called again thereafter.
-	Future<TLogQueueEntry> readNext(TLogData* tLog) { return readNext(this, tLog); }
+	Future<TLogQueueEntry> readNext(TLogData* tLog) {
+		TLogQueueEntry result;
+		int zeroFillSize = 0;
+
+		while (true) {
+			IDiskQueue::location startloc = queue->getNextReadLocation();
+			Standalone<StringRef> h = co_await queue->readNext(sizeof(uint32_t));
+			if (h.size() != sizeof(uint32_t)) {
+				if (!h.empty()) {
+					CODE_PROBE(true, "Zero fill within size field", probe::decoration::rare);
+					int payloadSize = 0;
+					memcpy(&payloadSize, h.begin(), h.size());
+					zeroFillSize = sizeof(uint32_t) - h.size(); // zero fill the size itself
+					zeroFillSize += payloadSize + 1; // and then the contents and valid flag
+				}
+				break;
+			}
+
+			uint32_t payloadSize = *(uint32_t*)h.begin();
+			ASSERT(payloadSize < (100 << 20));
+
+			Standalone<StringRef> e = co_await queue->readNext(payloadSize + 1);
+			if (e.size() != payloadSize + 1) {
+				CODE_PROBE(true, "Zero fill within payload");
+				zeroFillSize = payloadSize + 1 - e.size();
+				break;
+			}
+
+			if (e[payloadSize]) {
+				ASSERT(e[payloadSize] == 1);
+				Arena a = e.arena();
+				ArenaReader ar(a, e.substr(0, payloadSize), IncludeVersion());
+				ar >> result;
+				const IDiskQueue::location endloc = queue->getNextReadLocation();
+				updateVersionSizes(result, tLog, startloc, endloc);
+				co_return result;
+			}
+		}
+		if (zeroFillSize) {
+			CODE_PROBE(true, "Fixing a partial commit at the end of the tlog queue");
+			for (int i = 0; i < zeroFillSize; i++)
+				queue->push(StringRef((const uint8_t*)"", 1));
+		}
+		throw end_of_stream();
+	}
 
 	Future<bool> initializeRecovery(IDiskQueue::location recoverAt) { return queue->initializeRecovery(recoverAt); }
 
@@ -159,52 +203,6 @@ private:
 	                        TLogData* tLog,
 	                        IDiskQueue::location start,
 	                        IDiskQueue::location end);
-
-	static Future<TLogQueueEntry> readNext(TLogQueue* self, TLogData* tLog) {
-		TLogQueueEntry result;
-		int zeroFillSize = 0;
-
-		while (true) {
-			IDiskQueue::location startloc = self->queue->getNextReadLocation();
-			Standalone<StringRef> h = co_await self->queue->readNext(sizeof(uint32_t));
-			if (h.size() != sizeof(uint32_t)) {
-				if (!h.empty()) {
-					CODE_PROBE(true, "Zero fill within size field", probe::decoration::rare);
-					int payloadSize = 0;
-					memcpy(&payloadSize, h.begin(), h.size());
-					zeroFillSize = sizeof(uint32_t) - h.size(); // zero fill the size itself
-					zeroFillSize += payloadSize + 1; // and then the contents and valid flag
-				}
-				break;
-			}
-
-			uint32_t payloadSize = *(uint32_t*)h.begin();
-			ASSERT(payloadSize < (100 << 20));
-
-			Standalone<StringRef> e = co_await self->queue->readNext(payloadSize + 1);
-			if (e.size() != payloadSize + 1) {
-				CODE_PROBE(true, "Zero fill within payload");
-				zeroFillSize = payloadSize + 1 - e.size();
-				break;
-			}
-
-			if (e[payloadSize]) {
-				ASSERT(e[payloadSize] == 1);
-				Arena a = e.arena();
-				ArenaReader ar(a, e.substr(0, payloadSize), IncludeVersion());
-				ar >> result;
-				const IDiskQueue::location endloc = self->queue->getNextReadLocation();
-				self->updateVersionSizes(result, tLog, startloc, endloc);
-				co_return result;
-			}
-		}
-		if (zeroFillSize) {
-			CODE_PROBE(true, "Fixing a partial commit at the end of the tlog queue");
-			for (int i = 0; i < zeroFillSize; i++)
-				self->queue->push(StringRef((const uint8_t*)"", 1));
-		}
-		throw end_of_stream();
-	}
 };
 
 ////// Persistence format (for self->persistentData)

--- a/fdbserver/workloads/AtomicOpsApiCorrectness.cpp
+++ b/fdbserver/workloads/AtomicOpsApiCorrectness.cpp
@@ -53,34 +53,34 @@ public:
 		switch (opType) {
 		case 0:
 			CODE_PROBE(true, "Testing atomic Min");
-			return testMin(cx->clone(), this);
+			return testMin(cx->clone());
 		case 1:
 			CODE_PROBE(true, "Testing atomic And");
-			return testAnd(cx->clone(), this);
+			return testAnd(cx->clone());
 		case 2:
 			CODE_PROBE(true, "Testing atomic ByteMin");
-			return testByteMin(cx->clone(), this);
+			return testByteMin(cx->clone());
 		case 3:
 			CODE_PROBE(true, "Testing atomic ByteMax");
-			return testByteMax(cx->clone(), this);
+			return testByteMax(cx->clone());
 		case 4:
 			CODE_PROBE(true, "Testing atomic Or");
-			return testOr(cx->clone(), this);
+			return testOr(cx->clone());
 		case 5:
 			CODE_PROBE(true, "Testing atomic Max");
-			return testMax(cx->clone(), this);
+			return testMax(cx->clone());
 		case 6:
 			CODE_PROBE(true, "Testing atomic Xor");
-			return testXor(cx->clone(), this);
+			return testXor(cx->clone());
 		case 7:
 			CODE_PROBE(true, "Testing atomic Add");
-			return testAdd(cx->clone(), this);
+			return testAdd(cx->clone());
 		case 8:
 			CODE_PROBE(true, "Testing atomic CompareAndClear");
-			return testCompareAndClear(cx->clone(), this);
+			return testCompareAndClear(cx->clone());
 		case 9:
 			CODE_PROBE(true, "Testing atomic AppendIfFits");
-			return testAppendIfFits(cx->clone(), this);
+			return testAppendIfFits(cx->clone());
 		default:
 			ASSERT(false);
 		}
@@ -92,8 +92,8 @@ public:
 
 	void getMetrics(std::vector<PerfMetric>& m) override {}
 
-	Future<Void> testAppendIfFits(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
-		const Key key = self->getTestKey("test_key_append_if_fits_");
+	Future<Void> testAppendIfFits(Database cx) {
+		const Key key = getTestKey("test_key_append_if_fits_");
 		const Value nearlyFull(std::string(CLIENT_KNOBS->VALUE_SIZE_LIMIT - 1, 'x'));
 		const Value full(std::string(CLIENT_KNOBS->VALUE_SIZE_LIMIT, 'x'));
 		const Value suffix("x"_sr);
@@ -134,10 +134,7 @@ public:
 	}
 
 	// Test Atomic ops on non existing keys that results in a set
-	Future<Void> testAtomicOpSetOnNonExistingKey(Database cx,
-	                                             AtomicOpsApiCorrectnessWorkload* self,
-	                                             uint32_t opType,
-	                                             Key key) {
+	Future<Void> testAtomicOpSetOnNonExistingKey(Database cx, uint32_t opType, Key key) {
 		uint64_t intValue = deterministicRandom()->randomInt(0, 10000000);
 		Value val = StringRef((const uint8_t*)&intValue, sizeof(intValue));
 
@@ -173,7 +170,7 @@ public:
 				    .detail("Op", opType)
 				    .detail("ExpectedOutput", intValue)
 				    .detail("ActualOutput", output);
-				self->testFailed = true;
+				testFailed = true;
 			}
 		}
 
@@ -194,16 +191,13 @@ public:
 				    .detail("Op", opType)
 				    .detail("ExpectedOutput", intValue)
 				    .detail("ActualOutput", output);
-				self->testFailed = true;
+				testFailed = true;
 			}
 		}
 	}
 
 	// Test Atomic ops on non existing keys that results in a unset
-	Future<Void> testAtomicOpUnsetOnNonExistingKey(Database cx,
-	                                               AtomicOpsApiCorrectnessWorkload* self,
-	                                               uint32_t opType,
-	                                               Key key) {
+	Future<Void> testAtomicOpUnsetOnNonExistingKey(Database cx, uint32_t opType, Key key) {
 		uint64_t intValue = deterministicRandom()->randomInt(0, 10000000);
 		Value val = StringRef((const uint8_t*)&intValue, sizeof(intValue));
 
@@ -239,7 +233,7 @@ public:
 				    .detail("Op", opType)
 				    .detail("ExpectedOutput", 0)
 				    .detail("ActualOutput", output);
-				self->testFailed = true;
+				testFailed = true;
 			}
 		}
 
@@ -260,7 +254,7 @@ public:
 				    .detail("Op", opType)
 				    .detail("ExpectedOutput", 0)
 				    .detail("ActualOutput", output);
-				self->testFailed = true;
+				testFailed = true;
 			}
 		}
 	}
@@ -269,7 +263,6 @@ public:
 
 	// Test Atomic Ops when one of the value is empty
 	Future<Void> testAtomicOpOnEmptyValue(Database cx,
-	                                      AtomicOpsApiCorrectnessWorkload* self,
 	                                      uint32_t opType,
 	                                      Key key,
 	                                      DoAtomicOpOnEmptyValueFunction opFunc) {
@@ -314,7 +307,7 @@ public:
 				    .detail("Op", opType)
 				    .detail("ExpectedOutput", opFunc(existingVal, otherVal).toString())
 				    .detail("ActualOutput", output.toString());
-				self->testFailed = true;
+				testFailed = true;
 			}
 		}
 
@@ -334,7 +327,7 @@ public:
 				    .detail("Op", opType)
 				    .detail("ExpectedOutput", opFunc(existingVal, otherVal).toString())
 				    .detail("ActualOutput", output.toString());
-				self->testFailed = true;
+				testFailed = true;
 			}
 		}
 	}
@@ -342,11 +335,7 @@ public:
 	using DoAtomicOpFunction = std::function<uint64_t(uint64_t, uint64_t)>;
 
 	// Test atomic ops in the normal case when the existing value is present
-	Future<Void> testAtomicOpApi(Database cx,
-	                             AtomicOpsApiCorrectnessWorkload* self,
-	                             uint32_t opType,
-	                             Key key,
-	                             DoAtomicOpFunction opFunc) {
+	Future<Void> testAtomicOpApi(Database cx, uint32_t opType, Key key, DoAtomicOpFunction opFunc) {
 		uint64_t intValue1 = deterministicRandom()->randomInt(0, 10000000);
 		uint64_t intValue2 = deterministicRandom()->randomInt(0, 10000000);
 		Value val1 = StringRef((const uint8_t*)&intValue1, sizeof(intValue1));
@@ -389,7 +378,7 @@ public:
 				    .detail("AtomicOp", opType)
 				    .detail("ExpectedOutput", opFunc(intValue1, intValue2))
 				    .detail("ActualOutput", output);
-				self->testFailed = true;
+				testFailed = true;
 			}
 		}
 
@@ -413,15 +402,12 @@ public:
 				    .detail("AtomicOp", opType)
 				    .detail("ExpectedOutput", opFunc(intValue1, intValue2))
 				    .detail("ActualOutput", output);
-				self->testFailed = true;
+				testFailed = true;
 			}
 		}
 	}
 
-	Future<Void> testCompareAndClearAtomicOpApi(Database cx,
-	                                            AtomicOpsApiCorrectnessWorkload* self,
-	                                            Key key,
-	                                            bool keySet) {
+	Future<Void> testCompareAndClearAtomicOpApi(Database cx, Key key, bool keySet) {
 		uint64_t opType = MutationRef::CompareAndClear;
 		uint64_t intValue1 = deterministicRandom()->randomInt(0, 10000000);
 		uint64_t intValue2 =
@@ -485,7 +471,7 @@ public:
 					    .detail("AtomicOp", opType)
 					    .detail("ExpectedOutput", expectedOutput.get())
 					    .detail("ActualOutput", output);
-					self->testFailed = true;
+					testFailed = true;
 				}
 			}
 		}
@@ -517,24 +503,24 @@ public:
 					    .detail("AtomicOp", opType)
 					    .detail("ExpectedOutput", expectedOutput.get())
 					    .detail("ActualOutput", output);
-					self->testFailed = true;
+					testFailed = true;
 				}
 			}
 		}
 	}
 
-	Future<Void> testMin(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
+	Future<Void> testMin(Database cx) {
 		int currentApiVersion = getApiVersion(cx);
-		Key key = self->getTestKey("test_key_min_");
+		Key key = getTestKey("test_key_min_");
 
 		TraceEvent("AtomicOpCorrectnessApiWorkload").detail("OpType", "MIN");
 		// API Version 500
 		setApiVersion(&cx, 500);
 		TraceEvent(SevInfo, "Running Atomic Op Min Correctness Test Api Version 500").log();
-		co_await self->testAtomicOpUnsetOnNonExistingKey(cx, self, MutationRef::Min, key);
-		co_await self->testAtomicOpApi(
-		    cx, self, MutationRef::Min, key, [](uint64_t val1, uint64_t val2) { return val1 < val2 ? val1 : val2; });
-		co_await self->testAtomicOpOnEmptyValue(cx, self, MutationRef::Min, key, [](Value v1, Value v2) -> Value {
+		co_await testAtomicOpUnsetOnNonExistingKey(cx, MutationRef::Min, key);
+		co_await testAtomicOpApi(
+		    cx, MutationRef::Min, key, [](uint64_t val1, uint64_t val2) { return val1 < val2 ? val1 : val2; });
+		co_await testAtomicOpOnEmptyValue(cx, MutationRef::Min, key, [](Value v1, Value v2) -> Value {
 			uint64_t zeroVal = 0;
 			if (v2.empty())
 				return StringRef();
@@ -546,10 +532,10 @@ public:
 		setApiVersion(&cx, currentApiVersion);
 		TraceEvent(SevInfo, "Running Atomic Op Min Correctness Current Api Version")
 		    .detail("Version", currentApiVersion);
-		co_await self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::Min, key);
-		co_await self->testAtomicOpApi(
-		    cx, self, MutationRef::Min, key, [](uint64_t val1, uint64_t val2) { return val1 < val2 ? val1 : val2; });
-		co_await self->testAtomicOpOnEmptyValue(cx, self, MutationRef::Min, key, [](Value v1, Value v2) -> Value {
+		co_await testAtomicOpSetOnNonExistingKey(cx, MutationRef::Min, key);
+		co_await testAtomicOpApi(
+		    cx, MutationRef::Min, key, [](uint64_t val1, uint64_t val2) { return val1 < val2 ? val1 : val2; });
+		co_await testAtomicOpOnEmptyValue(cx, MutationRef::Min, key, [](Value v1, Value v2) -> Value {
 			uint64_t zeroVal = 0;
 			if (v2.empty())
 				return StringRef();
@@ -558,30 +544,28 @@ public:
 		});
 	}
 
-	Future<Void> testMax(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
-		Key key = self->getTestKey("test_key_max_");
+	Future<Void> testMax(Database cx) {
+		Key key = getTestKey("test_key_max_");
 
 		TraceEvent(SevInfo, "Running Atomic Op MAX Correctness Current Api Version").log();
-		co_await self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::Max, key);
-		co_await self->testAtomicOpApi(
-		    cx, self, MutationRef::Max, key, [](uint64_t val1, uint64_t val2) { return val1 > val2 ? val1 : val2; });
-		co_await self->testAtomicOpOnEmptyValue(cx, self, MutationRef::Max, key, [](Value v1, Value v2) -> Value {
-			return !v2.empty() ? v2 : StringRef();
-		});
+		co_await testAtomicOpSetOnNonExistingKey(cx, MutationRef::Max, key);
+		co_await testAtomicOpApi(
+		    cx, MutationRef::Max, key, [](uint64_t val1, uint64_t val2) { return val1 > val2 ? val1 : val2; });
+		co_await testAtomicOpOnEmptyValue(
+		    cx, MutationRef::Max, key, [](Value v1, Value v2) -> Value { return !v2.empty() ? v2 : StringRef(); });
 	}
 
-	Future<Void> testAnd(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
+	Future<Void> testAnd(Database cx) {
 		int currentApiVersion = getApiVersion(cx);
-		Key key = self->getTestKey("test_key_and_");
+		Key key = getTestKey("test_key_and_");
 
 		TraceEvent("AtomicOpCorrectnessApiWorkload").detail("OpType", "AND");
 		// API Version 500
 		setApiVersion(&cx, 500);
 		TraceEvent(SevInfo, "Running Atomic Op AND Correctness Test Api Version 500").log();
-		co_await self->testAtomicOpUnsetOnNonExistingKey(cx, self, MutationRef::And, key);
-		co_await self->testAtomicOpApi(
-		    cx, self, MutationRef::And, key, [](uint64_t val1, uint64_t val2) { return val1 & val2; });
-		co_await self->testAtomicOpOnEmptyValue(cx, self, MutationRef::And, key, [](Value v1, Value v2) -> Value {
+		co_await testAtomicOpUnsetOnNonExistingKey(cx, MutationRef::And, key);
+		co_await testAtomicOpApi(cx, MutationRef::And, key, [](uint64_t val1, uint64_t val2) { return val1 & val2; });
+		co_await testAtomicOpOnEmptyValue(cx, MutationRef::And, key, [](Value v1, Value v2) -> Value {
 			uint64_t zeroVal = 0;
 			if (v2.empty())
 				return StringRef();
@@ -593,10 +577,9 @@ public:
 		setApiVersion(&cx, currentApiVersion);
 		TraceEvent(SevInfo, "Running Atomic Op AND Correctness Current Api Version")
 		    .detail("Version", currentApiVersion);
-		co_await self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::And, key);
-		co_await self->testAtomicOpApi(
-		    cx, self, MutationRef::And, key, [](uint64_t val1, uint64_t val2) { return val1 & val2; });
-		co_await self->testAtomicOpOnEmptyValue(cx, self, MutationRef::And, key, [](Value v1, Value v2) -> Value {
+		co_await testAtomicOpSetOnNonExistingKey(cx, MutationRef::And, key);
+		co_await testAtomicOpApi(cx, MutationRef::And, key, [](uint64_t val1, uint64_t val2) { return val1 & val2; });
+		co_await testAtomicOpOnEmptyValue(cx, MutationRef::And, key, [](Value v1, Value v2) -> Value {
 			uint64_t zeroVal = 0;
 			if (v2.empty())
 				return StringRef();
@@ -605,73 +588,69 @@ public:
 		});
 	}
 
-	Future<Void> testOr(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
-		Key key = self->getTestKey("test_key_or_");
+	Future<Void> testOr(Database cx) {
+		Key key = getTestKey("test_key_or_");
 
 		TraceEvent(SevInfo, "Running Atomic Op OR Correctness Current Api Version").log();
-		co_await self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::Or, key);
-		co_await self->testAtomicOpApi(
-		    cx, self, MutationRef::Or, key, [](uint64_t val1, uint64_t val2) { return val1 | val2; });
-		co_await self->testAtomicOpOnEmptyValue(
-		    cx, self, MutationRef::Or, key, [](Value v1, Value v2) -> Value { return !v2.empty() ? v2 : StringRef(); });
+		co_await testAtomicOpSetOnNonExistingKey(cx, MutationRef::Or, key);
+		co_await testAtomicOpApi(cx, MutationRef::Or, key, [](uint64_t val1, uint64_t val2) { return val1 | val2; });
+		co_await testAtomicOpOnEmptyValue(
+		    cx, MutationRef::Or, key, [](Value v1, Value v2) -> Value { return !v2.empty() ? v2 : StringRef(); });
 	}
 
-	Future<Void> testXor(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
-		Key key = self->getTestKey("test_key_xor_");
+	Future<Void> testXor(Database cx) {
+		Key key = getTestKey("test_key_xor_");
 
 		TraceEvent(SevInfo, "Running Atomic Op XOR Correctness Current Api Version").log();
-		co_await self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::Xor, key);
-		co_await self->testAtomicOpApi(
-		    cx, self, MutationRef::Xor, key, [](uint64_t val1, uint64_t val2) { return val1 ^ val2; });
-		co_await self->testAtomicOpOnEmptyValue(cx, self, MutationRef::Xor, key, [](Value v1, Value v2) -> Value {
-			return !v2.empty() ? v2 : StringRef();
-		});
+		co_await testAtomicOpSetOnNonExistingKey(cx, MutationRef::Xor, key);
+		co_await testAtomicOpApi(cx, MutationRef::Xor, key, [](uint64_t val1, uint64_t val2) { return val1 ^ val2; });
+		co_await testAtomicOpOnEmptyValue(
+		    cx, MutationRef::Xor, key, [](Value v1, Value v2) -> Value { return !v2.empty() ? v2 : StringRef(); });
 	}
 
-	Future<Void> testAdd(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
-		Key key = self->getTestKey("test_key_add_");
+	Future<Void> testAdd(Database cx) {
+		Key key = getTestKey("test_key_add_");
 		TraceEvent(SevInfo, "Running Atomic Op ADD Correctness Current Api Version").log();
-		co_await self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::AddValue, key);
-		co_await self->testAtomicOpApi(
-		    cx, self, MutationRef::AddValue, key, [](uint64_t val1, uint64_t val2) { return val1 + val2; });
-		co_await self->testAtomicOpOnEmptyValue(cx, self, MutationRef::AddValue, key, [](Value v1, Value v2) -> Value {
-			return !v2.empty() ? v2 : StringRef();
-		});
+		co_await testAtomicOpSetOnNonExistingKey(cx, MutationRef::AddValue, key);
+		co_await testAtomicOpApi(
+		    cx, MutationRef::AddValue, key, [](uint64_t val1, uint64_t val2) { return val1 + val2; });
+		co_await testAtomicOpOnEmptyValue(
+		    cx, MutationRef::AddValue, key, [](Value v1, Value v2) -> Value { return !v2.empty() ? v2 : StringRef(); });
 	}
 
-	Future<Void> testCompareAndClear(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
-		Key key = self->getTestKey("test_key_compare_and_clear_");
+	Future<Void> testCompareAndClear(Database cx) {
+		Key key = getTestKey("test_key_compare_and_clear_");
 		TraceEvent(SevInfo, "Running Atomic Op COMPARE_AND_CLEAR Correctness Current Api Version").log();
-		co_await self->testCompareAndClearAtomicOpApi(cx, self, key, true);
-		co_await self->testCompareAndClearAtomicOpApi(cx, self, key, false);
+		co_await testCompareAndClearAtomicOpApi(cx, key, true);
+		co_await testCompareAndClearAtomicOpApi(cx, key, false);
 	}
 
-	Future<Void> testByteMin(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
-		Key key = self->getTestKey("test_key_byte_min_");
+	Future<Void> testByteMin(Database cx) {
+		Key key = getTestKey("test_key_byte_min_");
 
 		TraceEvent(SevInfo, "Running Atomic Op BYTE_MIN Correctness Current Api Version").log();
-		co_await self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::ByteMin, key);
-		co_await self->testAtomicOpApi(cx, self, MutationRef::ByteMin, key, [](uint64_t val1, uint64_t val2) {
+		co_await testAtomicOpSetOnNonExistingKey(cx, MutationRef::ByteMin, key);
+		co_await testAtomicOpApi(cx, MutationRef::ByteMin, key, [](uint64_t val1, uint64_t val2) {
 			return StringRef((const uint8_t*)&val1, sizeof(val1)) < StringRef((const uint8_t*)&val2, sizeof(val2))
 			           ? val1
 			           : val2;
 		});
-		co_await self->testAtomicOpOnEmptyValue(
-		    cx, self, MutationRef::ByteMin, key, [](Value v1, Value v2) -> Value { return StringRef(); });
+		co_await testAtomicOpOnEmptyValue(
+		    cx, MutationRef::ByteMin, key, [](Value v1, Value v2) -> Value { return StringRef(); });
 	}
 
-	Future<Void> testByteMax(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
-		Key key = self->getTestKey("test_key_byte_max_");
+	Future<Void> testByteMax(Database cx) {
+		Key key = getTestKey("test_key_byte_max_");
 
 		TraceEvent(SevInfo, "Running Atomic Op BYTE_MAX Correctness Current Api Version").log();
-		co_await self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::ByteMax, key);
-		co_await self->testAtomicOpApi(cx, self, MutationRef::ByteMax, key, [](uint64_t val1, uint64_t val2) {
+		co_await testAtomicOpSetOnNonExistingKey(cx, MutationRef::ByteMax, key);
+		co_await testAtomicOpApi(cx, MutationRef::ByteMax, key, [](uint64_t val1, uint64_t val2) {
 			return StringRef((const uint8_t*)&val1, sizeof(val1)) > StringRef((const uint8_t*)&val2, sizeof(val2))
 			           ? val1
 			           : val2;
 		});
-		co_await self->testAtomicOpOnEmptyValue(
-		    cx, self, MutationRef::ByteMax, key, [](Value v1, Value v2) -> Value { return !v1.empty() ? v1 : v2; });
+		co_await testAtomicOpOnEmptyValue(
+		    cx, MutationRef::ByteMax, key, [](Value v1, Value v2) -> Value { return !v1.empty() ? v1 : v2; });
 	}
 };
 

--- a/fdbserver/workloads/GetMappedRange.cpp
+++ b/fdbserver/workloads/GetMappedRange.cpp
@@ -63,20 +63,20 @@ struct GetMappedRangeWorkload : ApiWorkload {
 	Future<Void> start(Database const& cx) override {
 		// This workload is generated different from typical ApiWorkload. So don't use ApiWorkload::_start.
 		if (enabled) {
-			return GetMappedRangeWorkload::_start(cx, this);
+			return _start(cx);
 		}
 		return Void();
 	}
 
-	Future<Void> performSetup(Database cx, GetMappedRangeWorkload* self) {
+	Future<Void> performSetupImpl(Database cx) {
 		std::vector<TransactionType> types;
 		types.push_back(NATIVE);
 		types.push_back(READ_YOUR_WRITES);
 
-		co_await self->chooseTransactionFactory(cx, types);
+		co_await chooseTransactionFactory(cx, types);
 	}
 
-	Future<Void> performSetup(Database const& cx) override { return performSetup(cx, this); }
+	Future<Void> performSetup(Database const& cx) override { return performSetupImpl(cx); }
 
 	Future<Void> performTest(Database const& cx, Standalone<VectorRef<KeyValueRef>> const& data) override {
 		// Ignore this because we are not using ApiWorkload's default ::start.
@@ -94,7 +94,7 @@ struct GetMappedRangeWorkload : ApiWorkload {
 	static Value recordValue(int i) { return Tuple::makeTuple(dataOfRecord(i)).pack(); }
 	static Value recordValue(int i, int split) { return Tuple::makeTuple(dataOfRecord(i, split)).pack(); }
 
-	Future<Void> fillInRecords(Database cx, int n, GetMappedRangeWorkload* self) {
+	Future<Void> fillInRecords(Database cx, int n) {
 		Transaction tr(cx);
 		while (true) {
 			std::cout << "start fillInRecords n=" << n << std::endl;
@@ -105,7 +105,7 @@ struct GetMappedRangeWorkload : ApiWorkload {
 				Error err;
 				try {
 					for (int i = 0; i < n; i++) {
-						if (self->SPLIT_RECORDS) {
+						if (SPLIT_RECORDS) {
 							for (int split = 0; split < SPLIT_SIZE; split++) {
 								tr.set(recordKey(i, split), recordValue(i, split));
 								if (i == 0) {
@@ -163,17 +163,14 @@ struct GetMappedRangeWorkload : ApiWorkload {
 	}
 
 	// Return true if need to retry.
-	static bool validateRecord(int expectedId,
-	                           const MappedKeyValueRef* it,
-	                           GetMappedRangeWorkload* self,
-	                           bool allMissing) {
+	bool validateRecord(int expectedId, const MappedKeyValueRef* it, bool allMissing) {
 		// std::cout << "validateRecord expectedId " << expectedId << " it->key " << printable(it->key)
 		//           << " indexEntryKey(expectedId) " << printable(indexEntryKey(expectedId)) << std::endl;
 
 		ASSERT(it->key == indexEntryKey(expectedId));
 		ASSERT(it->value == EMPTY);
 
-		if (self->SPLIT_RECORDS) {
+		if (SPLIT_RECORDS) {
 			ASSERT(std::holds_alternative<GetRangeReqAndResultRef>(it->reqAndResult));
 			auto& getRange = std::get<GetRangeReqAndResultRef>(it->reqAndResult);
 			auto& rangeResult = getRange.result;
@@ -215,7 +212,6 @@ struct GetMappedRangeWorkload : ApiWorkload {
 	                                                    int limit,
 	                                                    int byteLimit,
 	                                                    int expectedBeginId,
-	                                                    GetMappedRangeWorkload* self,
 	                                                    bool allMissing) {
 
 		std::cout << "start scanMappedRangeWithLimits beginSelector:" << beginSelector.toString()
@@ -224,18 +220,14 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		          << " STRICTLY_ENFORCE_BYTE_LIMIT: " << SERVER_KNOBS->STRICTLY_ENFORCE_BYTE_LIMIT << " allMissing "
 		          << allMissing << std::endl;
 		while (true) {
-			Reference<TransactionWrapper> tr = self->createTransaction();
+			Reference<TransactionWrapper> tr = createTransaction();
 			{
 				Error err;
 				try {
-					MappedRangeResult result = co_await tr->getMappedRange(beginSelector,
-					                                                       endSelector,
-					                                                       mapper,
-					                                                       GetRangeLimits(limit, byteLimit),
-					                                                       self->snapshot,
-					                                                       Reverse::False);
+					MappedRangeResult result = co_await tr->getMappedRange(
+					    beginSelector, endSelector, mapper, GetRangeLimits(limit, byteLimit), snapshot, Reverse::False);
 					//			showResult(result);
-					if (self->BAD_MAPPER) {
+					if (BAD_MAPPER) {
 						TraceEvent("GetMappedRangeWorkloadShouldNotReachable").detail("ResultSize", result.size());
 					}
 					std::cout << "result.size()=" << result.size() << std::endl;
@@ -246,7 +238,7 @@ struct GetMappedRangeWorkload : ApiWorkload {
 					int cnt = 0;
 					const MappedKeyValueRef* it = result.begin();
 					for (; cnt < result.size(); cnt++, it++) {
-						if (validateRecord(expectedId, it, self, allMissing)) {
+						if (validateRecord(expectedId, it, allMissing)) {
 							needRetry = true;
 							break;
 						}
@@ -260,7 +252,7 @@ struct GetMappedRangeWorkload : ApiWorkload {
 				} catch (Error& e) {
 					err = e;
 				}
-				if ((self->BAD_MAPPER && err.code() == error_code_mapper_bad_index) ||
+				if ((BAD_MAPPER && err.code() == error_code_mapper_bad_index) ||
 				    (!SERVER_KNOBS->QUICK_GET_VALUE_FALLBACK && err.code() == error_code_quick_get_value_miss) ||
 				    (!SERVER_KNOBS->QUICK_GET_KEY_VALUES_FALLBACK &&
 				     err.code() == error_code_quick_get_key_values_miss)) {
@@ -282,11 +274,7 @@ struct GetMappedRangeWorkload : ApiWorkload {
 
 	// if sendFirstRequestIndefinitely is true, then this method would send the first request indefinitely
 	// it is in order to test the metric
-	Future<Void> submitSmallRequestIndefinitely(Database cx,
-	                                            int beginId,
-	                                            int endId,
-	                                            Key mapper,
-	                                            GetMappedRangeWorkload* self) {
+	Future<Void> submitSmallRequestIndefinitely(Database cx, int beginId, int endId, Key mapper) {
 		Key beginTuple = Tuple().append(prefix).append(INDEX).append(indexKey(beginId)).getDataAsStandalone();
 		KeySelector beginSelector = KeySelector(firstGreaterOrEqual(beginTuple));
 		Key endTuple = Tuple().append(prefix).append(INDEX).append(indexKey(endId)).getDataAsStandalone();
@@ -294,8 +282,8 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		int limit = 1;
 		int byteLimit = 10000;
 		while (true) {
-			MappedRangeResult result = co_await self->scanMappedRangeWithLimits(
-			    cx, beginSelector, endSelector, mapper, limit, byteLimit, beginId, self, false);
+			MappedRangeResult result = co_await scanMappedRangeWithLimits(
+			    cx, beginSelector, endSelector, mapper, limit, byteLimit, beginId, false);
 			if (result.empty()) {
 				TraceEvent("EmptyResult");
 			}
@@ -304,12 +292,7 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		}
 	}
 
-	Future<Void> scanMappedRange(Database cx,
-	                             int beginId,
-	                             int endId,
-	                             Key mapper,
-	                             GetMappedRangeWorkload* self,
-	                             bool allMissing = false) {
+	Future<Void> scanMappedRange(Database cx, int beginId, int endId, Key mapper, bool allMissing = false) {
 		Key beginTuple = Tuple::makeTuple(prefix, INDEX, indexKey(beginId)).getDataAsStandalone();
 		KeySelector beginSelector = KeySelector(firstGreaterOrEqual(beginTuple));
 		Key endTuple = Tuple::makeTuple(prefix, INDEX, indexKey(endId)).getDataAsStandalone();
@@ -321,8 +304,8 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		          << " FRACTION_INDEX_BYTELIMIT_PREFETCH: " << SERVER_KNOBS->FRACTION_INDEX_BYTELIMIT_PREFETCH
 		          << " MAX_PARALLEL_QUICK_GET_VALUE: " << SERVER_KNOBS->MAX_PARALLEL_QUICK_GET_VALUE << std::endl;
 		while (true) {
-			MappedRangeResult result = co_await self->scanMappedRangeWithLimits(
-			    cx, beginSelector, endSelector, mapper, limit, byteLimit, expectedBeginId, self, allMissing);
+			MappedRangeResult result = co_await scanMappedRangeWithLimits(
+			    cx, beginSelector, endSelector, mapper, limit, byteLimit, expectedBeginId, allMissing);
 			expectedBeginId += result.size();
 			if (result.more) {
 				if (result.empty()) {
@@ -360,16 +343,14 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		ASSERT(expectedBeginId == endId);
 	}
 
-	static void conflictWriteOnRecord(int conflictRecordId,
-	                                  Reference<TransactionWrapper>& tr,
-	                                  GetMappedRangeWorkload* self) {
+	void conflictWriteOnRecord(int conflictRecordId, Reference<TransactionWrapper>& tr) {
 		Key writeKey;
 		if (deterministicRandom()->random01() < 0.5) {
 			// Concurrent write to the primary scanned range
 			writeKey = indexEntryKey(conflictRecordId);
 		} else {
 			// Concurrent write to the underlying scanned ranges/keys
-			if (self->SPLIT_RECORDS) {
+			if (SPLIT_RECORDS) {
 				// Update one of the splits is sufficient.
 				writeKey = recordKey(conflictRecordId, 0);
 			} else {
@@ -396,11 +377,11 @@ struct GetMappedRangeWorkload : ApiWorkload {
 
 	// If another transaction writes to our read set (the scanned ranges) before we commit, the transaction should
 	// fail.
-	Future<Void> testSerializableConflicts(GetMappedRangeWorkload* self) {
+	Future<Void> testSerializableConflicts() {
 		std::cout << "testSerializableConflicts" << std::endl;
 
 		while (true) {
-			Reference<TransactionWrapper> tr1 = self->createTransaction();
+			Reference<TransactionWrapper> tr1 = createTransaction();
 			{
 				Error err;
 				try {
@@ -408,11 +389,11 @@ struct GetMappedRangeWorkload : ApiWorkload {
 
 					// Commit another transaction that has conflict writes.
 					while (true) {
-						Reference<TransactionWrapper> tr2 = self->createTransaction();
+						Reference<TransactionWrapper> tr2 = createTransaction();
 						{
 							Error err;
 							try {
-								conflictWriteOnRecord(7, tr2, self);
+								conflictWriteOnRecord(7, tr2);
 								co_await tr2->commit();
 								break;
 							} catch (Error& e) {
@@ -486,15 +467,15 @@ struct GetMappedRangeWorkload : ApiWorkload {
 
 	// If the same transaction writes to the read set (the scanned ranges) before reading, it should throw read your
 	// write exception.
-	Future<Void> testRYW(GetMappedRangeWorkload* self) {
+	Future<Void> testRYW() {
 		std::cout << "testRYW" << std::endl;
 		while (true) {
-			Reference<TransactionWrapper> tr1 = self->createTransaction();
+			Reference<TransactionWrapper> tr1 = createTransaction();
 			{
 				Error err;
 				try {
 					// Write something that will be read in getMappedRange.
-					conflictWriteOnRecord(7, tr1, self);
+					conflictWriteOnRecord(7, tr1);
 					MappedRangeResult result = co_await runGetMappedRange(5, 10, tr1);
 					UNREACHABLE();
 				} catch (Error& e) {
@@ -514,8 +495,8 @@ struct GetMappedRangeWorkload : ApiWorkload {
 
 	Future<Void> testMetric(Database cx, int beginId, int endId, Key mapper, int seconds) {
 		while (true) {
-			auto choice = co_await race(
-			    reportMetric(cx), submitSmallRequestIndefinitely(cx, 10, 490, mapper, this), delay(seconds));
+			auto choice =
+			    co_await race(reportMetric(cx), submitSmallRequestIndefinitely(cx, 10, 490, mapper), delay(seconds));
 			if (choice.index() == 0) {
 
 				TraceEvent(SevError, "Error: ReportMetric has ended");
@@ -589,7 +570,7 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		ASSERT(rejected);
 	}
 
-	Future<Void> checkMappedSelectorBoundaries(Database cx, Key mapper, GetMappedRangeWorkload* self) {
+	Future<Void> checkMappedSelectorBoundaries(Database cx, Key mapper) {
 		Key begin = indexEntryKey(10);
 		Key end = indexEntryKey(20);
 		co_await checkMappedSelectorRange(cx,
@@ -597,15 +578,13 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		                                  KeySelector(firstGreaterThan(end), end.arena()),
 		                                  mapper,
 		                                  /*expectedBeginId=*/11,
-		                                  /*expectedEndId=*/21,
-		                                  self);
+		                                  /*expectedEndId=*/21);
 		co_await checkMappedSelectorRange(cx,
 		                                  KeySelector(firstGreaterOrEqual(begin) + 2, begin.arena()),
 		                                  KeySelector(firstGreaterOrEqual(end) - 2, end.arena()),
 		                                  mapper,
 		                                  /*expectedBeginId=*/12,
-		                                  /*expectedEndId=*/18,
-		                                  self);
+		                                  /*expectedEndId=*/18);
 
 		co_await checkEmptyMappedRangeDoesNotConflict(cx,
 		                                              KeySelector(firstGreaterOrEqual(begin), begin.arena()),
@@ -645,8 +624,7 @@ struct GetMappedRangeWorkload : ApiWorkload {
 	                                      KeySelector end,
 	                                      Key mapper,
 	                                      int expectedBeginId,
-	                                      int expectedEndId,
-	                                      GetMappedRangeWorkload* self) {
+	                                      int expectedEndId) {
 		int expectedId = expectedBeginId;
 		while (true) {
 			MappedRangeResult result = co_await scanMappedRangeWithLimits(cx,
@@ -656,7 +634,6 @@ struct GetMappedRangeWorkload : ApiWorkload {
 			                                                              /*limit=*/100,
 			                                                              /*byteLimit=*/100000,
 			                                                              expectedId,
-			                                                              self,
 			                                                              /*allMissing=*/false);
 			expectedId += result.size();
 			ASSERT_LE(expectedId, expectedEndId);
@@ -673,23 +650,23 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		ASSERT_EQ(expectedId, expectedEndId);
 	}
 
-	Future<Void> _start(Database cx, GetMappedRangeWorkload* self) {
-		TraceEvent("GetMappedRangeWorkloadConfig").detail("BadMapper", self->BAD_MAPPER);
+	Future<Void> _start(Database cx) {
+		TraceEvent("GetMappedRangeWorkloadConfig").detail("BadMapper", BAD_MAPPER);
 
 		// TODO: Use toml to config
-		co_await self->fillInRecords(cx, 500, self);
+		co_await fillInRecords(cx, 500);
 
-		if (self->transactionType == NATIVE) {
-			self->snapshot = Snapshot::True;
-		} else if (self->transactionType == READ_YOUR_WRITES) {
-			self->snapshot = Snapshot::False;
-			co_await self->checkMappedSelectorBoundaries(cx, getMapper(false), self);
+		if (transactionType == NATIVE) {
+			snapshot = Snapshot::True;
+		} else if (transactionType == READ_YOUR_WRITES) {
+			snapshot = Snapshot::False;
+			co_await checkMappedSelectorBoundaries(cx, getMapper(false));
 			const double rand = deterministicRandom()->random01();
 			if (rand < 0.1) {
-				co_await self->testSerializableConflicts(self);
+				co_await testSerializableConflicts();
 				co_return;
 			} else if (rand < 0.2) {
-				co_await self->testRYW(self);
+				co_await testRYW();
 				co_return;
 			} else {
 				// Test the happy path where there is no conflicts or RYW
@@ -697,20 +674,20 @@ struct GetMappedRangeWorkload : ApiWorkload {
 		} else {
 			UNREACHABLE();
 		}
-		if (self->transactionType == NATIVE) {
-			co_await self->checkMappedSelectorBoundaries(cx, getMapper(false), self);
+		if (transactionType == NATIVE) {
+			co_await checkMappedSelectorBoundaries(cx, getMapper(false));
 		}
 
-		std::cout << "Test configuration: transactionType:" << self->transactionType << " snapshot:" << self->snapshot
-		          << "bad_mapper:" << self->BAD_MAPPER << std::endl;
+		std::cout << "Test configuration: transactionType:" << transactionType << " snapshot:" << snapshot
+		          << "bad_mapper:" << BAD_MAPPER << std::endl;
 
 		Key mapper = getMapper(false);
 		// The scanned range cannot be too large to hit get_mapped_key_values_has_more. We have a unit validating the
 		// error is thrown when the range is large.
 		bool originalStrictlyEnforeByteLimit = SERVER_KNOBS->STRICTLY_ENFORCE_BYTE_LIMIT;
 		(const_cast<ServerKnobs*>(SERVER_KNOBS))->STRICTLY_ENFORCE_BYTE_LIMIT = deterministicRandom()->coinflip();
-		co_await self->scanMappedRange(cx, 10, 490, mapper, self);
-		co_await testMetric(cx, 10, 490, mapper, self->checkStorageQueueSeconds);
+		co_await scanMappedRange(cx, 10, 490, mapper);
+		co_await testMetric(cx, 10, 490, mapper, checkStorageQueueSeconds);
 
 		// reset it to default
 		(const_cast<ServerKnobs*>(SERVER_KNOBS))->STRICTLY_ENFORCE_BYTE_LIMIT = originalStrictlyEnforeByteLimit;

--- a/flow/TLSConfig.cpp
+++ b/flow/TLSConfig.cpp
@@ -317,9 +317,9 @@ TLSPolicy::TLSPolicy(const LoadedTLSConfig& loaded, std::function<void()> on_fai
 	set_verify_peers(loaded.getVerifyPeers());
 }
 
-Future<LoadedTLSConfig> TLSConfig::loadAsync(const TLSConfig* self) {
+Future<LoadedTLSConfig> TLSConfig::loadAsync() const {
 	LoadedTLSConfig loaded;
-	auto materials = getTLSMaterialSources(*self, loaded);
+	auto materials = getTLSMaterialSources(*this, loaded);
 	std::vector<Future<Void>> reads;
 
 	for (const auto& material : materials) {
@@ -348,7 +348,7 @@ Future<LoadedTLSConfig> TLSConfig::loadAsync(const TLSConfig* self) {
 		throw;
 	}
 
-	copyTLSSettings(*self, loaded);
+	copyTLSSettings(*this, loaded);
 	co_return loaded;
 }
 

--- a/flow/include/flow/TLSConfig.h
+++ b/flow/include/flow/TLSConfig.h
@@ -188,7 +188,7 @@ public:
 	// Load all specified certificates into memory, and return an object that
 	// allows access to them.
 	// If self has any certificates by path, they will be *asynchronously* loaded from disk.
-	Future<LoadedTLSConfig> loadAsync() const { return loadAsync(this); } // FIXME: swift
+	Future<LoadedTLSConfig> loadAsync() const;
 
 	// Return the explicitly set path.
 	// If one was not set, return the path from the environment.
@@ -207,8 +207,6 @@ public:
 #ifndef PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP
 private:
 #endif
-	static Future<LoadedTLSConfig> loadAsync(const TLSConfig* self); // FIXME
-
 	std::string tlsCertPath, tlsKeyPath, tlsCAPath;
 	std::string tlsCertBytes, tlsKeyBytes, tlsCABytes;
 	std::string tlsPassword;


### PR DESCRIPTION
Remove actor-compiler-era explicit receiver parameters from 70 methods across 18 classes. Each class has its own commit.

Pure forwarding wrappers are folded into member coroutines. Helpers remain where they preserve owning arguments, synchronous fast paths, or cancellation and teardown ordering; owning `Reference<T>` receiver parameters are retained.

The changes cover TLS loading, cached-file I/O, backup readers/writers and restore configuration, prefix allocation, coordinator state, TLog and memory-store recovery, Redwood cache clearing, and the GetMappedRange and AtomicOpsApiCorrectness workloads.

Validation:

- 240 unit checks passed: RPC (68), client (103), server core (33), storage engines (25), coordinator (1), TLog (2), decoder (4), and simulated file I/O (4).
- Built the converter and verified its help output with the existing expected exit status.
- Five focused simulations passed with seed `20260830` and buggify enabled: `GetMappedRange`, `AtomicOpsApiCorrectness`, `TxnStateStoreCycleTest`, `CloggedCycleTest`, and `BackupAndRestore`. All expected test results passed and all runs completed without error traces; `CloggedCycleTest` recorded a completed coordinator move.
- Independent source review, clang-format 19, and `git diff --check` passed.

The build wrapper returned exit 1 after successful linking with zero compiler failures. The test results above come from direct runs of the freshly built binaries.
