### PR TITLE
Read `AsyncFileEncrypted` blocks concurrently

### DIFF
--- a/fdbrpc/AsyncFileEncrypted.cpp
+++ b/fdbrpc/AsyncFileEncrypted.cpp
@@ -77,12 +77,19 @@ public:
 		}
 		uint32_t firstBlock = offset / self->encryptionBlockSize;
 		uint32_t lastBlock = (offset + length - 1) / self->encryptionBlockSize;
-		uint32_t block{ 0 };
 		auto* output = reinterpret_cast<unsigned char*>(data);
 		int bytesRead = 0;
 		ASSERT(self->mode == AsyncFileEncrypted::Mode::READ_ONLY);
-		for (block = firstBlock; block <= lastBlock; ++block) {
-			Standalone<StringRef> plaintext = co_await readBlock(self.getPtr(), block);
+
+		std::vector<Future<Standalone<StringRef>>> blockReads;
+		blockReads.reserve(lastBlock - firstBlock + 1);
+		for (uint32_t block = firstBlock; block <= lastBlock; ++block) {
+			blockReads.push_back(readBlock(self.getPtr(), block));
+		}
+		co_await waitForAll(blockReads);
+
+		for (uint32_t block = firstBlock; block <= lastBlock; ++block) {
+			Standalone<StringRef> plaintext = blockReads[block - firstBlock].get();
 			auto start =
 			    (block == firstBlock) ? plaintext.begin() + (offset % self->encryptionBlockSize) : plaintext.begin();
 			auto end = (block == lastBlock) ? plaintext.begin() + ((offset + length) % self->encryptionBlockSize)


### PR DESCRIPTION
## Before this PR

`AsyncFileEncrypted::read()` waited for each encryption block before starting the next. When the configured encryption block size is small relative to the read-cache block size, a logical read can cover many independently decryptable blocks. If the request spans multiple cache blocks, serial issuance does not reach the next cache miss until the preceding encryption blocks finish, leaving the cache's configured per-file read concurrency unused.

#13750 moved the read cache beneath encryption, allowing small ciphertext reads to share cache fills. However, `AsyncFileEncrypted` still reaches those cache fills one encryption block at a time. Both the encryption block size and read-cache block size remain configurable.

## After this PR

`AsyncFileEncrypted::read()` starts all required block reads before waiting for them, then assembles the plaintext in block order. This allows the underlying cache to schedule distinct cache fills concurrently. AES-GCM verification, returned byte order, and the `AsyncFileEncrypted` interface are unchanged.

## Possible downsides

Each read now keeps one `Future` and decrypted result per encryption block until the requested range completes. Requests with very small encryption blocks and large read ranges use more temporary memory and queue more reads. Cached blobstore reads still limit active backend work using the configured per-file read concurrency.

## Testing

- `ninja -C cmake-build-local fdbrpc_test`
- `cmake-build-local/bin/fdbrpc_test -f fdbrpc/AsyncFileEncrypted`: 1 passed, 0 failed
- `clang-format --dry-run --Werror fdbrpc/AsyncFileEncrypted.cpp`
- `git diff --check`

No new test is included. The existing test verifies encrypted-file round trips; this change only alters when independent block reads are started.
