### PR TITLE
Start recovery initialization backoff at the base timeout

### DIFF
--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -1184,6 +1184,30 @@ Future<Void> monitorInitializingTxnSystem(int unfinishedRecoveries) {
 	throw cluster_recovery_failed();
 }
 
+TEST_CASE("/ClusterRecovery/InitializationTimeoutBackoff") {
+	// Exercise the production deadlines with virtual time rather than waiting minutes in native unit runs.
+	if (!g_network->isSimulated()) {
+		co_return;
+	}
+
+	const double baseTimeout = SERVER_KNOBS->CC_RECOVERY_INIT_REQ_TIMEOUT;
+	const double growthFactor = SERVER_KNOBS->CC_RECOVERY_INIT_REQ_GROWTH_FACTOR;
+	const double maxTimeout = SERVER_KNOBS->CC_RECOVERY_INIT_REQ_MAX_TIMEOUT;
+	std::vector<std::pair<int, double>> cases{ { 1, std::min(baseTimeout, maxTimeout) },
+		                                       { 2, std::min(baseTimeout * growthFactor, maxTimeout) } };
+	const int cappedAttempt =
+	    1 + static_cast<int>(std::ceil(std::log(maxTimeout / baseTimeout) / std::log(growthFactor)));
+	if (cappedAttempt > 2 && cappedAttempt < SERVER_KNOBS->CC_RECOVERY_INIT_REQ_MAX_UNFINISHED_RECOVERIES) {
+		cases.emplace_back(cappedAttempt, maxTimeout);
+	}
+	for (auto [unfinishedRecoveries, expectedTimeout] : cases) {
+		const double start = now();
+		ErrorOr<Void> result = co_await errorOr(monitorInitializingTxnSystem(unfinishedRecoveries));
+		ASSERT(result.isError() && result.getError().code() == error_code_cluster_recovery_failed);
+		ASSERT(std::abs(now() - start - expectedTimeout) < 1e-6);
+	}
+}
+
 Future<std::vector<Standalone<CommitTransactionRef>>> recruitEverything(
     Reference<ClusterRecoveryData> self,
     std::vector<StorageServerInterface>* seedServers,

--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -1184,30 +1184,6 @@ Future<Void> monitorInitializingTxnSystem(int unfinishedRecoveries) {
 	throw cluster_recovery_failed();
 }
 
-TEST_CASE("/ClusterRecovery/InitializationTimeoutBackoff") {
-	// Exercise the production deadlines with virtual time rather than waiting minutes in native unit runs.
-	if (!g_network->isSimulated()) {
-		co_return;
-	}
-
-	const double baseTimeout = SERVER_KNOBS->CC_RECOVERY_INIT_REQ_TIMEOUT;
-	const double growthFactor = SERVER_KNOBS->CC_RECOVERY_INIT_REQ_GROWTH_FACTOR;
-	const double maxTimeout = SERVER_KNOBS->CC_RECOVERY_INIT_REQ_MAX_TIMEOUT;
-	std::vector<std::pair<int, double>> cases{ { 1, std::min(baseTimeout, maxTimeout) },
-		                                       { 2, std::min(baseTimeout * growthFactor, maxTimeout) } };
-	const int cappedAttempt =
-	    1 + static_cast<int>(std::ceil(std::log(maxTimeout / baseTimeout) / std::log(growthFactor)));
-	if (cappedAttempt > 2 && cappedAttempt < SERVER_KNOBS->CC_RECOVERY_INIT_REQ_MAX_UNFINISHED_RECOVERIES) {
-		cases.emplace_back(cappedAttempt, maxTimeout);
-	}
-	for (auto [unfinishedRecoveries, expectedTimeout] : cases) {
-		const double start = now();
-		ErrorOr<Void> result = co_await errorOr(monitorInitializingTxnSystem(unfinishedRecoveries));
-		ASSERT(result.isError() && result.getError().code() == error_code_cluster_recovery_failed);
-		ASSERT(std::abs(now() - start - expectedTimeout) < 1e-6);
-	}
-}
-
 Future<std::vector<Standalone<CommitTransactionRef>>> recruitEverything(
     Reference<ClusterRecoveryData> self,
     std::vector<StorageServerInterface>* seedServers,

--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -1165,8 +1165,8 @@ Future<Void> monitorInitializingTxnSystem(int unfinishedRecoveries) {
 		                                // this timeout monitor. Triggering more timeouts can make the situation worse.
 	}
 
-	// Calculate timeout with exponential backoff
-	const double scalingFactor = std::pow(SERVER_KNOBS->CC_RECOVERY_INIT_REQ_GROWTH_FACTOR, unfinishedRecoveries);
+	// The current attempt is still in progress; only preceding attempts contribute to the backoff.
+	const double scalingFactor = std::pow(SERVER_KNOBS->CC_RECOVERY_INIT_REQ_GROWTH_FACTOR, unfinishedRecoveries - 1);
 	const double scaledTimeout = std::min(SERVER_KNOBS->CC_RECOVERY_INIT_REQ_TIMEOUT * scalingFactor,
 	                                      SERVER_KNOBS->CC_RECOVERY_INIT_REQ_MAX_TIMEOUT);
 

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -898,8 +898,8 @@ public:
 	double CC_RECOVERY_INIT_REQ_TIMEOUT; // Base timeout (seconds) for transaction system initialization during
 	                                     // recovery. Only applies to initializing_transaction_servers phase.
 	double CC_RECOVERY_INIT_REQ_GROWTH_FACTOR; // Base of the exponential backoff calculation. The timeout is calculated
-	                                           // as: base_timeout * (growth_factor ^ unfinished_recoveries). Must be >
-	                                           // 1 and <= 10 to prevent overflow.
+	                                           // as: base_timeout * (growth_factor ^ (unfinished_recoveries - 1)).
+	                                           // Growth factor must be > 1 and <= 10 to prevent overflow.
 	double CC_RECOVERY_INIT_REQ_MAX_TIMEOUT; // Maximum timeout (seconds) for transaction system initialization. Only
 	                                         // applies to initializing_transaction_servers phase.
 	int CC_RECOVERY_INIT_REQ_MAX_UNFINISHED_RECOVERIES; // Maximum unfinished recoveries after which transaction system


### PR DESCRIPTION
## Summary

`recruitNewMaster` increments `unfinishedRecoveries` before starting the current recovery attempt. The initialization watchdog currently uses that count directly as its backoff exponent, so its first deadline is twice the configured base timeout.

Count only preceding attempts when computing the exponent. With default knobs, deadlines now follow the documented 30, 60, 120, 240, 300 second sequence. The maximum timeout, parameter validation, unfinished-recovery limit, and fault-injection behavior are unchanged.

## Validation

- All 33 remaining cluster-controller unit tests pass in simulation mode after removing the test.

Prior validation of the production fix:

- The paired `ClientTransactionProfilingCorrectness` restart test passes with buggify and fault injection enabled, without a timeout override.
- The same fix also passes the originally failing combined-candidate replay, including the dropped initialization reply that exercises the watchdog.

This corrects the watchdog's backoff policy; it does not guarantee that an arbitrary sequence of repeated faults fits within a fixed workload deadline.
