### PR TITLE
[release-7.3] Turn DD global admission control off by default

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -147,13 +147,16 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( MERGE_RELOCATION_PARALLELISM_PER_TEAM,                   6 ); if (randomize && BUGGIFY ) MERGE_RELOCATION_PARALLELISM_PER_TEAM = 1;
 	init( DD_QUEUE_MAX_KEY_SERVERS,                              100 ); // Do not buggify
 	init( DD_REBALANCE_PARALLELISM,                               50 );
-	// Hard cap on total relocations DD tracks (queued + in-flight). 1000 corresponds to a 500-server
-	// cluster with two concurrent shard moves per storage server.  We have observed large clusters doing
-	// 25-30GB in flight, or closer to 100 shards at a time, so this has plenty of margin of safety
-	// built in.  For simulation, we don't really know how many servers there are, but 10 seems like a good
-	// guess (thus 20 moves).  Do not buggify this too small: testing under artificial scarcity results in
-	// uninteresting degenerate cases.
-	init( DD_MAX_PIPELINE_MOVES,                                1000 ); if( randomize && BUGGIFY ) DD_MAX_PIPELINE_MOVES = 20;
+	// Global admission control for DD relocations is OFF by default. The default limit is set high
+	// enough that pipelineSize() can never reach it, so pipelineFull never becomes true and the
+	// relocation gate in pipelineGateActor() never holds anything back. To turn the feature on, set
+	// this to a real cap: 1000 corresponds to a 500-server cluster with two concurrent shard moves
+	// per storage server. We have observed large clusters doing 25-30GB in flight, or closer to 100
+	// shards at a time, so 1000 would have plenty of margin of safety built in. Simulation still
+	// exercises the gate via the BUGGIFY value below. For simulation, we don't really know how many
+	// servers there are, but 10 seems like a good guess (thus 20 moves). Do not buggify this too
+	// small: testing under artificial scarcity results in uninteresting degenerate cases.
+	init( DD_MAX_PIPELINE_MOVES, std::numeric_limits<int>::max() ); if( randomize && BUGGIFY ) DD_MAX_PIPELINE_MOVES = 20;
 	init( DD_REBALANCE_RESET_AMOUNT,                              30 );
 	init( INFLIGHT_PENALTY_HEALTHY,                              1.0 );
 	init( INFLIGHT_PENALTY_UNHEALTHY,                          500.0 );


### PR DESCRIPTION
backport of https://github.com/apple/foundationdb/pull/13918 / https://github.com/apple/foundationdb/pull/13917

(not that we plan to make another 7.3.x release soon, but just in case)

(also using this to test fdb-build-support updates for old centos7 builds 😬 - those will be gone soon enough, but might as well make sure they still work for now)