### PR TITLE
Prioritize CDC consume metadata reads under admission pressure

### DIFF
--- a/fdbserver/cdcproxy/CDCProxy.cpp
+++ b/fdbserver/cdcproxy/CDCProxy.cpp
@@ -435,7 +435,8 @@ Optional<MutationRef> clipCDCMutation(MutationRef const& mutation, KeyRangeRef c
 Future<CDCStreamReadState> readCDCStreamState(Database cx,
                                               CDCStreamId streamId,
                                               UID expectedProxyId,
-                                              bool requireKeys) {
+                                              bool requireKeys,
+                                              bool prioritizeConsume = false) {
 	if (streamId == 0) {
 		throw client_invalid_operation();
 	}
@@ -446,6 +447,10 @@ Future<CDCStreamReadState> readCDCStreamState(Database cx,
 		try {
 			tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
 			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			if (prioritizeConsume) {
+				// Draining committed CDC data must continue while ordinary transaction admission is throttled.
+				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+			}
 
 			Future<Optional<Value>> keysFuture = tr.get(cdcStreamKeyFor(streamId));
 			Future<Optional<Value>> minVersionFuture = tr.get(cdcMinVersionKeyFor(streamId));
@@ -1512,7 +1517,7 @@ Future<Void> CDCProxy::consume(CDCConsumeRequest request) {
 			ASSERT_GT(stream->activeConsumes, 0);
 			--stream->activeConsumes;
 		});
-		const CDCStreamReadState metadata = co_await readCDCStreamState(cx, request.cursor.streamId, id, true);
+		const CDCStreamReadState metadata = co_await readCDCStreamState(cx, request.cursor.streamId, id, true, true);
 		CODE_PROBE(stream->minVersion < metadata.minVersion, "Native CDC consume reconciles a durable acknowledgement");
 		reconcileStreamMinVersion(stream, metadata.minVersion);
 		if (request.cursor.lastConsumedVersion > stream->bufferedThrough) {

--- a/fdbserver/cdcproxy/CDCProxy.cpp
+++ b/fdbserver/cdcproxy/CDCProxy.cpp
@@ -432,11 +432,13 @@ Optional<MutationRef> clipCDCMutation(MutationRef const& mutation, KeyRangeRef c
 	return Optional<MutationRef>();
 }
 
+FDB_BOOLEAN_PARAM(PrioritizeConsume);
+
 Future<CDCStreamReadState> readCDCStreamState(Database cx,
                                               CDCStreamId streamId,
                                               UID expectedProxyId,
                                               bool requireKeys,
-                                              bool prioritizeConsume = false) {
+                                              PrioritizeConsume prioritizeConsume = PrioritizeConsume::False) {
 	if (streamId == 0) {
 		throw client_invalid_operation();
 	}
@@ -1517,7 +1519,8 @@ Future<Void> CDCProxy::consume(CDCConsumeRequest request) {
 			ASSERT_GT(stream->activeConsumes, 0);
 			--stream->activeConsumes;
 		});
-		const CDCStreamReadState metadata = co_await readCDCStreamState(cx, request.cursor.streamId, id, true, true);
+		const CDCStreamReadState metadata =
+		    co_await readCDCStreamState(cx, request.cursor.streamId, id, true, PrioritizeConsume::True);
 		CODE_PROBE(stream->minVersion < metadata.minVersion, "Native CDC consume reconciles a durable acknowledgement");
 		reconcileStreamMinVersion(stream, metadata.minVersion);
 		if (request.cursor.lastConsumedVersion > stream->bufferedThrough) {


### PR DESCRIPTION
## Summary

Use system-immediate transaction priority only for the fresh metadata transaction performed by an active CDC consume request. Initialization and acknowledgement validation retain their existing priority.

CDC consume drains already-committed data. Making its metadata GRV compete with foreground transaction admission can delay that drain when Ratekeeper throttles ordinary transactions. Apply the priority option before the first read on every retry, while retaining the same concurrent metadata reads, transaction version, ownership/history checks, minimum-version checks, cursor validation, and error handling. No GRV cache or admission-limit change is introduced.

## Validation

- Exact public-branch Release build and all 11 `/NativeCDC/` tests in `fdbserver_cdcproxy_test` passed.
- Controlled single-stream ingestion experiment, three-role single-replica Redwood cluster, identical client/consumer/workload and only the server changed: at 4,500 offered transactions/s, completed throughput was 4,484.79 before and 4,486.90 after. At 5,500 offered, the baseline stopped during warmup on growing acknowledgement lag; the candidate completed at 4,775.12 transactions/s with zero non-conflict errors/timeouts (17,151 measured conflicts), maximum sampled writer acknowledgement lag 0.67s, and successful full-prefix read/fence/acknowledgement/drain checks.
- The performance experiment used a separate integration build with batching changes and passive timing instrumentation. These are not measurements of this public branch alone, and the stopped baseline has no completed-throughput result. Full-prefix read validation is not an independent byte-for-byte FDB snapshot oracle.

## Draft limitations

System-immediate requests still count toward shared GRV release accounting. Higher consume demand can reduce foreground admission or worsen latency tails. Single-stream results do not establish fairness for many streams, cancellation-heavy consumers, or maximum sustainable capacity. Keep this draft pending that broader validation; no Ratekeeper, retention, storage-read priority, public API, or wire-format change is included.
