### PR TITLE
Remove native resource cleanup in Java finalizers

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/FDB.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDB.java
@@ -86,7 +86,6 @@ public class FDB {
 	private final int apiVersion;
 	private volatile boolean netStarted = false;
 	private volatile boolean netStopped = false;
-	volatile boolean warnOnUnclosed = true;
 	private boolean enableDirectBufferQueries = false;
 
 	private boolean useShutdownHook = true;
@@ -212,14 +211,12 @@ public class FDB {
 	}
 
 	/**
-	 * Enables or disables the stderr warning that is printed whenever an object with FoundationDB
-	 *  native resources is garbage collected without being closed. By default, this feature is enabled.
+	 * @deprecated This function no longer has any effect.
 	 *
-	 * @param warnOnUnclosed Whether the warning should be printed for unclosed objects
+	 * @param warnOnUnclosed unused
 	 */
-	public void setUnclosedWarning(boolean warnOnUnclosed) {
-		this.warnOnUnclosed = warnOnUnclosed;
-	}
+	@Deprecated
+	public void setUnclosedWarning(boolean warnOnUnclosed) {}
 
 	/**
 	 * Returns the API version that was selected by the {@link #selectAPIVersion(int) selectAPIVersion()}

--- a/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
@@ -113,17 +113,6 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 	}
 
 	@Override
-	protected void finalize() throws Throwable {
-		try {
-			checkUnclosed("Database");
-			close();
-		}
-		finally {
-			super.finalize();
-		}
-	}
-
-	@Override
 	public Transaction createTransaction(Executor e) {
 		return createTransaction(e, eventKeeper);
 	}

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
@@ -808,17 +808,6 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 	}
 
 	@Override
-	protected void finalize() throws Throwable {
-		try {
-			checkUnclosed("Transaction");
-			close();
-		}
-		finally {
-			super.finalize();
-		}
-	}
-
-	@Override
 	protected void closeInternal(long cPtr) {
 		if(eventKeeper!=null){
 			eventKeeper.increment(Events.JNI_CALL);

--- a/bindings/java/src/main/com/apple/foundationdb/LocalityUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/LocalityUtil.java
@@ -129,7 +129,6 @@ public class LocalityUtil {
 
 		AsyncIterator<KeyValue> block;
 		private CompletableFuture<Boolean> nextFuture;
-		private boolean closed;
 
 		BoundaryIterator(Transaction tr, byte[] begin, byte[] end) {
 			this.tr = tr;
@@ -144,8 +143,6 @@ public class LocalityUtil {
 			firstGet = tr.getRange(keyServersForKey(begin), keyServersForKey(end));
 			block = firstGet.iterator();
 			nextFuture = AsyncUtil.composeHandleAsync(block.onHasNext(), handler, tr.getExecutor());
-
-			closed = false;
 		}
 
 		@Override
@@ -219,22 +216,6 @@ public class LocalityUtil {
 		@Override
 		public void close() {
 			BoundaryIterator.this.tr.close();
-			closed = true;
-		}
-
-		@Override
-		protected void finalize() throws Throwable {
-			try {
-				if(FDB.instance().warnOnUnclosed && !closed) {
-					System.err.println("CloseableAsyncIterator not closed (getBoundaryKeys)");
-				}
-				if(!closed) {
-					close();
-				}
-			}
-			finally {
-				super.finalize();
-			}
 		}
 	}
 

--- a/bindings/java/src/main/com/apple/foundationdb/NativeObjectWrapper.java
+++ b/bindings/java/src/main/com/apple/foundationdb/NativeObjectWrapper.java
@@ -45,18 +45,6 @@ abstract class NativeObjectWrapper implements AutoCloseable {
 		return closed;
 	}
 
-	public void checkUnclosed(String context) {
-		try {
-			if(FDB.instance().warnOnUnclosed && !closed) {
-				System.err.println(context + " not closed");
-			}
-		}
-		catch(Exception e) {
-			// Eat this error. This is called from the finalizer,
-			// so there isn't much we can do.
-		}
-	}
-
 	@Override
 	public void close() {
 		rwl.writeLock().lock();


### PR DESCRIPTION
Rebased #3243 which was then closed in favor of this issue.

Original commit message from #3243 by ajbeamon:
        
       We deprecated the behavior of relying on Java finalizers
        for native resource cleanup a while ago in release 5.1.
        This PR now removes this behavior so that we don't have
        any custom finalizers.

Added cleanup of some leftover dead state.
