### PR TITLE
Fix WatchAndWait recovery after commit errors

### DIFF
--- a/bindings/c/test/apitester/TesterWatchAndWaitWorkload.cpp
+++ b/bindings/c/test/apitester/TesterWatchAndWaitWorkload.cpp
@@ -19,6 +19,8 @@
  */
 #include "TesterApiWorkload.h"
 #include "test/fdb_api.hpp"
+#include <atomic>
+#include <memory>
 
 namespace FdbApiTester {
 
@@ -48,10 +50,18 @@ private:
 		execTransaction(
 		    [key, initialVal](auto ctx) {
 			    // Set the key to initialVal.
+			    ctx->makeSelfConflicting();
 			    ctx->tx().set(key, initialVal);
 			    ctx->commit();
 		    },
 		    [this, key, newVal, cont]() {
+			    // Finish both transactions before another operation can reuse this key.
+			    auto remaining = std::make_shared<std::atomic<int>>(2);
+			    auto transactionDone = [this, remaining, cont] {
+				    if (--(*remaining) == 0) {
+					    schedule(cont);
+				    }
+			    };
 			    execTransaction(
 			        [key, newVal](auto ctx) {
 				        // Check the value of the key.
@@ -66,23 +76,25 @@ private:
 						        auto watchF = ctx->tx().watch(key);
 						        auto commitF = ctx->tx().commit();
 
-						        ctx->continueAfterAll({ commitF, watchF }, [ctx] {
+						        // A failed commit can leave watchF pending. Handle commit errors first.
+						        ctx->continueAfter(commitF, [ctx, watchF] {
 							        // Wait for the watch to report a change (to newVal).
-							        ctx->done();
+							        ctx->continueAfter(watchF, [ctx] { ctx->done(); });
 						        });
 					        }
 				        });
 			        },
-			        [this, cont]() { schedule(cont); });
-			    schedule([this, key, newVal] {
+			        transactionDone);
+			    schedule([this, key, newVal, transactionDone] {
 				    execTransaction(
 				        // Set the key to a newVal which is guaranteed to be different from initialVal, i.e.,
 				        // must trigger the watch.
 				        [key, newVal](auto ctx) {
+					        ctx->makeSelfConflicting();
 					        ctx->tx().set(key, newVal);
 					        ctx->commit();
 				        },
-				        []() {});
+				        transactionDone);
 			    });
 		    });
 	}

--- a/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
+++ b/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
@@ -56,9 +56,5 @@ maxClients = 8
     name = 'WatchAndWait'
     initialSize = 0
     runUntilStop = true
-    # WatchAndWait does not get a timeout: it relies on a concurrent transaction
-    # setting the watched key to fire the watch naturally. A timeout would leave
-    # the watch future orphaned in pre-8.0.0 client libraries (which lack the
-    # cancelWatches fix), causing the workload to hang permanently even on a
-    # stable cluster. The other workloads' timeouts are sufficient to recover
-    # from stale-endpoint hangs during upgrades.
+    minTxTimeoutMs = 2000
+    maxTxTimeoutMs = 10000


### PR DESCRIPTION
`WatchAndWait` waits for both the commit and watch before handling either error. A timed-out commit can leave its watch pending, preventing retries and keeping the workload alive during shutdown.

Handle the commit result before waiting for the watch, then restore the upgrade workload's 2–10 second transaction timeouts. Make both writers self-conflicting and wait for both the watcher and replacement writer to finish before starting the next operation, so timeout retries cannot overwrite a later operation's values. A successfully committed watch must still fire normally.

Validation:

- Compiled the C API tester with Clang.
- With temporary instrumentation forcing a transaction timeout after watch creation and before commit, the original code stalled in all four cases: current and 7.4.5 clients, each with callback and blocking execution. The repaired code completed all four in 0.08–0.12 seconds. The instrumentation is not included in this PR.
- `clang-format --dry-run --Werror` and `git diff --check` pass.
- On the final source, `fdb_c_wiggle_and_upgrade` passes in 73.11 seconds, including the 7.4.5 → wiggle → 8.0.0 path and shutdown.
