### PR TITLE
Enable clang-tidy checks for condition assignments, NUL strings, and vector growth

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: >
   -*,
+  bugprone-assignment-in-if-condition,
   bugprone-dangling-handle,
   bugprone-implicit-widening-of-multiplication-result,
   bugprone-inaccurate-erase,
@@ -13,6 +14,7 @@ Checks: >
   bugprone-sizeof-expression,
   bugprone-string-constructor,
   bugprone-string-integer-assignment,
+  bugprone-string-literal-with-embedded-nul,
   bugprone-stringview-nullptr,
   bugprone-suspicious-memory-comparison,
   bugprone-suspicious-memset-usage,
@@ -32,6 +34,7 @@ Checks: >
   modernize-use-using,
   performance-for-range-copy,
   performance-implicit-conversion-in-loop,
+  performance-inefficient-vector-operation,
   performance-move-const-arg,
   performance-move-constructor-init,
   readability-braces-around-statements,

--- a/bindings/c/test/apitester/TesterTransactionExecutor.cpp
+++ b/bindings/c/test/apitester/TesterTransactionExecutor.cpp
@@ -295,6 +295,7 @@ protected:
 
 	std::vector<fdb::Error::CodeType> retriedErrorCodes() {
 		std::vector<fdb::Error::CodeType> retriedErrorCodes;
+		retriedErrorCodes.reserve(retriedErrors.size());
 		for (auto e : retriedErrors) {
 			retriedErrorCodes.push_back(e.code());
 		}

--- a/bindings/c/test/apitester/TesterWorkload.cpp
+++ b/bindings/c/test/apitester/TesterWorkload.cpp
@@ -305,6 +305,7 @@ void WorkloadManager::schedulePrintStatistics(int timeIntervalMs) {
 std::vector<std::shared_ptr<IWorkload>> WorkloadManager::getActiveWorkloads() {
 	std::unique_lock<std::mutex> lock(mutex);
 	std::vector<std::shared_ptr<IWorkload>> res;
+	res.reserve(workloads.size());
 	for (const auto& iter : workloads) {
 		res.push_back(iter.second.ref);
 	}

--- a/bindings/c/test/client_memory_test.cpp
+++ b/bindings/c/test/client_memory_test.cpp
@@ -64,6 +64,7 @@ int main(int argc, char** argv) {
 	};
 	std::vector<std::thread> threads;
 	constexpr auto kThreadCount = 64;
+	threads.reserve(kThreadCount);
 	for (int i = 0; i < kThreadCount; ++i) {
 		threads.emplace_back(thread_func);
 	}

--- a/bindings/flow/fdb_flow.cpp
+++ b/bindings/flow/fdb_flow.cpp
@@ -53,6 +53,7 @@ Future<Void> _test() {
 	// for (int i = 0; i < 100000; i++) {
 	// 	Version v = wait( tr->getReadVersion() );
 	// }
+	versions.reserve(100000);
 	for (int i = 0; i < 100000; i++) {
 		versions.push_back(tr->getReadVersion());
 	}

--- a/documentation/sphinx/source/clang-tidy.rst
+++ b/documentation/sphinx/source/clang-tidy.rst
@@ -10,15 +10,15 @@ This guide explains how to run ``clang-tidy`` locally so you can fix issues befo
 What clang-tidy checks
 ======================
 
-FoundationDB configures 40 named checks in the ``.clang-tidy`` file at the repository root. The
+FoundationDB configures 43 named checks in the ``.clang-tidy`` file at the repository root. The
 active set depends on the clang-tidy version and can be inspected with ``clang-tidy --list-checks``.
 The intent is to enable more as we go forward. Here are some example rules:
 
-* **22 Bugprone rules** -- catch potential runtime errors, including dangling returned references, incorrect forwarding, bytewise operations on non-trivially-copyable objects, incorrect erase/remove calls, and arithmetic widened after the calculation
+* **24 Bugprone rules** -- catch potential runtime errors, including assignments in conditions, truncated string literals with embedded NUL bytes, dangling returned references, incorrect forwarding, bytewise operations on non-trivially-copyable objects, incorrect erase/remove calls, and arithmetic widened after the calculation
 * **1 C++ Core Guidelines rule** -- catch unsafe captures in coroutine lambdas (``cppcoreguidelines-avoid-capturing-lambda-coroutines``)
 * **2 Misc rules** -- catch redundant expressions and RAII objects held across coroutine suspension points
 * **4 Modernize rules** -- encourage modern C++ practices (e.g., ``modernize-use-auto``, ``modernize-use-override``)
-* **4 Performance rules** -- avoid unnecessary copies, hidden range-loop conversions, pointless moves, and move constructors that copy movable members (``performance-for-range-copy``, ``performance-implicit-conversion-in-loop``, ``performance-move-const-arg``, ``performance-move-constructor-init``)
+* **5 Performance rules** -- avoid unnecessary copies, hidden range-loop conversions, repeated vector growth in simple loops, pointless moves, and move constructors that copy movable members (``performance-for-range-copy``, ``performance-implicit-conversion-in-loop``, ``performance-inefficient-vector-operation``, ``performance-move-const-arg``, ``performance-move-constructor-init``)
 * **7 Readability rules** -- improve code clarity (e.g., ``readability-container-contains``, ``readability-container-size-empty``)
 
 ``misc-coroutine-hostile-raii`` checks Flow's blocking ``MutexHolder`` and

--- a/fdbbackup/FileConverter.cpp
+++ b/fdbbackup/FileConverter.cpp
@@ -308,6 +308,7 @@ struct MutationFilesReadProgress : public ReferenceCounted<MutationFilesReadProg
 	// Opens log files in the progress and starts decoding until the beginVersion is seen.
 	static Future<Void> openLogFilesImpl(MutationFilesReadProgress* progress, Reference<IBackupContainer> container) {
 		std::vector<Future<Reference<IAsyncFile>>> asyncFiles;
+		asyncFiles.reserve(progress->files.size());
 		for (const auto& file : progress->files) {
 			asyncFiles.push_back(container->readFile(file.fileName));
 		}

--- a/fdbbackup/backup.cpp
+++ b/fdbbackup/backup.cpp
@@ -4526,6 +4526,7 @@ int main() {
 		int argc = static_cast<int>(persistentArgs.size());
 
 		std::vector<char*> argv;
+		argv.reserve(persistentArgs.size() + 1);
 		for (auto& arg : persistentArgs) {
 			argv.push_back(arg.data());
 		}

--- a/fdbcli/LocationMetadataCommand.cpp
+++ b/fdbcli/LocationMetadataCommand.cpp
@@ -29,6 +29,7 @@
 namespace {
 Future<std::string> describeServers(Reference<ReadYourWritesTransaction> tr, std::vector<UID> ids) {
 	std::vector<Future<Optional<Value>>> serverListEntries;
+	serverListEntries.reserve(ids.size());
 	for (const UID& id : ids) {
 		serverListEntries.push_back(tr->get(serverListKeyFor(id)));
 	}

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -272,6 +272,7 @@ Future<std::vector<KeyBackedTag>> TagUidMap::getAll_impl(TagUidMap* tagsMap,
 	Key prefix = tagsMap->prefix; // Copying it here as tagsMap lifetime is not tied to this actor
 	TagMap::RangeResultType tagPairs = co_await tagsMap->getRange(tr, std::string(), {}, 1e6, snapshot);
 	std::vector<KeyBackedTag> results;
+	results.reserve(tagPairs.results.size());
 	for (auto& p : tagPairs.results)
 		results.push_back(KeyBackedTag(p.first, prefix));
 	co_return results;
@@ -288,6 +289,7 @@ Future<bool> anyPartitionedBackupRunning(Reference<ReadYourWritesTransaction> tr
 	std::vector<KeyBackedTag> tags = co_await getAllBackupTags(tr);
 
 	std::vector<Future<Optional<UidAndAbortedFlagT>>> futures;
+	futures.reserve(tags.size());
 	for (const auto& tag : tags) {
 		futures.push_back(tag.get(tr));
 	}
@@ -318,6 +320,7 @@ Future<bool> anyRangePartitionedBackupRunning(Reference<ReadYourWritesTransactio
 	std::vector<KeyBackedTag> tags = co_await getAllBackupTags(tr);
 
 	std::vector<Future<Optional<UidAndAbortedFlagT>>> futures;
+	futures.reserve(tags.size());
 	for (const auto& tag : tags) {
 		futures.push_back(tag.get(tr));
 	}
@@ -3885,6 +3888,7 @@ struct BulkDumpTaskFunc : BackupTaskFuncBase {
 
 					// Build beginEndKeys from backup ranges
 					std::vector<std::pair<Key, Key>> beginEndKeys;
+					beginEndKeys.reserve(backupRanges.size());
 					for (const auto& range : backupRanges) {
 						beginEndKeys.emplace_back(range.begin, range.end);
 					}

--- a/fdbclient/ManagementAPI.cpp
+++ b/fdbclient/ManagementAPI.cpp
@@ -2273,6 +2273,7 @@ Future<Void> waitForFullReplication(Database cx) {
 			config.fromKeyValues((VectorRef<KeyValueRef>)confResults);
 
 			std::vector<Future<Optional<Value>>> replicasFutures;
+			replicasFutures.reserve(config.regions.size());
 			for (auto& region : config.regions) {
 				replicasFutures.push_back(tr.get(datacenterReplicasKeyFor(region.dcId)));
 			}

--- a/fdbclient/MonitorLeader.cpp
+++ b/fdbclient/MonitorLeader.cpp
@@ -276,6 +276,7 @@ Future<std::vector<NetworkAddress>> tryResolveHostnamesImpl(ClusterConnectionStr
 		allCoordinatorsSet.insert(coord);
 	}
 	std::vector<Future<Void>> fs;
+	fs.reserve(self->hostnames.size());
 	for (auto& hostname : self->hostnames) {
 		fs.push_back(map(hostname.resolve(), [&](Optional<NetworkAddress> const& addr) -> Void {
 			if (addr.present()) {
@@ -888,6 +889,7 @@ void shrinkProxyList(ClientDBInfo& ni,
                      std::vector<GrvProxyInterface>& lastGrvProxies) {
 	if (ni.commitProxies.size() > CLIENT_KNOBS->MAX_COMMIT_PROXY_CONNECTIONS) {
 		std::vector<UID> commitProxyUIDs;
+		commitProxyUIDs.reserve(ni.commitProxies.size());
 		for (auto& commitProxy : ni.commitProxies) {
 			commitProxyUIDs.push_back(commitProxy.id());
 		}
@@ -905,6 +907,7 @@ void shrinkProxyList(ClientDBInfo& ni,
 	}
 	if (ni.grvProxies.size() > CLIENT_KNOBS->MAX_GRV_PROXY_CONNECTIONS) {
 		std::vector<UID> grvProxyUIDs;
+		grvProxyUIDs.reserve(ni.grvProxies.size());
 		for (auto& grvProxy : ni.grvProxies) {
 			grvProxyUIDs.push_back(grvProxy.id());
 		}

--- a/fdbclient/MultiVersionTransaction.cpp
+++ b/fdbclient/MultiVersionTransaction.cpp
@@ -2263,9 +2263,9 @@ std::vector<std::pair<std::string, bool>> MultiVersionApi::copyExternalLibraryPe
 			char tempName[MAX_TMP_NAME_LENGTH];
 			snprintf(tempName, MAX_TMP_NAME_LENGTH, "%s/%s-XXXXXX", tmpDir.c_str(), filename.c_str());
 			int tempFd = mkstemp(tempName);
-			int fd;
+			int fd = open(path.c_str(), O_RDONLY);
 
-			if ((fd = open(path.c_str(), O_RDONLY)) == -1) {
+			if (fd == -1) {
 				TraceEvent("ExternalClientNotFound").detail("LibraryPath", path);
 				throw file_not_found();
 			}

--- a/fdbclient/NativeAPI.cpp
+++ b/fdbclient/NativeAPI.cpp
@@ -7044,6 +7044,7 @@ Future<std::vector<std::pair<KeyRange, CheckpointMetaData>>> getCheckpointMetaDa
                                                                                    Optional<UID> actionId,
                                                                                    double timeout) {
 	std::vector<Future<std::vector<std::pair<KeyRange, CheckpointMetaData>>>> futures;
+	futures.reserve(ranges.size());
 
 	// TODO(heliu): Avoid send requests to the same shard.
 	for (const auto& range : ranges) {

--- a/fdbclient/SpecialKeySpace.cpp
+++ b/fdbclient/SpecialKeySpace.cpp
@@ -1254,6 +1254,7 @@ Future<RangeResult> ExclusionInProgressActor(ReadYourWritesTransaction* ryw, Key
 	std::vector<std::string> excludedLocalities = fExcludedLocalities.get();
 	// Decode the excluded localities to check if any server is excluded by locality.
 	std::vector<std::pair<std::string, std::string>> decodedExcludedLocalities;
+	decodedExcludedLocalities.reserve(excludedLocalities.size());
 	for (auto& excludedLocality : excludedLocalities) {
 		decodedExcludedLocalities.push_back(decodeLocality(excludedLocality));
 	}

--- a/fdbclient/VersionVector.cpp
+++ b/fdbclient/VersionVector.cpp
@@ -120,6 +120,7 @@ void populateVersionVector(VersionVector& vv,
 	}
 
 	// Populate ids.
+	ids.reserve(tagCount > 0 ? tagCount : 0);
 	for (int i = 0; i < tagCount; i++) {
 		// Some of the ids could be duplicates, that's fine.
 		ids.push_back(deterministicRandom()->randomInt(0, maxTagId));

--- a/fdbclient/include/fdbclient/KeyBackedTypes.h
+++ b/fdbclient/include/fdbclient/KeyBackedTypes.h
@@ -176,6 +176,7 @@ struct TupleCodec<std::vector<T>> {
 	static std::vector<T> unpack(Standalone<StringRef> const& val) {
 		Tuple t = Tuple::unpack(val);
 		std::vector<T> v;
+		v.reserve(t.size());
 
 		for (int i = 0; i < t.size(); i++) {
 			v.push_back(TupleCodec<T>::unpack(t.getString(i)));

--- a/fdbclient/include/fdbclient/RangeLock.h
+++ b/fdbclient/include/fdbclient/RangeLock.h
@@ -154,6 +154,7 @@ public:
 
 	std::vector<RangeLockState> getAllLockStats() const {
 		std::vector<RangeLockState> res;
+		res.reserve(locks.size());
 		for (const auto& [name, lock] : locks) {
 			res.push_back(lock);
 		}

--- a/fdbclient/include/fdbclient/StackLineage.h
+++ b/fdbclient/include/fdbclient/StackLineage.h
@@ -33,6 +33,7 @@ struct StackLineageCollector : IALPCollector<StackLineage> {
 		auto vec = lineage->stack(&StackLineage::actorName);
 
 		std::vector<std::string_view> res;
+		res.reserve(vec.size());
 		for (const auto& str : vec) {
 			res.push_back(std::string_view(reinterpret_cast<const char*>(str.begin()), str.size()));
 		}

--- a/fdbrpc/FlowTests.cpp
+++ b/fdbrpc/FlowTests.cpp
@@ -670,6 +670,7 @@ TEST_CASE("/flow/flow/quorum") {
 	std::vector<Promise<int>> ps(5);
 	std::vector<Future<int>> fs;
 	std::vector<Future<Void>> qs;
+	fs.reserve(ps.size());
 	for (auto& p : ps)
 		fs.push_back(p.getFuture());
 
@@ -912,6 +913,7 @@ TEST_CASE("/flow/flow/yieldedFuture/progress") {
 	Future<Void> i = success(u);
 
 	std::vector<Future<Void>> v;
+	v.reserve(5);
 	for (int i = 0; i < 5; i++)
 		v.push_back(yieldedFuture(u));
 	auto numReady = [&v]() { return std::count_if(v.begin(), v.end(), [](Future<Void> v) { return v.isReady(); }); };
@@ -943,6 +945,7 @@ TEST_CASE("/flow/flow/yieldedFuture/random") {
 		Future<Void> i = success(u);
 
 		std::vector<Future<Void>> v;
+		v.reserve(25);
 		for (int i = 0; i < 25; i++)
 			v.push_back(yieldedFuture(u));
 		auto numReady = [&v]() {
@@ -991,6 +994,7 @@ TEST_CASE("/flow/perf/yieldedFuture") {
 	std::vector<Future<Void>> ys;
 
 	start = timer();
+	ys.reserve(N);
 	for (int i = 0; i < N; i++)
 		ys.push_back(yieldedFuture(f));
 	printf("yieldedFuture(f) create: %0.1f M/sec\n", N / 1e6 / (timer() - start));

--- a/fdbrpc/bench/BenchSelectReplicas.cpp
+++ b/fdbrpc/bench/BenchSelectReplicas.cpp
@@ -54,6 +54,7 @@ static void bench_select_replicas(int repCount, benchmark::State& state) {
 
 	// fromServersSet->DisplayEntries();
 
+	localityGroupEntries.reserve(serverCount > 0 ? serverCount : 0);
 	for (int i = 0; i < serverCount; i++) {
 		localityGroupEntries.push_back(fromServersGroup->getEntry(i));
 	}

--- a/fdbrpc/sim2.cpp
+++ b/fdbrpc/sim2.cpp
@@ -767,8 +767,8 @@ private:
 			throw io_error();
 		}
 
-		unsigned int read_bytes = 0;
-		if ((read_bytes = _read(self->h, data, (unsigned int)length)) == -1) {
+		unsigned int read_bytes = _read(self->h, data, (unsigned int)length);
+		if (read_bytes == -1) {
 			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 2);
 			throw io_error();
 		}
@@ -814,8 +814,8 @@ private:
 			throw io_error();
 		}
 
-		unsigned int write_bytes = 0;
-		if ((write_bytes = _write(self->h, (void*)data.begin(), data.size())) == -1) {
+		unsigned int write_bytes = _write(self->h, (void*)data.begin(), data.size());
+		if (write_bytes == -1) {
 			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 4);
 			throw io_error();
 		}

--- a/fdbserver/backupworker/RangePartitionedBackupWorker.cpp
+++ b/fdbserver/backupworker/RangePartitionedBackupWorker.cpp
@@ -239,6 +239,7 @@ struct RangePartitionedBackupData {
 
 	Future<Void> waitAllBackupsReady() {
 		std::vector<Future<Void>> all;
+		all.reserve(backups.size());
 		for (auto& [uid, info] : backups) {
 			all.push_back(info.waitBackupReady());
 		}
@@ -909,6 +910,7 @@ Future<Void> saveMutationsToFile(RangePartitionedBackupData* self, Version lastV
 	// Finish files
 	// TODO akanksha: Add FileLevel checksum.
 	std::vector<Future<Void>> finished;
+	finished.reserve(activeFiles.size());
 	for (auto& lf : activeFiles) {
 		finished.push_back(lf.file->finish());
 	}

--- a/fdbserver/clustercontroller/ClusterController.cpp
+++ b/fdbserver/clustercontroller/ClusterController.cpp
@@ -581,6 +581,7 @@ Future<Void> monitorAndRecruitLogRouters(ClusterControllerData* self) {
 
 Future<std::vector<int>> monitorCDCProxies(std::vector<CDCProxyInterface> const& cdcProxies) {
 	std::vector<Future<Void>> failures;
+	failures.reserve(cdcProxies.size());
 	for (const auto& proxy : cdcProxies) {
 		failures.push_back(
 		    waitFailureClient(proxy.waitFailure,

--- a/fdbserver/clustercontroller/ClusterController.h
+++ b/fdbserver/clustercontroller/ClusterController.h
@@ -3200,12 +3200,14 @@ public:
 
 		// Sort degraded peers based on the number of workers complaining about it.
 		std::vector<std::pair<int, NetworkAddress>> count2DegradedPeer;
+		count2DegradedPeer.reserve(degradedLinkDst2Src.size());
 		for (const auto& [degradedPeer, complainers] : degradedLinkDst2Src) {
 			count2DegradedPeer.push_back({ complainers.size(), degradedPeer });
 		}
 		std::sort(count2DegradedPeer.begin(), count2DegradedPeer.end(), deterministicDecendingOrder);
 
 		std::vector<std::pair<int, NetworkAddress>> count2DisconnectedPeer;
+		count2DisconnectedPeer.reserve(disconnectedLinkDst2Src.size());
 		for (const auto& [disconnectedPeer, complainers] : disconnectedLinkDst2Src) {
 			count2DisconnectedPeer.push_back({ complainers.size(), disconnectedPeer });
 		}

--- a/fdbserver/clustercontroller/Status.cpp
+++ b/fdbserver/clustercontroller/Status.cpp
@@ -2740,6 +2740,7 @@ AsyncResult<JsonBuilderObject> layerStatusFetcher(Database cx,
 				// TODO:  Also fetch other linked subtrees of meta keys
 
 				std::vector<Future<RangeResult>> docFutures;
+				docFutures.reserve(jsonLayers.size());
 				for (int i = 0; i < jsonLayers.size(); ++i) {
 					docFutures.push_back(
 					    tr.getRange(KeyRangeRef(jsonLayers[i].value, strinc(jsonLayers[i].value)), 1000));

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -207,6 +207,7 @@ Future<Void> deleteCheckpoints(Transaction* tr, std::set<UID> checkpointIds, UID
 	}
 	TraceEvent(SevDebug, "DataMoveDeleteCheckpoints", dataMoveId).detail("Checkpoints", describe(checkpointIds));
 	std::vector<Future<Optional<Value>>> checkpointEntries;
+	checkpointEntries.reserve(checkpointIds.size());
 	for (const UID& id : checkpointIds) {
 		checkpointEntries.push_back(tr->get(checkpointKeyFor(id)));
 	}
@@ -884,6 +885,7 @@ Future<std::vector<UID>> addReadWriteDestinations(KeyRangeRef shard,
 // Returns storage servers selected from 'candidates', who is serving a read-write copy of 'range'.
 Future<std::vector<UID>> pickReadWriteServers(Transaction* tr, std::vector<UID> candidates, KeyRangeRef range) {
 	std::vector<Future<Optional<Value>>> serverListEntries;
+	serverListEntries.reserve(candidates.size());
 
 	for (const UID id : candidates) {
 		serverListEntries.push_back(tr->get(serverListKeyFor(id)));
@@ -892,6 +894,7 @@ Future<std::vector<UID>> pickReadWriteServers(Transaction* tr, std::vector<UID> 
 	std::vector<Optional<Value>> serverListValues = co_await getAll(serverListEntries);
 
 	std::vector<StorageServerInterface> ssis;
+	ssis.reserve(serverListValues.size());
 	for (auto& v : serverListValues) {
 		ssis.push_back(decodeServerListValue(v.get()));
 	}
@@ -3155,6 +3158,7 @@ Future<std::pair<Version, Tag>> addStorageServer(Database cx, StorageServerInter
 
 			std::vector<Future<Optional<Value>>> localityExclusions;
 			std::map<std::string, std::string> localityData = server.locality.getAllData();
+			localityExclusions.reserve(localityData.size());
 			for (const auto& l : localityData) {
 				localityExclusions.push_back(tr->get(StringRef(encodeExcludedLocalityKey(
 				    LocalityData::ExcludeLocalityPrefix.toString() + l.first + ":" + l.second))));
@@ -3575,6 +3579,7 @@ Future<Void> removeKeysFromFailedServer(Database cx,
 						}
 
 						std::vector<Future<Void>> actors;
+						actors.reserve(dest.size());
 
 						// Unassign the shard from the dest servers.
 						for (const UID& id : dest) {
@@ -3864,6 +3869,7 @@ Future<Void> cleanUpDataMoveCore(Database occ,
 				}
 
 				std::vector<Future<Void>> actors;
+				actors.reserve(oldDests.size());
 				for (const auto& uid : oldDests) {
 					actors.push_back(unassignServerKeys(&tr, uid, range, physicalShardMap[uid], dataMoveId));
 				}

--- a/fdbserver/core/RocksDBCheckpointUtils.cpp
+++ b/fdbserver/core/RocksDBCheckpointUtils.cpp
@@ -571,6 +571,7 @@ rocksdb::Status RocksDBColumnFamilyReader::Reader::tryOpenForRead(const std::str
 
 	const rocksdb::ColumnFamilyOptions cfOptions = getCFOptions();
 	std::vector<rocksdb::ColumnFamilyDescriptor> descriptors;
+	descriptors.reserve(columnFamilies.size());
 	for (const std::string& name : columnFamilies) {
 		descriptors.emplace_back(name, cfOptions);
 	}
@@ -633,6 +634,7 @@ rocksdb::Status RocksDBColumnFamilyReader::Reader::importCheckpoint(const std::s
 
 	const rocksdb::ColumnFamilyOptions cfOptions = getCFOptions();
 	std::vector<rocksdb::ColumnFamilyDescriptor> descriptors;
+	descriptors.reserve(columnFamilies.size());
 	for (const std::string& name : columnFamilies) {
 		descriptors.emplace_back(name, cfOptions);
 	}

--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -324,6 +324,7 @@ public:
 
 	Future<Void> updateStorageMetrics() override {
 		std::vector<Future<Void>> futures;
+		futures.reserve(teams.size());
 
 		for (auto& team : teams) {
 			futures.push_back(team->updateStorageMetrics());

--- a/fdbserver/datadistributor/DDTeamCollection.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.cpp
@@ -3320,6 +3320,7 @@ public:
 
 	static Future<Void> updateReplicasKey(DDTeamCollection* self, Optional<Key> dcId) {
 		std::vector<Future<Void>> serverUpdates;
+		serverUpdates.reserve(self->server_info.size());
 
 		for (auto& it : self->server_info) {
 			serverUpdates.push_back(it.second->updated.getFuture());

--- a/fdbserver/datadistributor/DDTxnProcessor.cpp
+++ b/fdbserver/datadistributor/DDTxnProcessor.cpp
@@ -151,6 +151,7 @@ class DDTxnProcessorImpl {
 					decodeKeyServersValue(UIDtoTagMap, shards[i].value, src, dest, srcId, destId);
 
 					std::vector<Future<Optional<Value>>> serverListEntries;
+					serverListEntries.reserve(src.size());
 					for (int j = 0; j < src.size(); ++j) {
 						serverListEntries.push_back(tr.get(serverListKeyFor(src[j])));
 					}

--- a/fdbserver/kvstore/KeyValueStoreRocksDB.cpp
+++ b/fdbserver/kvstore/KeyValueStoreRocksDB.cpp
@@ -1432,6 +1432,7 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 
 			rocksdb::ColumnFamilyOptions cfOptions = sharedState->getCfOptions();
 			std::vector<rocksdb::ColumnFamilyDescriptor> descriptors;
+			descriptors.reserve(columnFamilies.size());
 			for (const std::string& name : columnFamilies) {
 				descriptors.push_back(rocksdb::ColumnFamilyDescriptor{ name, cfOptions });
 			}
@@ -1648,6 +1649,7 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 				std::set<std::string> columnFamilies{ "default" };
 				columnFamilies.insert(SERVER_KNOBS->DEFAULT_FDB_ROCKSDB_COLUMN_FAMILY);
 				std::vector<rocksdb::ColumnFamilyDescriptor> descriptors;
+				descriptors.reserve(columnFamilies.size());
 				for (const std::string name : columnFamilies) {
 					descriptors.push_back(rocksdb::ColumnFamilyDescriptor{ name, sharedState->getCfOptions() });
 				}

--- a/fdbserver/kvstore/KeyValueStoreShardedRocksDB.cpp
+++ b/fdbserver/kvstore/KeyValueStoreShardedRocksDB.cpp
@@ -1936,6 +1936,7 @@ public:
 
 	std::vector<rocksdb::ColumnFamilyHandle*> getColumnFamilies() {
 		std::vector<rocksdb::ColumnFamilyHandle*> res;
+		res.reserve(columnFamilyMap.size());
 		for (auto& [id, cf] : columnFamilyMap) {
 			res.push_back(cf);
 		}
@@ -4939,7 +4940,7 @@ TEST_CASE("noSim/determinism/checkpoint_metadata/serde3") {
 }
 
 TEST_CASE("noSim/determinism/checkpoint_metadata/serde4") {
-	checkpointMetadataSerdeTest("some_\nrocksdb_checkpoint_\nmetadata_123\0");
+	checkpointMetadataSerdeTest("some_\nrocksdb_checkpoint_\nmetadata_123\0"_sr.toString());
 	return Void();
 }
 

--- a/fdbserver/kvstore/VersionedBTree.cpp
+++ b/fdbserver/kvstore/VersionedBTree.cpp
@@ -2989,6 +2989,7 @@ public:
 		// TODO:  Could a dispatched read try to write to page after it has been destroyed if this actor is cancelled?
 		int blockSize = self->physicalPageSize;
 		std::vector<Future<int>> reads;
+		reads.reserve(pageIDs.size());
 		for (int i = 0; i < pageIDs.size(); ++i) {
 			reads.push_back(
 			    readPhysicalBlock(self, page, i * blockSize, blockSize, ((int64_t)pageIDs[i]) * blockSize, priority));

--- a/fdbserver/logsystem/LogSystem.cpp
+++ b/fdbserver/logsystem/LogSystem.cpp
@@ -877,6 +877,7 @@ Version LogSystem::getKnownCommittedVersion() {
 
 Future<Void> LogSystem::onKnownCommittedVersionChange() {
 	std::vector<Future<Void>> result;
+	result.reserve(lockResults.size());
 	for (auto& it : lockResults) {
 		result.push_back(LogSystem::getDurableVersionChanged(it));
 	}

--- a/fdbserver/logsystem/LogSystemPeekCursor.cpp
+++ b/fdbserver/logsystem/LogSystemPeekCursor.cpp
@@ -824,6 +824,7 @@ MergedPeekCursor::MergedPeekCursor(std::vector<Reference<ServerPeekCursor>> cons
 
 Reference<IReplayPeekCursor> MergedPeekCursor::cloneNoMore() {
 	std::vector<Reference<ServerPeekCursor>> cursors;
+	cursors.reserve(serverCursors.size());
 	for (const auto& it : serverCursors) {
 		cursors.push_back(it->cloneServerNoMore());
 	}

--- a/fdbserver/sequencer/ResolutionBalancer.cpp
+++ b/fdbserver/sequencer/ResolutionBalancer.cpp
@@ -121,6 +121,7 @@ Future<Void> ResolutionBalancer::resolutionBalancing() {
 		while (!resolverChanges.get().empty())
 			co_await resolverChanges.onChange();
 		std::vector<Future<ResolutionMetricsReply>> futures;
+		futures.reserve(resolvers.size());
 		for (auto& p : resolvers)
 			futures.push_back(
 			    brokenPromiseToNever(p.metrics.getReply(ResolutionMetricsRequest(), TaskPriority::ResolutionMetrics)));

--- a/fdbserver/tester/TesterServer.cpp
+++ b/fdbserver/tester/TesterServer.cpp
@@ -117,6 +117,7 @@ Future<Reference<TestWorkload>> getWorkloadIface(WorkloadRequest work,
 	wcx.rangesToCheck = work.rangesToCheck;
 	// FIXME: Other stuff not filled in; why isn't this constructed here and passed down to the other
 	// getWorkloadIface()?
+	ifaces.reserve(work.options.size());
 	for (int i = 0; i < work.options.size(); i++) {
 		ifaces.push_back(getWorkloadIface(work, ccr, work.options[i], dbInfo));
 	}

--- a/fdbserver/worker/MetricClient.cpp
+++ b/fdbserver/worker/MetricClient.cpp
@@ -119,6 +119,7 @@ void UDPMetricClient::send(MetricCollection* metrics) {
 
 		metrics->histMap.clear();
 
+		gauges.reserve(metrics->gaugeMap.size());
 		for (auto& [_, g] : metrics->gaugeMap) {
 			gauges.push_back(std::move(g));
 		}

--- a/fdbserver/workloads/AutomaticIdempotencyWorkload.cpp
+++ b/fdbserver/workloads/AutomaticIdempotencyWorkload.cpp
@@ -277,6 +277,7 @@ struct AutomaticIdempotencyWorkload : TestWorkload {
 			Error err;
 			try {
 				std::vector<Future<Optional<Value>>> futures;
+				futures.reserve(keys.size());
 
 				for (auto const& key : keys) {
 					futures.push_back(tr.get(key));

--- a/fdbserver/workloads/BackupToDBCorrectness.cpp
+++ b/fdbserver/workloads/BackupToDBCorrectness.cpp
@@ -196,6 +196,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 				co_await waitForAll(results);
 
 				std::vector<RangeResult> ret;
+				ret.reserve(results.size());
 				for (const auto& result : results) {
 					ret.push_back(result.get());
 				}

--- a/fdbserver/workloads/BulkLoading.cpp
+++ b/fdbserver/workloads/BulkLoading.cpp
@@ -442,6 +442,7 @@ struct BulkLoading : TestWorkload {
 
 	std::vector<Key> getAllKeys(const std::vector<KeyValue>& kvs) {
 		std::vector<Key> res;
+		res.reserve(kvs.size());
 		for (const auto& kv : kvs) {
 			res.push_back(kv.key);
 		}
@@ -556,6 +557,7 @@ struct BulkLoading : TestWorkload {
 		oldBulkLoadMode = co_await setBulkLoadMode(cx, 1);
 		TraceEvent("BulkLoadingWorkLoadSimpleTestSetMode").detail("OldMode", oldBulkLoadMode).detail("NewMode", 1);
 		std::vector<BulkLoadTaskState> errorTasks = co_await self->waitUntilAllTaskCompleteOrError(self, cx);
+		errorRanges.reserve(errorTasks.size());
 		for (const auto& errorTask : errorTasks) {
 			errorRanges.push_back(errorTask.getRange());
 		}
@@ -667,6 +669,7 @@ struct BulkLoading : TestWorkload {
 		}
 		// Wait until all tasks have completed
 		std::vector<BulkLoadTaskState> errorTasks = co_await self->waitUntilAllTaskCompleteOrError(self, cx);
+		errorRanges.reserve(errorTasks.size());
 		for (const auto& errorTask : errorTasks) {
 			errorRanges.push_back(errorTask.getRange()); // for any error range, do not check data
 		}
@@ -759,6 +762,7 @@ struct BulkLoading : TestWorkload {
 		if (backgroundTrafficEnabled) {
 			std::vector<Future<Void>> trafficActors;
 			int actorCount = deterministicRandom()->randomInt(1, 10);
+			trafficActors.reserve(actorCount);
 			for (int i = 0; i < actorCount; i++) {
 				trafficActors.push_back(backgroundWriteTraffic(this, cx));
 			}

--- a/fdbserver/workloads/BulkSetup.h
+++ b/fdbserver/workloads/BulkSetup.h
@@ -327,6 +327,7 @@ Future<Void> bulkSetup(Database cx,
 		keySaveIncrement = 0;
 	}
 
+	fs.reserve(BULK_SETUP_WORKERS);
 	for (int j = 0; j < BULK_SETUP_WORKERS; j++) {
 		fs.push_back(setupRangeWorker(cx, workload, &jobs, maxWorkerInsertRate, keySaveIncrement, j));
 	}

--- a/fdbserver/workloads/ConsistencyCheckUrgent.cpp
+++ b/fdbserver/workloads/ConsistencyCheckUrgent.cpp
@@ -275,6 +275,7 @@ struct ConsistencyCheckUrgentWorkload : TestWorkload {
 					tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 					tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 					std::vector<Future<Optional<Value>>> serverListEntries;
+					serverListEntries.reserve(storageServers.size());
 					for (int s = 0; s < storageServers.size(); s++)
 						serverListEntries.push_back(tr.get(serverListKeyFor(storageServers[s])));
 					std::vector<Optional<Value>> serverListValues = co_await getAll(serverListEntries);

--- a/fdbserver/workloads/HighContentionPrefixAllocatorWorkload.cpp
+++ b/fdbserver/workloads/HighContentionPrefixAllocatorWorkload.cpp
@@ -54,6 +54,7 @@ struct HighContentionPrefixAllocatorWorkload : TestWorkload {
 			Error err;
 			try {
 				std::vector<Future<Key>> futures;
+				futures.reserve(numAllocations);
 				for (int i = 0; i < numAllocations; ++i) {
 					futures.push_back(allocator.allocate(tr));
 				}
@@ -105,6 +106,7 @@ struct HighContentionPrefixAllocatorWorkload : TestWorkload {
 		for (int roundNum = 0; roundNum < numRounds; ++roundNum) {
 			std::vector<Future<Void>> futures;
 			int numTransactions = deterministicRandom()->randomInt(1, maxTransactionsPerRound + 1);
+			futures.reserve(numTransactions);
 			for (int i = 0; i < numTransactions; ++i) {
 				futures.push_back(runAllocationTransaction(cx));
 			}

--- a/fdbserver/workloads/MiniCycle.cpp
+++ b/fdbserver/workloads/MiniCycle.cpp
@@ -74,6 +74,7 @@ struct MiniCycleWorkload : TestWorkload {
 
 	Future<bool> _check(Database cx, MiniCycleWorkload* self) {
 		std::vector<Future<Void>> cycleClients;
+		cycleClients.reserve(self->clientCount > 0 ? self->clientCount : 0);
 		for (int c = 0; c < self->clientCount; c++) {
 			cycleClients.push_back(
 			    timeout(self->cycleClient(cx->clone(), self, self->actorCount / self->transactionsPerSecond),
@@ -113,6 +114,7 @@ struct MiniCycleWorkload : TestWorkload {
 
 	Future<bool> _checkCycle(Database cx, MiniCycleWorkload* self, bool ok) {
 		std::vector<Future<bool>> checkClients;
+		checkClients.reserve(self->clientCount > 0 ? self->clientCount : 0);
 		for (int c = 0; c < self->clientCount; c++)
 			checkClients.push_back(self->cycleCheckClient(cx->clone(), self, ok));
 		bool ret = co_await allTrue(checkClients);

--- a/fdbserver/workloads/NativeCdcEndToEnd.cpp
+++ b/fdbserver/workloads/NativeCdcEndToEnd.cpp
@@ -1761,6 +1761,7 @@ class NativeCdcEndToEndWorkload : public TestWorkload {
 				chosenKeys.insert(deterministicRandom()->randomInt(0, keyCount));
 			}
 			std::vector<std::pair<Key, Value>> values;
+			values.reserve(chosenKeys.size());
 			for (int index : chosenKeys) {
 				values.emplace_back(keyForIndex(index), Value(StringRef(format("round/%04d/key/%04d", round, index))));
 			}

--- a/fdbserver/workloads/PhysicalShardMove.cpp
+++ b/fdbserver/workloads/PhysicalShardMove.cpp
@@ -260,6 +260,7 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 			Error err;
 			try {
 				std::vector<Future<Optional<Value>>> checkpointEntries;
+				checkpointEntries.reserve(checkpointIds.size());
 				for (const UID& id : checkpointIds) {
 					checkpointEntries.push_back(tr.get(checkpointKeyFor(id)));
 				}
@@ -380,6 +381,7 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		}
 
 		std::vector<UID> checkpointIds;
+		checkpointIds.reserve(records.size());
 		for (const auto& it : records) {
 			checkpointIds.push_back(it.second.checkpointID);
 		}

--- a/fdbserver/workloads/RandomRangeLock.cpp
+++ b/fdbserver/workloads/RandomRangeLock.cpp
@@ -177,6 +177,7 @@ struct RandomRangeLockWorkload : FailureInjectionWorkload {
 			// and this injected workload should not block other workloads.
 			std::string rangeLockOwnerNamePrefix = "Owner" + std::to_string(clientId);
 			std::vector<Future<Void>> actors;
+			actors.reserve(lockActorCount);
 			for (int i = 0; i < lockActorCount; i++) {
 				actors.push_back(lockActor(cx, this, rangeLockOwnerNamePrefix));
 			}

--- a/fdbserver/workloads/RangeLock.cpp
+++ b/fdbserver/workloads/RangeLock.cpp
@@ -557,6 +557,7 @@ struct RangeLocking : TestWorkload {
 		std::vector<std::pair<KeyRange, RangeLockState>> res;
 		res = co_await findExclusiveReadLockOnRange(cx, normalKeys);
 		std::vector<KeyRange> ranges;
+		ranges.reserve(res.size());
 		for (const auto& [lockedRange, _lockState] : res) {
 			ranges.push_back(lockedRange);
 		}

--- a/fdbserver/workloads/SkewedReadWrite.cpp
+++ b/fdbserver/workloads/SkewedReadWrite.cpp
@@ -274,6 +274,7 @@ struct SkewedReadWriteWorkload : ReadWriteCommon {
 			std::vector<KeyRange> extra_ranges;
 			int reads = aTransaction ? self->readsPerTransactionA : self->readsPerTransactionB;
 			int writes = aTransaction ? self->writesPerTransactionA : self->writesPerTransactionB;
+			keys.reserve(reads > 0 ? reads : 0);
 			for (int op = 0; op < reads; op++)
 				keys.push_back(self->getRandomKey(self->nodeCount));
 

--- a/fdbserver/workloads/Throttling.cpp
+++ b/fdbserver/workloads/Throttling.cpp
@@ -184,6 +184,7 @@ struct ThrottlingWorkload : KVWorkload {
 
 	Future<Void> start(Database const& cx) override {
 		std::vector<Future<Void>> clientActors;
+		clientActors.reserve(static_cast<std::size_t>(actorsPerClient > 0 ? actorsPerClient : 0) + 2);
 		for (int actorId = 0; actorId < actorsPerClient; ++actorId) {
 			clientActors.push_back(timeout(clientActor(cx), testDuration, Void()));
 		}

--- a/fdbserver/workloads/TransactionCost.cpp
+++ b/fdbserver/workloads/TransactionCost.cpp
@@ -207,6 +207,7 @@ class TransactionCostWorkload : public TestWorkload {
 
 		Future<Void> exec(TransactionCostWorkload const& workload, Reference<ReadYourWritesTransaction> tr) override {
 			std::vector<Future<Void>> futures;
+			futures.reserve(10);
 			for (int i = 0; i < 10; ++i) {
 				futures.push_back(success(tr->get(workload.getKey(testNumber, i))));
 			}

--- a/fdbserver/workloads/TxnTimeout.cpp
+++ b/fdbserver/workloads/TxnTimeout.cpp
@@ -142,6 +142,7 @@ struct TxnTimeout : TestWorkload {
 	// Runs database population concurrently across actors and clients
 	Future<Void> populateDatabaseAllActors(Database db) {
 		std::vector<Future<Void>> populationActors;
+		populationActors.reserve(actorsPerClient > 0 ? actorsPerClient : 0);
 		for (int actorIdx = 0; actorIdx < actorsPerClient; ++actorIdx) {
 			populationActors.push_back(populateDatabase(db, actorIdx));
 		}
@@ -308,6 +309,7 @@ struct TxnTimeout : TestWorkload {
 
 		// Phase 2: Run transaction clients that test timeout behavior
 		std::vector<Future<Void>> txnClients;
+		txnClients.reserve(self->actorsPerClient > 0 ? self->actorsPerClient : 0);
 		for (int actorIdx = 0; actorIdx < self->actorsPerClient; ++actorIdx) {
 			txnClients.emplace_back(txnClient(db, actorIdx));
 		}

--- a/flow/CoroTests.cpp
+++ b/flow/CoroTests.cpp
@@ -597,6 +597,7 @@ TEST_CASE("/flow/coro/yieldedFuture/progress") {
 	Future<Void> i = success(u);
 
 	std::vector<Future<Void>> v;
+	v.reserve(5);
 	for (int j = 0; j < 5; j++)
 		v.push_back(yieldedFuture(u));
 	auto numReady = [&v]() { return std::count_if(v.begin(), v.end(), [](Future<Void> v) { return v.isReady(); }); };
@@ -628,6 +629,7 @@ TEST_CASE("/flow/coro/yieldedFuture/random") {
 		Future<Void> i = success(u);
 
 		std::vector<Future<Void>> v;
+		v.reserve(25);
 		for (int j = 0; j < 25; j++)
 			v.push_back(yieldedFuture(u));
 		auto numReady = [&v]() {
@@ -676,6 +678,7 @@ TEST_CASE("/flow/coro/perf/yieldedFuture") {
 	std::vector<Future<Void>> ys;
 
 	start = timer();
+	ys.reserve(N);
 	for (int i = 0; i < N; i++)
 		ys.push_back(yieldedFuture(f));
 	printf("yieldedFuture(f) create: %0.1f M/sec\n", N / 1e6 / (timer() - start));
@@ -1615,6 +1618,7 @@ TEST_CASE("/flow/coro/quorumAsyncResultReady") {
 TEST_CASE("/flow/coro/quorumAsyncResultSuccess") {
 	std::vector<Promise<Void>> signals(3);
 	std::vector<AsyncResult<int>> results;
+	results.reserve(signals.size());
 	for (int i = 0; i < signals.size(); ++i) {
 		results.push_back(delayedAsyncResultInt(signals[i].getFuture(), i));
 	}
@@ -1671,6 +1675,7 @@ TEST_CASE("/flow/coro/quorumAsyncResultCancelsRemainingProducers") {
 	int completedCount = 0;
 	std::vector<Promise<Void>> signals(3);
 	std::vector<AsyncResult<int>> results;
+	results.reserve(signals.size());
 	for (int i = 0; i < signals.size(); ++i) {
 		results.push_back(trackedAsyncResultInt(signals[i].getFuture(), i, &cancelledCount, &completedCount));
 	}
@@ -1692,6 +1697,7 @@ TEST_CASE("/flow/coro/quorumAsyncResultDropCancelsProducers") {
 	std::vector<Promise<Void>> signals(2);
 	{
 		std::vector<AsyncResult<int>> results;
+		results.reserve(signals.size());
 		for (int i = 0; i < signals.size(); ++i) {
 			results.push_back(trackedAsyncResultInt(signals[i].getFuture(), i, &cancelledCount, &completedCount));
 		}
@@ -1881,6 +1887,7 @@ TEST_CASE("/flow/coro/getAllAsyncResultDropCancelsProducers") {
 	std::vector<Promise<Void>> signals(2);
 	{
 		std::vector<AsyncResult<int>> results;
+		results.reserve(signals.size());
 		for (int i = 0; i < signals.size(); ++i) {
 			results.push_back(trackedAsyncResultInt(signals[i].getFuture(), i, &cancelledCount, &completedCount));
 		}
@@ -1903,6 +1910,7 @@ TEST_CASE("/flow/coro/getAllAsyncResultMoveDropCancelsProducers") {
 	std::vector<Promise<Void>> signals(2);
 	{
 		std::vector<AsyncResult<int>> results;
+		results.reserve(signals.size());
 		for (int i = 0; i < signals.size(); ++i) {
 			results.push_back(trackedAsyncResultInt(signals[i].getFuture(), i, &cancelledCount, &completedCount));
 		}

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -1206,7 +1206,7 @@ void getNetworkTraffic(const IPAddress& ip,
 		struct if_msghdr* ifm = (struct if_msghdr*)next;
 		next += ifm->ifm_msglen;
 
-		if ((ifm->ifm_type = RTM_IFINFO2)) {
+		if (ifm->ifm_type == RTM_IFINFO2) {
 			struct if_msghdr2* if2m = (struct if_msghdr2*)ifm;
 			struct sockaddr_dl* sdl = (struct sockaddr_dl*)(if2m + 1);
 
@@ -1313,23 +1313,25 @@ DiskStatistics getDiskStatistics(std::string const& directory) {
 
 	DiskStatistics diskStats;
 
-	if ((number = (CFNumberRef)CFDictionaryGetValue(stats_dict, CFSTR(kIOBlockStorageDriverStatisticsReadsKey)))) {
+	number = (CFNumberRef)CFDictionaryGetValue(stats_dict, CFSTR(kIOBlockStorageDriverStatisticsReadsKey));
+	if (number) {
 		CFNumberGetValue(number, kCFNumberSInt64Type, &diskStats.reads);
 	}
 
-	if ((number = (CFNumberRef)CFDictionaryGetValue(stats_dict, CFSTR(kIOBlockStorageDriverStatisticsWritesKey)))) {
+	number = (CFNumberRef)CFDictionaryGetValue(stats_dict, CFSTR(kIOBlockStorageDriverStatisticsWritesKey));
+	if (number) {
 		CFNumberGetValue(number, kCFNumberSInt64Type, &diskStats.writes);
 	}
 
 	uint64_t nanoSecs;
-	if ((number =
-	         (CFNumberRef)CFDictionaryGetValue(stats_dict, CFSTR(kIOBlockStorageDriverStatisticsTotalReadTimeKey)))) {
+	number = (CFNumberRef)CFDictionaryGetValue(stats_dict, CFSTR(kIOBlockStorageDriverStatisticsTotalReadTimeKey));
+	if (number) {
 		CFNumberGetValue(number, kCFNumberSInt64Type, &nanoSecs);
 		diskStats.readMilliSecs += nanoSecs / 1000000;
 		diskStats.IOMilliSecs += nanoSecs / 1000000;
 	}
-	if ((number =
-	         (CFNumberRef)CFDictionaryGetValue(stats_dict, CFSTR(kIOBlockStorageDriverStatisticsTotalWriteTimeKey)))) {
+	number = (CFNumberRef)CFDictionaryGetValue(stats_dict, CFSTR(kIOBlockStorageDriverStatisticsTotalWriteTimeKey));
+	if (number) {
 		CFNumberGetValue(number, kCFNumberSInt64Type, &nanoSecs);
 		diskStats.writeMilliSecs += nanoSecs / 1000000;
 		diskStats.IOMilliSecs += nanoSecs / 1000000;
@@ -3137,8 +3139,8 @@ int setEnvironmentVar(const char* name, const char* value, int overwrite) {
 #define getcwd(buf, maxlen) _getcwd(buf, maxlen)
 #endif
 std::string getWorkingDirectory() {
-	char* buf;
-	if ((buf = getcwd(nullptr, 0)) == nullptr) {
+	char* buf = getcwd(nullptr, 0);
+	if (buf == nullptr) {
 		TraceEvent(SevWarnAlways, "GetWorkingDirectoryError").GetLastError();
 		throw platform_error();
 	}

--- a/flow/SimpleCounter.cpp
+++ b/flow/SimpleCounter.cpp
@@ -144,6 +144,7 @@ TEST_CASE("/flow/simplecounter/int64") {
 	};
 
 	std::vector<std::thread> threads;
+	threads.reserve(10);
 	for (int i = 0; i < 10; i++) {
 		threads.emplace_back(inclots);
 	}
@@ -184,6 +185,7 @@ TEST_CASE("/flow/simplecounter/double") {
 	};
 
 	std::vector<std::thread> threads;
+	threads.reserve(10);
 	for (int i = 0; i < 10; i++) {
 		threads.emplace_back(double_inclots);
 	}

--- a/flow/include/flow/TDMetric.h
+++ b/flow/include/flow/TDMetric.h
@@ -56,11 +56,12 @@ struct MetricNameRef {
 	int expectedSize() const { return type.expectedSize() + name.expectedSize(); }
 
 	inline int compare(MetricNameRef const& r) const {
-		int cmp;
-		if ((cmp = type.compare(r.type))) {
+		int cmp = type.compare(r.type);
+		if (cmp) {
 			return cmp;
 		}
-		if ((cmp = name.compare(r.name))) {
+		cmp = name.compare(r.name);
+		if (cmp) {
 			return cmp;
 		}
 		return id.compare(r.id);

--- a/flow/include/flow/TreeBenchmark.h
+++ b/flow/include/flow/TreeBenchmark.h
@@ -89,6 +89,7 @@ void treeBenchmark(T& tree, F generateKey) {
 	int keyCount = 1000000;
 
 	std::vector<key> keys;
+	keys.reserve(keyCount);
 	for (int i = 0; i < keyCount; i++) {
 		keys.push_back(generateKey());
 	}


### PR DESCRIPTION
Enable three clang-tidy checks and repair their existing findings:

- `bugprone-assignment-in-if-condition`: separate intentional assignments from conditions and fix the macOS routing-message type check to compare rather than assign.
- `bugprone-string-literal-with-embedded-nul`: preserve the explicit NUL byte in the RocksDB checkpoint metadata round-trip test.
- `performance-inefficient-vector-operation`: reserve capacity for 85 loops with known bounds, accounting for signed counts and additional appended elements. Retain the check's default options.

The source changes address 92 findings in the Linux inventory plus five macOS-specific assignments. Update the clang-tidy documentation to reflect the three additions.

Validation used Linux with LLVM 19.1.5/libc++, RocksDB enabled, and AWS backup disabled:

- The three new checks produced no diagnostics or compiler errors across 598 translation units, including the three supplemental RocksDB consumers.
- The full supported policy covered 54 translation units and all seven changed headers through real consumers. All 21 pre-existing warnings were unchanged; no new warnings were introduced. The pre-existing `readability-inconsistent-ifelse-braces` check is unavailable in LLVM 19.1.5.
- All 43 selected unit tests passed with seed `20260830`: 20 client, 11 Flow, 3 RPC, 6 key-value store, 2 core, and 1 cluster-controller tests. These include the corrected NUL round trip, RocksDB initialization/read coverage, and coroutine cancellation cases.
- All six test executables linked with zero compilation failures. The build wrappers returned exit 1 after linking/cache statistics; direct execution of the verified fresh binaries passed the selected tests.
- `git diff --check` passed.

AWS SDK preparation was blocked by a dependency download. Native macOS and Windows builds and whole-cluster correctness runs were not performed.
