### PR TITLE
Use member coroutines for simulated file I/O

### DIFF
--- a/fdbrpc/sim2.cpp
+++ b/fdbrpc/sim2.cpp
@@ -688,17 +688,180 @@ public:
 
 	int64_t debugFD() const override { return (int64_t)h; }
 
-	Future<int> read(void* data, int length, int64_t offset) override { return read_impl(this, data, length, offset); }
+	Future<int> read(void* data, int length, int64_t offset) override {
+		ASSERT((this->flags & IAsyncFile::OPEN_NO_AIO) != 0 ||
+		       ((uintptr_t)data % 4096 == 0 && length % 4096 == 0 && offset % 4096 == 0)); // Required by KAIO.
+		UID opId = deterministicRandom()->randomUniqueID();
+		if (randLog) {
+			fmt::print(randLog,
+			           "SFR1 {0} {1} {2} {3} {4}\n",
+			           this->dbgId.shortString(),
+			           this->filename,
+			           opId.shortString(),
+			           length,
+			           offset);
+		}
 
-	Future<Void> write(void const* data, int length, int64_t offset) override {
-		return write_impl(this, StringRef((const uint8_t*)data, length), offset);
+		co_await waitUntilDiskReady(this->diskParameters, length);
+
+		if (_lseeki64(this->h, offset, SEEK_SET) == -1) {
+			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 1);
+			throw io_error();
+		}
+
+		unsigned int read_bytes = _read(this->h, data, (unsigned int)length);
+		if (read_bytes == -1) {
+			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 2);
+			throw io_error();
+		}
+
+		if (randLog) {
+			uint32_t a = crc32c_append(0, (const uint8_t*)data, read_bytes);
+			fprintf(randLog,
+			        "SFR2 %s %s %s %d %d\n",
+			        this->dbgId.shortString().c_str(),
+			        this->filename.c_str(),
+			        opId.shortString().c_str(),
+			        read_bytes,
+			        a);
+		}
+
+		debugFileCheck("SimpleFileRead", this->filename, data, offset, length);
+
+		INJECT_FAULT(io_timeout, "SimpleFile::read"); // SimpleFile::read io_timeout injected
+		INJECT_FAULT(io_error, "SimpleFile::read"); // SimpleFile::read io_error injected
+
+		co_return read_bytes;
 	}
 
-	Future<Void> truncate(int64_t size) override { return truncate_impl(this, size); }
+	Future<Void> write(void const* data, int length, int64_t offset) override {
+		return write_impl(StringRef((const uint8_t*)data, length), offset);
+	}
 
