### PR TITLE
Give Redwood cache-hit test sufficient cache capacity

### DIFF
--- a/fdbserver/kvstore/VersionedBTree.cpp
+++ b/fdbserver/kvstore/VersionedBTree.cpp
@@ -10303,7 +10303,9 @@ TEST_CASE("Lredwood/correctness/seekExactKey") {
 	          Optional<Value>(StringRef(format("value-%04d-%s", 150, std::string(512, 'v').c_str()))));
 	ASSERT_EQ(emptyValue, Optional<Value>(""_sr));
 
-	kvStore = keyValueStoreRedwoodV1(kvFile, UID(), {}, 65536);
+	// Keep the large leaf, its ancestors, and pager metadata cached even with buggified page sizes.
+	// The earlier reads exercise eviction with a small cache; this phase requires a cache hit.
+	kvStore = keyValueStoreRedwoodV1(kvFile, UID(), {}, FLOW_KNOBS->PAGE_CACHE_4K);
 	co_await kvStore->init();
 	unsigned int cacheHitsBefore = g_redwoodMetrics.metric.pagerCacheHit;
 	co_await checkExactKVStoreKey(kvStore, largeKey.toString(), largeValue.toString());


### PR DESCRIPTION
`Lredwood/correctness/seekExactKey` expects a cache hit after reopening the store and reading a 32 KiB value twice. With its 64 KiB budget, buggified page sizes and pager metadata can legitimately evict the root and large leaf between reads even though both reads return the correct value.

Use the normal page-cache budget for the reopened cache-hit phase. The earlier 64 KiB eviction exercise and all value and cache-hit assertions remain intact. Tracing the failure on `main` confirmed the intervening evictions, so this repairs a test precondition without changing storage-engine behavior.

Validation:
- The focused `Lredwood/correctness/seekExactKey` test passed in normal and Sim2 modes.
- The previously failing `RedwoodCorrectnessBTree.toml` simulation passed all three phases with buggify and fault injection enabled, exit 0, and no error events.
- Both Clang targets linked with zero compilation failures. The build wrappers exited after linking; validation used the verified fresh binaries directly.
- `git diff --check` passed.
