### PR TITLE
Use AsyncResult for single-consumer container results

### DIFF
--- a/fdbclient/BackupContainerFileSystem.cpp
+++ b/fdbclient/BackupContainerFileSystem.cpp
@@ -51,7 +51,7 @@ public:
 
 	// TODO:  Do this more efficiently, as the range file list for a snapshot could potentially be hundreds of
 	// megabytes.
-	static Future<std::pair<std::vector<RangeFile>, std::map<std::string, KeyRange>>> readKeyspaceSnapshot(
+	static AsyncResult<std::pair<std::vector<RangeFile>, std::map<std::string, KeyRange>>> readKeyspaceSnapshot(
 	    Reference<BackupContainerFileSystem> bc,
 	    KeyspaceSnapshotFile snapshot) {
 		// Read the range file list for the specified version range, and then index them by fileName.
@@ -149,7 +149,7 @@ public:
 			}
 		}
 
-		co_return std::make_pair(results, fileKeyRanges);
+		co_return std::make_pair(std::move(results), std::move(fileKeyRanges));
 	}
 
 	// Find what should be the filename of a path by finding whatever is after the last forward or backward slash, or
@@ -1615,7 +1615,7 @@ Future<Void> BackupContainerFileSystem::writePartitionListFile(Version v, std::s
 	                       contents);
 }
 
-Future<std::pair<std::vector<RangeFile>, std::map<std::string, KeyRange>>>
+AsyncResult<std::pair<std::vector<RangeFile>, std::map<std::string, KeyRange>>>
 BackupContainerFileSystem::readKeyspaceSnapshot(KeyspaceSnapshotFile snapshot) {
 	return BackupContainerFileSystemImpl::readKeyspaceSnapshot(Reference<BackupContainerFileSystem>::addRef(this),
 	                                                           snapshot);

--- a/fdbclient/NativeAPI.cpp
+++ b/fdbclient/NativeAPI.cpp
@@ -1388,14 +1388,15 @@ void DatabaseContext::updateBackoff(const Error& err) {
 	}
 }
 
-Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations_internal(Database cx,
-                                                                        KeyRange keys,
-                                                                        int limit,
-                                                                        Reverse reverse,
-                                                                        SpanContext spanContext,
-                                                                        Optional<UID> debugID,
-                                                                        UseProvisionalProxies useProvisionalProxies,
-                                                                        Version version) {
+AsyncResult<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations_internal(
+    Database cx,
+    KeyRange keys,
+    int limit,
+    Reverse reverse,
+    SpanContext spanContext,
+    Optional<UID> debugID,
+    UseProvisionalProxies useProvisionalProxies,
+    Version version) {
 	Span span("NAPI:getKeyRangeLocations"_loc, spanContext);
 	if (debugID.present()) {
 		g_traceBatch.addEvent("TransactionDebug",
@@ -1452,6 +1453,12 @@ Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations_internal(Database
 	}
 }
 
+// Complete cache hits synchronously without adding a wrapper coroutine around cache misses.
+static AsyncResult<std::vector<KeyRangeLocationInfo>> readyKeyRangeLocations(
+    std::vector<KeyRangeLocationInfo> locations) {
+	co_return locations;
+}
+
 // Get the SS locations for each shard in the 'keys' key-range;
 // Returned vector size is the number of shards in the input keys key-range.
 // Returned vector element is <ShardRange, storage server location info> pairs, where
@@ -1459,15 +1466,15 @@ Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations_internal(Database
 // Example: If query the function with  key range (b, d), the returned list of pairs could be something like:
 // [([a, b1), locationInfo), ([b1, c), locationInfo), ([c, d1), locationInfo)].
 template <class F>
-Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations(Database const& cx,
-                                                               KeyRange const& keys,
-                                                               int limit,
-                                                               Reverse reverse,
-                                                               F StorageServerInterface::* member,
-                                                               SpanContext const& spanContext,
-                                                               Optional<UID> const& debugID,
-                                                               UseProvisionalProxies useProvisionalProxies,
-                                                               Version version) {
+AsyncResult<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations(Database const& cx,
+                                                                    KeyRange const& keys,
+                                                                    int limit,
+                                                                    Reverse reverse,
+                                                                    F StorageServerInterface::* member,
+                                                                    SpanContext const& spanContext,
+                                                                    Optional<UID> const& debugID,
+                                                                    UseProvisionalProxies useProvisionalProxies,
+                                                                    Version version) {
 
 	ASSERT(!keys.empty());
 
@@ -1498,15 +1505,15 @@ Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations(Database const& c
 		    cx, keys, limit, reverse, spanContext, debugID, useProvisionalProxies, version);
 	}
 
-	return locations;
+	return readyKeyRangeLocations(std::move(locations));
 }
 
 template <class F>
-Future<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations(Reference<TransactionState> trState,
-                                                               KeyRange const& keys,
-                                                               int limit,
-                                                               Reverse reverse,
-                                                               F StorageServerInterface::* member) {
+AsyncResult<std::vector<KeyRangeLocationInfo>> getKeyRangeLocations(Reference<TransactionState> trState,
+                                                                    KeyRange const& keys,
+                                                                    int limit,
+                                                                    Reverse reverse,
+                                                                    F StorageServerInterface::* member) {
 	return getKeyRangeLocations(trState->cx,
 	                            keys,
 	                            limit,
@@ -6960,7 +6967,7 @@ static Future<CheckpointMetaData> getCheckpointMetaDataInternal(KeyRange range,
 	throw error.get();
 }
 
-static Future<std::vector<std::pair<KeyRange, CheckpointMetaData>>> getCheckpointMetaDataForRange(
+static AsyncResult<std::vector<std::pair<KeyRange, CheckpointMetaData>>> getCheckpointMetaDataForRange(
     Database cxInput,
     KeyRange rangeInput,
     Version version,
@@ -7037,26 +7044,27 @@ static Future<std::vector<std::pair<KeyRange, CheckpointMetaData>>> getCheckpoin
 	co_return res;
 }
 
-Future<std::vector<std::pair<KeyRange, CheckpointMetaData>>> getCheckpointMetaData(Database cx,
-                                                                                   std::vector<KeyRange> ranges,
-                                                                                   Version version,
-                                                                                   CheckpointFormat format,
-                                                                                   Optional<UID> actionId,
-                                                                                   double timeout) {
-	std::vector<Future<std::vector<std::pair<KeyRange, CheckpointMetaData>>>> futures;
+AsyncResult<std::vector<std::pair<KeyRange, CheckpointMetaData>>> getCheckpointMetaData(Database cx,
+                                                                                        std::vector<KeyRange> ranges,
+                                                                                        Version version,
+                                                                                        CheckpointFormat format,
+                                                                                        Optional<UID> actionId,
+                                                                                        double timeout) {
+	std::vector<AsyncResult<std::vector<std::pair<KeyRange, CheckpointMetaData>>>> futures;
 
 	// TODO(heliu): Avoid send requests to the same shard.
 	for (const auto& range : ranges) {
 		futures.push_back(getCheckpointMetaDataForRange(cx, range, version, format, actionId, timeout));
 	}
 
-	std::vector<std::vector<std::pair<KeyRange, CheckpointMetaData>>> results = co_await getAll(futures);
+	std::vector<std::vector<std::pair<KeyRange, CheckpointMetaData>>> results =
+	    co_await getAllAsync(std::move(futures));
 
 	std::vector<std::pair<KeyRange, CheckpointMetaData>> res;
 
-	for (const auto& r : results) {
+	for (auto& r : results) {
 		ASSERT(!r.empty());
-		res.insert(res.end(), r.begin(), r.end());
+		res.insert(res.end(), std::make_move_iterator(r.begin()), std::make_move_iterator(r.end()));
 	}
 
 	co_return res;

--- a/fdbclient/include/fdbclient/BackupContainerFileSystem.h
+++ b/fdbclient/include/fdbclient/BackupContainerFileSystem.h
@@ -120,7 +120,7 @@ public:
 	                                              Version fileVersion,
 	                                              int blockSize) override;
 
-	Future<std::pair<std::vector<RangeFile>, std::map<std::string, KeyRange>>> readKeyspaceSnapshot(
+	AsyncResult<std::pair<std::vector<RangeFile>, std::map<std::string, KeyRange>>> readKeyspaceSnapshot(
 	    KeyspaceSnapshotFile snapshot);
 
 	Future<Void> writeKeyspaceSnapshotFile(const std::vector<std::string>& fileNames,

--- a/fdbclient/include/fdbclient/NativeAPI.h
+++ b/fdbclient/include/fdbclient/NativeAPI.h
@@ -559,7 +559,7 @@ Future<Void> createCheckpoint(Reference<ReadYourWritesTransaction> tr,
 // Gets checkpoint metadata for `ranges` at the specific version, with the particular format.
 // Returns a list of [range, checkpoint], where the `checkpoint` has data over `range`.
 // checkpoint_not_found() error will be returned if the specific checkpoint cannot be found.
-Future<std::vector<std::pair<KeyRange, CheckpointMetaData>>> getCheckpointMetaData(
+AsyncResult<std::vector<std::pair<KeyRange, CheckpointMetaData>>> getCheckpointMetaData(
     Database cx,
     std::vector<KeyRange> ranges,
     Version version,

--- a/fdbserver/cdcproxy/CDCProxy.cpp
+++ b/fdbserver/cdcproxy/CDCProxy.cpp
@@ -432,10 +432,10 @@ Optional<MutationRef> clipCDCMutation(MutationRef const& mutation, KeyRangeRef c
 	return Optional<MutationRef>();
 }
 
-Future<CDCStreamReadState> readCDCStreamState(Database cx,
-                                              CDCStreamId streamId,
-                                              UID expectedProxyId,
-                                              bool requireKeys) {
+AsyncResult<CDCStreamReadState> readCDCStreamState(Database cx,
+                                                   CDCStreamId streamId,
+                                                   UID expectedProxyId,
+                                                   bool requireKeys) {
 	if (streamId == 0) {
 		throw client_invalid_operation();
 	}
@@ -1211,7 +1211,7 @@ Future<Void> CDCProxy::initializeStream(Reference<CDCBufferedStream> stream) {
 
 // Post-GA optimization: persist per-tag safe-pop state or coordinate pops centrally instead of rebuilding minima from
 // all stream history on every acknowledgement scan. Revisit if acknowledgement volume makes this scan material.
-Future<CDCPopState> readPopState(Database cx) {
+AsyncResult<CDCPopState> readPopState(Database cx) {
 	Transaction tr(cx);
 	while (true) {
 		Error err;

--- a/fdbserver/commitproxy/CommitProxyServer.cpp
+++ b/fdbserver/commitproxy/CommitProxyServer.cpp
@@ -478,8 +478,8 @@ Future<Void> releaseResolvingAfter(ProxyCommitData* self, Future<Void> releaseDe
 	return releaseResolvingAfterImpl(self, releaseDelay, localBatchNumber);
 }
 
-static Future<ResolveTransactionBatchReply> trackResolutionMetrics(Reference<Histogram> dist,
-                                                                   Future<ResolveTransactionBatchReply> in) {
+static AsyncResult<ResolveTransactionBatchReply> trackResolutionMetrics(Reference<Histogram> dist,
+                                                                        Future<ResolveTransactionBatchReply> in) {
 	double startTime = g_network->timer_monotonic();
 	ResolveTransactionBatchReply reply = co_await in;
 	dist->sampleSeconds(g_network->timer_monotonic() - startTime);
@@ -964,7 +964,7 @@ Future<Void> getResolution(CommitBatchContext* self) {
 		ASSERT(requests.requests[r].txnStateTransactions.size() == requests.requests[0].txnStateTransactions.size());
 
 	pProxyCommitData->stats.txnCommitResolving += trs.size();
-	std::vector<Future<ResolveTransactionBatchReply>> replies;
+	std::vector<AsyncResult<ResolveTransactionBatchReply>> replies;
 	Future<ResolveTransactionBatchReply> singleResolverReply;
 	double singleResolverStart = 0;
 	if (pProxyCommitData->resolvers.size() == 1) {
@@ -1011,7 +1011,7 @@ Future<Void> getResolution(CommitBatchContext* self) {
 		self->resolution.clear();
 		self->resolution.push_back(std::move(resolutionResp));
 	} else {
-		std::vector<ResolveTransactionBatchReply> resolutionResp = co_await getAll(replies);
+		std::vector<ResolveTransactionBatchReply> resolutionResp = co_await getAllAsync(std::move(replies));
 		self->resolution = std::move(resolutionResp);
 	}
 

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -827,12 +827,12 @@ Future<Void> cleanUpSingleShardDataMove(Database occ,
 	TraceEvent(SevInfo, "CleanUpSingleShardDataMoveEnd", dataMoveId).detail("Range", keys);
 }
 
-Future<std::vector<UID>> addReadWriteDestinations(KeyRangeRef shard,
-                                                  std::vector<StorageServerInterface> srcInterfs,
-                                                  std::vector<StorageServerInterface> destInterfs,
-                                                  Version version,
-                                                  int desiredHealthy,
-                                                  int maxServers) {
+AsyncResult<std::vector<UID>> addReadWriteDestinations(KeyRangeRef shard,
+                                                       std::vector<StorageServerInterface> srcInterfs,
+                                                       std::vector<StorageServerInterface> destInterfs,
+                                                       Version version,
+                                                       int desiredHealthy,
+                                                       int maxServers) {
 	if (srcInterfs.size() >= maxServers) {
 		co_return std::vector<UID>();
 	}
@@ -920,10 +920,10 @@ Future<std::vector<UID>> pickReadWriteServers(Transaction* tr, std::vector<UID> 
 	co_return result;
 }
 
-Future<std::vector<std::vector<UID>>> additionalSources(RangeResult shards,
-                                                        Reference<ReadYourWritesTransaction> tr,
-                                                        int desiredHealthy,
-                                                        int maxServers) {
+AsyncResult<std::vector<std::vector<UID>>> additionalSources(RangeResult shards,
+                                                             Reference<ReadYourWritesTransaction> tr,
+                                                             int desiredHealthy,
+                                                             int maxServers) {
 	RangeResult UIDtoTagMap = co_await tr->getRange(serverTagKeys, CLIENT_KNOBS->TOO_MANY);
 	ASSERT(!UIDtoTagMap.more && UIDtoTagMap.size() < CLIENT_KNOBS->TOO_MANY);
 	std::vector<Future<Optional<Value>>> serverListEntries;
@@ -957,7 +957,7 @@ Future<std::vector<std::vector<UID>>> additionalSources(RangeResult shards,
 		ssiMap[ssi.id()] = ssi;
 	}
 
-	std::vector<Future<std::vector<UID>>> allChecks;
+	std::vector<AsyncResult<std::vector<UID>>> allChecks;
 	for (int i = 0; i < shards.size() - 1; ++i) {
 		KeyRangeRef rangeIntersectKeys(shards[i].key, shards[i + 1].key);
 		std::vector<UID> src;
@@ -982,7 +982,7 @@ Future<std::vector<std::vector<UID>>> additionalSources(RangeResult shards,
 		    rangeIntersectKeys, srcInterfs, destInterfs, tr->getReadVersion().get(), desiredHealthy, maxServers));
 	}
 
-	std::vector<std::vector<UID>> result = co_await getAll(allChecks);
+	std::vector<std::vector<UID>> result = co_await getAllAsync(std::move(allChecks));
 	co_return result;
 }
 

--- a/fdbserver/tlog/TLogServer.cpp
+++ b/fdbserver/tlog/TLogServer.cpp
@@ -2031,7 +2031,7 @@ TLogPeekMemoryVersions peekMessageVersionsFromMemory(Reference<LogData> self, Ta
 	return result;
 }
 
-Future<std::vector<StringRef>> parseMessagesForTag(StringRef commitBlob, Tag tag, int logRouters) {
+AsyncResult<std::vector<StringRef>> parseMessagesForTag(StringRef commitBlob, Tag tag, int logRouters) {
 	// See the comment in LogSystem.cpp for the binary format of commitBlob.
 	std::vector<StringRef> relevantMessages;
 	BinaryReader rd(commitBlob, AssumeVersion(g_network->protocolVersion()));


### PR DESCRIPTION
Several one-shot coroutine results contain owned vectors, maps, sets, or strings. Awaiting their `Future<T>` results into local values copies those containers even though there is only one consumer.

Use `AsyncResult` for CDC metadata snapshots, resolver reply aggregation, backup snapshot metadata, additional shard sources, spilled-log message descriptors, client shard locations, and checkpoint metadata. Preserve moves through `getAllAsync`, snapshot pair construction, and checkpoint flattening. Keep shared RPC/readiness futures and existing retry logic; cache-hit location results complete synchronously without adding a coroutine wrapper to cache misses.

Validation:

- Compiled the client and affected server test targets, `fdbdecode`, and `fdbserver`. Passed 103 client tests and 16 focused server tests covering MoveKeys, CDC, TLog, and commit-proxy behavior.
- Passed seven simulations at seed `20260830` with buggify disabled: `NativeCdcDurableAckScan`, `ReportConflictingKeys` with two resolvers, `StreamingRangeRead`, `MoveKeysCycle` with legacy shard-location metadata, `BackupCorrectnessClean`, `NativeCdcEndToEnd` with reference spilling forced, and `PhysicalShardMove`. The latter verified three checkpoint restorations, including multiple ranges.
- `StorageServerCheckpointRestore` fails with `checkpoint_not_found` on both the unchanged base and this branch at the same assertion, simulation time, and unseed. Its configuration uses ordinary RocksDB, whose unchanged checkpoint handler requires shard-aware storage. This pre-existing test failure remains unresolved by this PR.

Performance improvements have not been benchmarked.
