### PR TITLE
Avoid copying tag containers when constructing log messages

### DIFF
--- a/fdbserver/logsystem/LogSystemRecoveryTests.cpp
+++ b/fdbserver/logsystem/LogSystemRecoveryTests.cpp
@@ -58,6 +58,66 @@ std::tuple<int, std::vector<TLogLockResult>, bool> makeLogGroupResults(
 
 void forceLinkLogSystemRecoveryTests() {}
 
+TEST_CASE("/LogSystem/LogPushData/AddTagsBorrowsContainers") {
+	class NonCopyableTags : NonCopyable {
+	public:
+		explicit NonCopyableTags(std::vector<Tag> tags) : tags(std::move(tags)) {}
+		auto begin() const { return tags.begin(); }
+		auto end() const { return tags.end(); }
+
+	private:
+		std::vector<Tag> tags;
+	};
+
+	LocalityData locality;
+	auto logSet = makeSingleLogSet({ TLogInterface(locality) });
+	logSet->locality = tagLocalitySpecial;
+	logSet->tLogPolicy = makeReference<PolicyOne>();
+	logSet->updateLocalitySet({ locality });
+	auto logSystem = makeReference<LogSystem>(UID(), locality, LogEpoch(1));
+	logSystem->tLogs.push_back(logSet);
+	LogPushData actual(logSystem, 1);
+	LogPushData expected(logSystem, 1);
+
+	const Tag storageTag(0, 1);
+	const Tag cdcTag(tagLocalityCDC, 3);
+	std::vector<Tag> vectorTags{ storageTag, cdcTag, storageTag };
+	std::set<Tag> setTags{ storageTag, cdcTag };
+	actual.addTags(vectorTags);
+	actual.addTags(std::as_const(setTags));
+	for (Tag tag : vectorTags) {
+		expected.addTag(tag);
+	}
+	for (Tag tag : setTags) {
+		expected.addTag(tag);
+	}
+	vectorTags.clear();
+	setTags.clear();
+	actual.addTags(std::vector<Tag>{});
+	actual.addTags(std::set<Tag>{ cdcTag });
+	expected.addTag(cdcTag);
+	{
+		const NonCopyableTags tags({ cdcTag, storageTag });
+		actual.addTags(tags);
+		expected.addTag(cdcTag);
+		expected.addTag(storageTag);
+	}
+	actual.writeMessage("first"_sr, false);
+	expected.writeMessage("first"_sr, false);
+	ASSERT_EQ(actual.getMessages(0), expected.getMessages(0));
+
+	actual.addTags(std::vector<Tag>{ storageTag });
+	expected.addTag(storageTag);
+	actual.writeMessage("second"_sr, false);
+	expected.writeMessage("second"_sr, false);
+	ASSERT_EQ(actual.getMessages(0), expected.getMessages(0));
+	ASSERT_EQ(actual.getMutationCount(), 2);
+	std::set<Tag> writtenTags;
+	actual.saveTags(writtenTags);
+	ASSERT_EQ(writtenTags, (std::set<Tag>{ storageTag, cdcTag }));
+	return Void();
+}
+
 TEST_CASE("/LogSystem/GetPseudoPopTag/LogRouterWithoutMappedLocality") {
 	LocalityData locality;
 	auto logSystem = makeReference<LogSystem>(UID(), locality, LogEpoch(1));

--- a/fdbserver/logsystem/LogSystemRecoveryTests.cpp
+++ b/fdbserver/logsystem/LogSystemRecoveryTests.cpp
@@ -58,66 +58,6 @@ std::tuple<int, std::vector<TLogLockResult>, bool> makeLogGroupResults(
 
 void forceLinkLogSystemRecoveryTests() {}
 
-TEST_CASE("/LogSystem/LogPushData/AddTagsBorrowsContainers") {
-	class NonCopyableTags : NonCopyable {
-	public:
-		explicit NonCopyableTags(std::vector<Tag> tags) : tags(std::move(tags)) {}
-		auto begin() const { return tags.begin(); }
-		auto end() const { return tags.end(); }
-
-	private:
-		std::vector<Tag> tags;
-	};
-
-	LocalityData locality;
-	auto logSet = makeSingleLogSet({ TLogInterface(locality) });
-	logSet->locality = tagLocalitySpecial;
-	logSet->tLogPolicy = makeReference<PolicyOne>();
-	logSet->updateLocalitySet({ locality });
-	auto logSystem = makeReference<LogSystem>(UID(), locality, LogEpoch(1));
-	logSystem->tLogs.push_back(logSet);
-	LogPushData actual(logSystem, 1);
-	LogPushData expected(logSystem, 1);
-
-	const Tag storageTag(0, 1);
-	const Tag cdcTag(tagLocalityCDC, 3);
-	std::vector<Tag> vectorTags{ storageTag, cdcTag, storageTag };
-	std::set<Tag> setTags{ storageTag, cdcTag };
-	actual.addTags(vectorTags);
-	actual.addTags(std::as_const(setTags));
-	for (Tag tag : vectorTags) {
-		expected.addTag(tag);
-	}
-	for (Tag tag : setTags) {
-		expected.addTag(tag);
-	}
-	vectorTags.clear();
-	setTags.clear();
-	actual.addTags(std::vector<Tag>{});
-	actual.addTags(std::set<Tag>{ cdcTag });
-	expected.addTag(cdcTag);
-	{
-		const NonCopyableTags tags({ cdcTag, storageTag });
-		actual.addTags(tags);
-		expected.addTag(cdcTag);
-		expected.addTag(storageTag);
-	}
-	actual.writeMessage("first"_sr, false);
-	expected.writeMessage("first"_sr, false);
-	ASSERT_EQ(actual.getMessages(0), expected.getMessages(0));
-
-	actual.addTags(std::vector<Tag>{ storageTag });
-	expected.addTag(storageTag);
-	actual.writeMessage("second"_sr, false);
-	expected.writeMessage("second"_sr, false);
-	ASSERT_EQ(actual.getMessages(0), expected.getMessages(0));
-	ASSERT_EQ(actual.getMutationCount(), 2);
-	std::set<Tag> writtenTags;
-	actual.saveTags(writtenTags);
-	ASSERT_EQ(writtenTags, (std::set<Tag>{ storageTag, cdcTag }));
-	return Void();
-}
-
 TEST_CASE("/LogSystem/GetPseudoPopTag/LogRouterWithoutMappedLocality") {
 	LocalityData locality;
 	auto logSystem = makeReference<LogSystem>(UID(), locality, LogEpoch(1));

--- a/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
+++ b/fdbserver/logsystem/include/fdbserver/logsystem/LogSystem.h
@@ -135,7 +135,7 @@ struct LogPushData : NonCopyable {
 	void addTag(Tag tag) { next_message_tags.push_back(tag); }
 
 	template <class T>
-	void addTags(T tags) {
+	void addTags(T const& tags) {
 		next_message_tags.insert(next_message_tags.end(), tags.begin(), tags.end());
 	}
 


### PR DESCRIPTION
## Summary

`LogPushData::addTags` only reads its input before appending tag values to its owned vector, but its by-value parameter copies each lvalue container first. This copies storage-tag vectors and allocates temporary set nodes for CDC point-mutation tags on the commit path.

Take the container by const reference instead. No input reference is retained, and tag ordering, duplicate handling, message encoding, and scheduling remain unchanged.

## Validation

Before removal of the additional unit test, Clang compile/link completed with zero compiler failures, and the produced binary passed all 14 `/LogSystem/` and six `/NativeCDC/` tests. The build wrapper returned nonzero after linking; binary freshness/source hashes and direct test execution were verified separately.

The test removal restores `LogSystemRecoveryTests.cpp` to the base version. `git diff --check` passed; no build or tests were rerun for this test-only cleanup. No end-to-end throughput or latency improvement is claimed.