-	Future<Void> sync() override { return sync_impl(this); }
+	Future<Void> truncate(int64_t size) override {
+		UID opId = deterministicRandom()->randomUniqueID();
+		if (randLog)
+			fmt::print(
+			    randLog, "SFT1 {0} {1} {2} {3}\n", this->dbgId.shortString(), this->filename, opId.shortString(), size);
 
-	Future<int64_t> size() const override { return size_impl(this); }
+		// KAIO will return EINVAL, as len==0 is an error.
+		if ((this->flags & IAsyncFile::OPEN_NO_AIO) == 0 && size == 0) {
+			throw io_error();
+		}
+
+		if (this->delayOnWrite)
+			co_await waitUntilDiskReady(this->diskParameters, 0);
+
+		if (_chsize(this->h, (long)size) == -1) {
+			TraceEvent(SevWarn, "SimpleFileIOError")
+			    .detail("Location", 6)
+			    .detail("Filename", this->filename)
+			    .detail("Size", size)
+			    .detail("Fd", this->h)
+			    .GetLastError();
+			throw io_error();
+		}
+
+		if (randLog) {
+			fprintf(randLog,
+			        "SFT2 %s %s %s\n",
+			        this->dbgId.shortString().c_str(),
+			        this->filename.c_str(),
+			        opId.shortString().c_str());
+		}
+
+		INJECT_FAULT(io_timeout, "SimpleFile::truncate"); // SimpleFile::truncate inject io_timeout
+		INJECT_FAULT(io_error, "SimpleFile::truncate"); // SimpleFile::truncate inject io_error
+
+		co_return;
+	}
+
+	// Simulated sync does not actually do anything besides wait a random amount of time
+	Future<Void> sync() override {
+		UID opId = deterministicRandom()->randomUniqueID();
+		if (randLog) {
+			fprintf(randLog,
+			        "SFC1 %s %s %s\n",
+			        this->dbgId.shortString().c_str(),
+			        this->filename.c_str(),
+			        opId.shortString().c_str());
+		}
+
+		if (this->delayOnWrite)
+			co_await waitUntilDiskReady(this->diskParameters, 0, true);
+
+		if (this->flags & OPEN_ATOMIC_WRITE_AND_CREATE) {
+			this->flags &= ~OPEN_ATOMIC_WRITE_AND_CREATE;
+			auto& machineCache = g_simulator->getCurrentProcess()->machine->openFiles;
+			std::string sourceFilename = this->filename + ".part";
+
+			if (machineCache.contains(sourceFilename)) {
+				// it seems gcc has some trouble with these types. Aliasing with typename is ugly, but seems to work.
+				using block_value_type = typename decltype(g_simulator->corruptedBlocks)::key_type::second_type;
+				TraceEvent("SimpleFileRename")
+				    .detail("From", sourceFilename)
+				    .detail("To", this->filename)
+				    .detail("SourceCount", machineCache.count(sourceFilename))
+				    .detail("FileCount", machineCache.count(this->filename));
+				auto maxBlockValue = std::numeric_limits<block_value_type>::max();
+				g_simulator->corruptedBlocks.erase(
+				    g_simulator->corruptedBlocks.lower_bound(std::make_pair(sourceFilename, 0u)),
+				    g_simulator->corruptedBlocks.upper_bound(std::make_pair(this->filename, maxBlockValue)));
+				// next we need to rename all files. In practice, the number of corruptions for a given file should be
+				// very small
+				auto begin = g_simulator->corruptedBlocks.lower_bound(std::make_pair(sourceFilename, 0u)),
+				     end = g_simulator->corruptedBlocks.upper_bound(std::make_pair(sourceFilename, maxBlockValue));
+				for (auto iter = begin; iter != end; ++iter) {
+					g_simulator->corruptedBlocks.emplace(this->filename, iter->second);
+				}
+				g_simulator->corruptedBlocks.erase(begin, end);
+				renameFile(sourceFilename.c_str(), this->filename.c_str());
+
+				machineCache[this->filename] = machineCache[sourceFilename];
+				machineCache.erase(sourceFilename);
+				this->actualFilename = this->filename;
+			}
+		}
+
+		if (randLog) {
+			fprintf(randLog,
+			        "SFC2 %s %s %s\n",
+			        this->dbgId.shortString().c_str(),
+			        this->filename.c_str(),
+			        opId.shortString().c_str());
+		}
+
+		INJECT_FAULT(io_timeout, "SimpleFile::sync"); // SimpleFile::sync inject io_timeout
+		INJECT_FAULT(io_error, "SimpleFile::sync"); // SimpleFile::sync inject io_errot
+
+		co_return;
+	}
+
+	Future<int64_t> size() const override {
+		UID opId = deterministicRandom()->randomUniqueID();
+		if (randLog) {
+			fprintf(randLog,
+			        "SFS1 %s %s %s\n",
+			        this->dbgId.shortString().c_str(),
+			        this->filename.c_str(),
+			        opId.shortString().c_str());
+		}
+
+		co_await waitUntilDiskReady(this->diskParameters, 0);
+
+		int64_t pos = _lseeki64(this->h, 0L, SEEK_END);
+		if (pos == -1) {
+			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 8);
+			throw io_error();
+		}
+
+		if (randLog)
+			fmt::print(
+			    randLog, "SFS2 {0} {1} {2} {3}\n", this->dbgId.shortString(), this->filename, opId.shortString(), pos);
+		INJECT_FAULT(io_error, "SimpleFile::size"); // SimpleFile::size inject io_error
+
+		co_return pos;
+	}
 
 	std::string getFilename() const override { return actualFilename; }
 
