### PR TITLE
Keep current snapshot restart tests single-region

### DIFF
--- a/tests/restarting/from_7.4.0/SnapCycleRestart-1.toml
+++ b/tests/restarting/from_7.4.0/SnapCycleRestart-1.toml
@@ -1,4 +1,7 @@
 [configuration]
+# Simulated snapshot restore only supports a single-region source cluster.
+generateFearless=false
+datacenters=1
 storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
 tenantModes = ['disabled']

--- a/tests/restarting/from_7.4.0/SnapTestAttrition-1.toml
+++ b/tests/restarting/from_7.4.0/SnapTestAttrition-1.toml
@@ -1,4 +1,7 @@
 [configuration]
+# Simulated snapshot restore only supports a single-region source cluster.
+generateFearless=false
+datacenters=1
 storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
 tenantModes = ['disabled']

--- a/tests/restarting/from_7.4.0/SnapTestRestart-1.toml
+++ b/tests/restarting/from_7.4.0/SnapTestRestart-1.toml
@@ -1,4 +1,7 @@
 [configuration]
+# Simulated snapshot restore only supports a single-region source cluster.
+generateFearless=false
+datacenters=1
 storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
 tenantModes = ['disabled']

--- a/tests/restarting/from_7.4.0/SnapTestSimpleRestart-1.toml
+++ b/tests/restarting/from_7.4.0/SnapTestSimpleRestart-1.toml
@@ -1,4 +1,7 @@
 [configuration]
+# Simulated snapshot restore only supports a single-region source cluster.
+generateFearless=false
+datacenters=1
 storageEngineExcludeTypes=[3,4,5]
 logAntiQuorum=0
 tenantModes = ['disabled']


### PR DESCRIPTION
The `from_7.4.0` snapshot restart fixtures can generate multi-region clusters even though simulated snapshot restore forces `usable_regions=1`. Snapshots capture primary-region storage and local, non-satellite TLogs. If restore first recovers in the other region, the restored storage servers can lose access to a required log generation, shut down with `worker_removed`, and leave recovery timing out.

Keep the snapshot-producing phase of all four fixtures single-region with `generateFearless=false` and `datacenters=1`, matching the existing pre-7.4 fixtures. Both options are recognized by supported 7.4 binaries; `singleRegion` is not a TOML option in 7.4.0. Workloads, ordinary redundancy, storage-engine selection, buggify, fault injection, and restore checks are unchanged.

Validation:
- Reproduced the original snapshot/restore timeout with the original binary and unchanged fixtures; the corrected pair passed with that binary.
- All four corrected snapshot/restore pairs passed on current `main`, with full traces confirming single-region configurations and no error-severity events.
- The unmodified seed pair also passed on current `main`. Changing topology or revision changes the deterministic schedule; the fix enforces the simulator's documented restore constraint rather than treating matching seeds as causal proof.