@@ -746,75 +909,29 @@ private:
 		return outFlags;
 	}
 
-	static Future<int> read_impl(SimpleFile* self, void* data, int length, int64_t offset) {
-		ASSERT((self->flags & IAsyncFile::OPEN_NO_AIO) != 0 ||
-		       ((uintptr_t)data % 4096 == 0 && length % 4096 == 0 && offset % 4096 == 0)); // Required by KAIO.
-		UID opId = deterministicRandom()->randomUniqueID();
-		if (randLog) {
-			fmt::print(randLog,
-			           "SFR1 {0} {1} {2} {3} {4}\n",
-			           self->dbgId.shortString(),
-			           self->filename,
-			           opId.shortString(),
-			           length,
-			           offset);
-		}
-
-		co_await waitUntilDiskReady(self->diskParameters, length);
-
-		if (_lseeki64(self->h, offset, SEEK_SET) == -1) {
-			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 1);
-			throw io_error();
-		}
-
-		unsigned int read_bytes = _read(self->h, data, (unsigned int)length);
-		if (read_bytes == -1) {
-			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 2);
-			throw io_error();
-		}
-
-		if (randLog) {
-			uint32_t a = crc32c_append(0, (const uint8_t*)data, read_bytes);
-			fprintf(randLog,
-			        "SFR2 %s %s %s %d %d\n",
-			        self->dbgId.shortString().c_str(),
-			        self->filename.c_str(),
-			        opId.shortString().c_str(),
-			        read_bytes,
-			        a);
-		}
-
-		debugFileCheck("SimpleFileRead", self->filename, data, offset, length);
-
-		INJECT_FAULT(io_timeout, "SimpleFile::read"); // SimpleFile::read io_timeout injected
-		INJECT_FAULT(io_error, "SimpleFile::read"); // SimpleFile::read io_error injected
-
-		co_return read_bytes;
-	}
-
-	static Future<Void> write_impl(SimpleFile* self, StringRef data, int64_t offset) {
+	Future<Void> write_impl(StringRef data, int64_t offset) {
 		UID opId = deterministicRandom()->randomUniqueID();
 		if (randLog) {
 			uint32_t a = crc32c_append(0, data.begin(), data.size());
 			fmt::print(randLog,
 			           "SFW1 {0} {1} {2} {3} {4} {5}\n",
-			           self->dbgId.shortString(),
-			           self->filename,
+			           this->dbgId.shortString(),
+			           this->filename,
 			           opId.shortString(),
 			           a,
 			           data.size(),
 			           offset);
 		}
 
-		if (self->delayOnWrite)
-			co_await waitUntilDiskReady(self->diskParameters, data.size());
+		if (this->delayOnWrite)
+			co_await waitUntilDiskReady(this->diskParameters, data.size());
 
-		if (_lseeki64(self->h, offset, SEEK_SET) == -1) {
+		if (_lseeki64(this->h, offset, SEEK_SET) == -1) {
 			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 3);
 			throw io_error();
 		}
 
-		unsigned int write_bytes = _write(self->h, (void*)data.begin(), data.size());
+		unsigned int write_bytes = _write(this->h, (void*)data.begin(), data.size());
 		if (write_bytes == -1) {
 			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 4);
 			throw io_error();
@@ -828,142 +945,17 @@ private:
 		if (randLog) {
 			fprintf(randLog,
 			        "SFW2 %s %s %s\n",
-			        self->dbgId.shortString().c_str(),
-			        self->filename.c_str(),
+			        this->dbgId.shortString().c_str(),
+			        this->filename.c_str(),
 			        opId.shortString().c_str());
 		}
 
-		debugFileCheck("SimpleFileWrite", self->filename, (void*)data.begin(), offset, data.size());
+		debugFileCheck("SimpleFileWrite", this->filename, (void*)data.begin(), offset, data.size());
 
 		INJECT_FAULT(io_timeout, "SimpleFile::write"); // SimpleFile::write inject io_timeout
 		INJECT_FAULT(io_error, "SimpleFile::write"); // SimpleFile::write inject io_error
 
 		co_return;
-	}
-
-	static Future<Void> truncate_impl(SimpleFile* self, int64_t size) {
-		UID opId = deterministicRandom()->randomUniqueID();
-		if (randLog)
-			fmt::print(
-			    randLog, "SFT1 {0} {1} {2} {3}\n", self->dbgId.shortString(), self->filename, opId.shortString(), size);
-
-		// KAIO will return EINVAL, as len==0 is an error.
-		if ((self->flags & IAsyncFile::OPEN_NO_AIO) == 0 && size == 0) {
-			throw io_error();
-		}
-
-		if (self->delayOnWrite)
-			co_await waitUntilDiskReady(self->diskParameters, 0);
-
-		if (_chsize(self->h, (long)size) == -1) {
-			TraceEvent(SevWarn, "SimpleFileIOError")
-			    .detail("Location", 6)
-			    .detail("Filename", self->filename)
-			    .detail("Size", size)
-			    .detail("Fd", self->h)
-			    .GetLastError();
-			throw io_error();
-		}
-
-		if (randLog) {
-			fprintf(randLog,
-			        "SFT2 %s %s %s\n",
-			        self->dbgId.shortString().c_str(),
-			        self->filename.c_str(),
-			        opId.shortString().c_str());
-		}
-
-		INJECT_FAULT(io_timeout, "SimpleFile::truncate"); // SimpleFile::truncate inject io_timeout
-		INJECT_FAULT(io_error, "SimpleFile::truncate"); // SimpleFile::truncate inject io_error
-
-		co_return;
-	}
-
-	// Simulated sync does not actually do anything besides wait a random amount of time
-	static Future<Void> sync_impl(SimpleFile* self) {
-		UID opId = deterministicRandom()->randomUniqueID();
-		if (randLog) {
-			fprintf(randLog,
-			        "SFC1 %s %s %s\n",
-			        self->dbgId.shortString().c_str(),
-			        self->filename.c_str(),
-			        opId.shortString().c_str());
-		}
-
-		if (self->delayOnWrite)
-			co_await waitUntilDiskReady(self->diskParameters, 0, true);
-
-		if (self->flags & OPEN_ATOMIC_WRITE_AND_CREATE) {
-			self->flags &= ~OPEN_ATOMIC_WRITE_AND_CREATE;
-			auto& machineCache = g_simulator->getCurrentProcess()->machine->openFiles;
-			std::string sourceFilename = self->filename + ".part";
-
-			if (machineCache.contains(sourceFilename)) {
-				// it seems gcc has some trouble with these types. Aliasing with typename is ugly, but seems to work.
-				using block_value_type = typename decltype(g_simulator->corruptedBlocks)::key_type::second_type;
-				TraceEvent("SimpleFileRename")
-				    .detail("From", sourceFilename)
-				    .detail("To", self->filename)
-				    .detail("SourceCount", machineCache.count(sourceFilename))
-				    .detail("FileCount", machineCache.count(self->filename));
-				auto maxBlockValue = std::numeric_limits<block_value_type>::max();
-				g_simulator->corruptedBlocks.erase(
-				    g_simulator->corruptedBlocks.lower_bound(std::make_pair(sourceFilename, 0u)),
-				    g_simulator->corruptedBlocks.upper_bound(std::make_pair(self->filename, maxBlockValue)));
-				// next we need to rename all files. In practice, the number of corruptions for a given file should be
-				// very small
-				auto begin = g_simulator->corruptedBlocks.lower_bound(std::make_pair(sourceFilename, 0u)),
-				     end = g_simulator->corruptedBlocks.upper_bound(std::make_pair(sourceFilename, maxBlockValue));
-				for (auto iter = begin; iter != end; ++iter) {
-					g_simulator->corruptedBlocks.emplace(self->filename, iter->second);
-				}
-				g_simulator->corruptedBlocks.erase(begin, end);
-				renameFile(sourceFilename.c_str(), self->filename.c_str());
-
-				machineCache[self->filename] = machineCache[sourceFilename];
-				machineCache.erase(sourceFilename);
-				self->actualFilename = self->filename;
-			}
-		}
-
-		if (randLog) {
-			fprintf(randLog,
-			        "SFC2 %s %s %s\n",
-			        self->dbgId.shortString().c_str(),
-			        self->filename.c_str(),
-			        opId.shortString().c_str());
-		}
-
-		INJECT_FAULT(io_timeout, "SimpleFile::sync"); // SimpleFile::sync inject io_timeout
-		INJECT_FAULT(io_error, "SimpleFile::sync"); // SimpleFile::sync inject io_errot
-
-		co_return;
-	}
-
-	static Future<int64_t> size_impl(SimpleFile const* self) {
-		UID opId = deterministicRandom()->randomUniqueID();
-		if (randLog) {
-			fprintf(randLog,
-			        "SFS1 %s %s %s\n",
-			        self->dbgId.shortString().c_str(),
-			        self->filename.c_str(),
-			        opId.shortString().c_str());
-		}
-
-		co_await waitUntilDiskReady(self->diskParameters, 0);
-
-		int64_t pos = _lseeki64(self->h, 0L, SEEK_END);
-		if (pos == -1) {
-			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 8);
-			throw io_error();
-		}
-
-		if (randLog)
-			fmt::print(
-			    randLog, "SFS2 {0} {1} {2} {3}\n", self->dbgId.shortString(), self->filename, opId.shortString(), pos);
-		INJECT_FAULT(io_error, "SimpleFile::size"); // SimpleFile::size inject io_error
-
-		co_return pos;
 	}
 };
 


### PR DESCRIPTION
## Summary

Follow up on #13969 by removing the remaining raw `SimpleFile* self` coroutine receivers in `SimpleFile`.

- Make `read`, `truncate`, `sync`, and `size` direct member coroutine overrides, removing their forwarding wrappers.
- Keep `write` as the existing `StringRef` adapter and make `write_impl` a private member coroutine.
- Preserve `size() const`, buffer ownership, explicit delays and random draws, fault-injection calls, and rename state transitions. Leave `open` and other legitimate static helpers unchanged.

The diff is limited to `SimpleFile` in `fdbrpc/sim2.cpp`. Moving code changes source line numbers used by simulator fault selection, so identical seeds are not guaranteed to inject identical faults across revisions.

## Validation

- `git diff --check`, clang-format 19, and method-body comparison after receiver substitution passed.
- `fdbrpc_test --seed 20260901`: 68 passed, 0 failed.
- `fdbrpc_test --simulation -f /fileio/ --seed 20260901`: 4 passed, 0 failed.
- `tests/fast/CycleTest.toml` in simulation with `--buggify on`, seeds `20260901` and `20260902`: all four test phases passed; no severity-40-or-higher trace events.

Both Clang/Release targets (`fdbrpc_test` and `fdbserver`) compiled and linked with zero compilation failures. The build harness returned a nonzero status after linking; the fresh binaries were verified and executed directly for the results above.

Validation limitation: an attempted simulation run of the legacy `tests/AsyncFileCorrectness.txt` failed during setup because its non-atomic `OPEN_CREATE` request is rejected by the unchanged `Sim2FileSystem::open` assertion, before reaching `SimpleFile`. That invocation is not counted as passing, and no workload or simulator guard was changed.
