### PR TITLE
Make DD's destination selection observable during a host migration

### DIFF
--- a/fdbserver/core/ServerKnobs.cpp
+++ b/fdbserver/core/ServerKnobs.cpp
@@ -449,6 +449,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( TSS_RECRUITMENT_TIMEOUT,       3*STORAGE_RECRUITMENT_DELAY ); if (randomize && buggify() ) TSS_RECRUITMENT_TIMEOUT = 1.0; // Super low timeout should cause tss recruitments to fail
 	init( TSS_DD_CHECK_INTERVAL,                                60.0 ); if (randomize && buggify() ) TSS_DD_CHECK_INTERVAL = 1.0;    // May kill all TSS quickly
 	init( DATA_DISTRIBUTION_LOGGING_INTERVAL,                    5.0 );
+	init( DD_SERVER_ELIGIBILITY_LOGGING_INTERVAL,              300.0 );
 	init( DD_ENABLED_CHECK_DELAY,                                1.0 );
 	init( DD_STALL_CHECK_DELAY,                                  0.4 ); //Must be larger than 2*MAX_BUGGIFIED_DELAY
 	init( DD_LOW_BANDWIDTH_DELAY,         isSimulated ? 15.0 : 240.0 ); if( randomize && buggify() ) DD_LOW_BANDWIDTH_DELAY = 0; //Because of delayJitter, this should be less than 0.9 * DD_MERGE_COALESCE_DELAY

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -322,11 +322,9 @@ public:
 	double TSS_RECRUITMENT_TIMEOUT;
 	double TSS_DD_CHECK_INTERVAL;
 	double DATA_DISTRIBUTION_LOGGING_INTERVAL;
-	// Cadence of DDServerEligibility. Deliberately much coarser than the logging interval above: it
-	// gauges conditions that persist for hours, so sampling it as often as the rest of the logging path
-	// costs trace volume across a fleet without adding resolution. A newly constructed team collection
-	// emits immediately regardless, so distributor restarts are captured whatever this is set to. Lower
-	// it while watching a migration.
+	// Cadence of DDServerEligibility. Coarse because it gauges conditions that persist for hours. A new
+	// team collection emits immediately, so distributor restarts are captured at any value. Lower it
+	// while watching a migration.
 	double DD_SERVER_ELIGIBILITY_LOGGING_INTERVAL;
 	double DD_ENABLED_CHECK_DELAY;
 	double DD_STALL_CHECK_DELAY;

--- a/fdbserver/core/include/fdbserver/core/Knobs.h
+++ b/fdbserver/core/include/fdbserver/core/Knobs.h
@@ -322,6 +322,12 @@ public:
 	double TSS_RECRUITMENT_TIMEOUT;
 	double TSS_DD_CHECK_INTERVAL;
 	double DATA_DISTRIBUTION_LOGGING_INTERVAL;
+	// Cadence of DDServerEligibility. Deliberately much coarser than the logging interval above: it
+	// gauges conditions that persist for hours, so sampling it as often as the rest of the logging path
+	// costs trace volume across a fleet without adding resolution. A newly constructed team collection
+	// emits immediately regardless, so distributor restarts are captured whatever this is set to. Lower
+	// it while watching a migration.
+	double DD_SERVER_ELIGIBILITY_LOGGING_INTERVAL;
 	double DD_ENABLED_CHECK_DELAY;
 	double DD_STALL_CHECK_DELAY;
 	double DD_LOW_BANDWIDTH_DELAY;

--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -3140,9 +3140,31 @@ struct DDQueueImpl {
 
 		auto const highestPriorityRelocation = self->getHighestPriorityRelocation();
 
+		// InFlight and InQueue below are counters, maintained by increment/decrement as relocations are
+		// launched and completed. They have been observed diverging badly from the work actually present
+		// — an order of magnitude — which makes them useless for judging whether DD is holding real work
+		// or has simply lost count. The retained-object sizes here are the independent view: they are
+		// what DD's resident memory is actually made of, so they distinguish a genuine backlog from
+		// counter drift, and they are the accounting to reach for when DD approaches its memory limit.
+		//
+		// fetchKeysComplete in particular is the known driver of DD memory growth: relocations land
+		// there once their fetch finishes and wait to be retired, so it grows without bound whenever
+		// completion processing falls behind.
+		int serverQueueEntries = 0;
+		for (auto const& [serverId, serverQueue] : self->queue) {
+			serverQueueEntries += serverQueue.size();
+		}
+
 		TraceEvent("MovingData", self->distributorId)
 		    .detail("InFlight", self->activeRelocations)
 		    .detail("InQueue", self->queuedRelocations)
+		    .detail("FetchKeysComplete", self->fetchKeysComplete.size())
+		    .detail("FetchingSourcesQueue", self->fetchingSourcesQueue.size())
+		    .detail("ServerQueues", self->queue.size())
+		    .detail("ServerQueueEntries", serverQueueEntries)
+		    .detail("BusySourceServers", self->busymap.size())
+		    .detail("BusyDestServers", self->destBusymap.size())
+		    .detail("LastAsSourceEntries", self->lastAsSource.size())
 		    .detail("AverageShardSize", req.getFuture().isReady() ? req.getFuture().get() : -1)
 		    .detail("UnhealthyRelocations", self->unhealthyRelocations)
 		    .detail("HighestPriority", highestPriorityRelocation)

--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -3140,16 +3140,10 @@ struct DDQueueImpl {
 
 		auto const highestPriorityRelocation = self->getHighestPriorityRelocation();
 
-		// InFlight and InQueue below are counters, maintained by increment/decrement as relocations are
-		// launched and completed. They have been observed diverging badly from the work actually present
-		// — an order of magnitude — which makes them useless for judging whether DD is holding real work
-		// or has simply lost count. The retained-object sizes here are the independent view: they are
-		// what DD's resident memory is actually made of, so they distinguish a genuine backlog from
-		// counter drift, and they are the accounting to reach for when DD approaches its memory limit.
-		//
-		// fetchKeysComplete in particular is the known driver of DD memory growth: relocations land
-		// there once their fetch finishes and wait to be retired, so it grows without bound whenever
-		// completion processing falls behind.
+		// InFlight and InQueue are counters and have been seen diverging from the work actually present
+		// by an order of magnitude, so also report the structures DD's memory consists of, which cannot
+		// drift. fetchKeysComplete is the known driver of that growth: relocations wait there to be
+		// retired, so it is unbounded whenever completion processing falls behind.
 		int serverQueueEntries = 0;
 		for (auto const& [serverId, serverQueue] : self->queue) {
 			serverQueueEntries += serverQueue.size();

--- a/fdbserver/datadistributor/DDTeamCollection.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.cpp
@@ -3636,6 +3636,7 @@ public:
 
 			// The following actors (e.g. storageRecruiter) do not need to be assigned to a variable because
 			// they are always running.
+			self->addActor.send(self->serverEligibilityLogger());
 			self->addActor.send(self->monitorHealthyTeams());
 
 			self->addActor.send(self->storageRecruiter(recruitStorage, *ddEnabledState));
@@ -3696,8 +3697,6 @@ public:
 					// DataDistributor::totalDataInFlightRemoteEventHolder.
 					// The track latest key we use here must match the key used in
 					// the holder.
-
-					self->traceServerEligibility();
 
 					loggingTrigger = delay(SERVER_KNOBS->DATA_DISTRIBUTION_LOGGING_INTERVAL, TaskPriority::FlushTrace);
 				}
@@ -4074,21 +4073,23 @@ void DDTeamCollection::updateTeamEligibility() {
 	    .detail("LowCPUTeam", lowCpuTotal)
 	    .detail("PivotAvailableSpaceRatio", teamPivots.pivotAvailableSpaceRatio)
 	    .detail("PivotCpuRatio", teamPivots.pivotCPU);
+
+	lastEligibilitySurvey = now();
 }
 
-// Per-server counterpart to TeamEligibilityCount's team-level tallies, and the reason it is reported
-// on a timer rather than alongside the eligibility survey: updateTeamEligibility() runs only when
-// something asks for a team, so a distributor that has stopped issuing requests emits nothing at all.
-// That is the state most worth observing, so these gauges must not share its trigger.
-//
-// Reads the eligibility counters the last survey left behind rather than recomputing them, so the
-// pivot may be up to DD_TEAM_PIVOT_UPDATE_DELAY stale here. That is immaterial for a gauge and keeps
-// this to one O(1) check per team membership, with nothing allocated.
-void DDTeamCollection::traceServerEligibility() const {
-	if (now() - lastServerEligibilityTrace < SERVER_KNOBS->DD_SERVER_ELIGIBILITY_LOGGING_INTERVAL) {
-		return;
+Future<Void> DDTeamCollection::serverEligibilityLogger() {
+	while (true) {
+		// Body before the delay, so a new collection -- every distributor restart -- reports at once.
+		traceServerEligibility();
+		co_await delay(SERVER_KNOBS->DD_SERVER_ELIGIBILITY_LOGGING_INTERVAL, TaskPriority::FlushTrace);
 	}
-	lastServerEligibilityTrace = now();
+}
+
+// Per-server counterpart to TeamEligibilityCount. Reuses the counters the last survey left behind, so
+// the figures can be up to DD_TEAM_PIVOT_UPDATE_DELAY stale; SurveyAgeSeconds reports that, and -1 says
+// no survey has run and the eligibility figures are unknown rather than zero.
+void DDTeamCollection::traceServerEligibility() const {
+	const bool surveyed = lastEligibilitySurvey.present();
 
 	const int targetTeamsPerServer = (SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER * (configuration.storageTeamSize + 1)) / 2;
 	int healthyServers = 0, serversWithoutEligibleTeam = 0, serversWithMetrics = 0;
@@ -4101,15 +4102,17 @@ void DDTeamCollection::traceServerEligibility() const {
 		}
 		++healthyServers;
 
-		bool anyEligible = false;
-		for (auto const& team : server->getTeams()) {
-			if (team->getEligibilityCount(data_distribution::EligibilityCounter::LOW_DISK_UTIL) > 0) {
-				anyEligible = true;
-				break;
+		if (surveyed) {
+			bool anyEligible = false;
+			for (auto const& team : server->getTeams()) {
+				if (team->getEligibilityCount(data_distribution::EligibilityCounter::LOW_DISK_UTIL) > 0) {
+					anyEligible = true;
+					break;
+				}
 			}
-		}
-		if (!anyEligible) {
-			++serversWithoutEligibleTeam;
+			if (!anyEligible) {
+				++serversWithoutEligibleTeam;
+			}
 		}
 
 		const int serverTeams = server->getTeams().size();
@@ -4132,7 +4135,8 @@ void DDTeamCollection::traceServerEligibility() const {
 	TraceEvent("DDServerEligibility", distributorId)
 	    .detail("Primary", primary)
 	    .detail("HealthyServers", healthyServers)
-	    .detail("ServersWithoutEligibleTeam", serversWithoutEligibleTeam)
+	    .detail("ServersWithoutEligibleTeam", surveyed ? serversWithoutEligibleTeam : -1)
+	    .detail("SurveyAgeSeconds", surveyed ? now() - lastEligibilitySurvey.get() : -1.0)
 	    .detail("ServersBelowTeamTarget", serversBelowTeamTarget)
 	    .detail("TargetTeamsPerServer", targetTeamsPerServer)
 	    .detail("MinTeamsPerServer", healthyServers ? minTeamsPerServer : -1)
@@ -6962,10 +6966,9 @@ public:
 		collection->addTeam(std::set<UID>({ UID(2, 0), UID(3, 0), UID(4, 0) }), IsInitialTeam::True);
 		collection->disableBuildingTeams();
 		collection->setCheckTeamDelay();
-		// This case depends on the eligibility survey having run, and updateTeamPivotValues() only
-		// refreshes once DD_TEAM_PIVOT_UPDATE_DELAY has elapsed. Without forcing it the outcome depends
-		// on how much time earlier tests happened to consume, so the case passes in a full run and
-		// fails when run alone.
+		// Force the eligibility survey: updateTeamPivotValues() only refreshes once
+		// DD_TEAM_PIVOT_UPDATE_DELAY has elapsed, so without this the case depends on how much time
+		// earlier tests consumed and fails when run alone.
 		collection->teamPivots.lastPivotValuesUpdate = -100;
 
 		collection->server_info[UID(1, 0)]->setMetrics(high_avail);
@@ -7023,8 +7026,7 @@ public:
 		collection->addTeam(std::set<UID>({ UID(3, 0), UID(4, 0), UID(5, 0) }), IsInitialTeam::True);
 		collection->disableBuildingTeams();
 		collection->setCheckTeamDelay();
-		// See the note in GetTeam_ServerUtilizationBelowCutoff: force the eligibility survey so this
-		// case does not depend on how much simulated time earlier tests consumed.
+		// Force the eligibility survey; see GetTeam_ServerUtilizationBelowCutoff.
 		collection->teamPivots.lastPivotValuesUpdate = -100;
 
 		collection->server_info[UID(1, 0)]->setMetrics(high_avail);
@@ -7055,15 +7057,13 @@ public:
 		ASSERT(!resTeam.present());
 	}
 
-	// Above AVAILABLE_SPACE_RATIO_CUTOFF the free-space multiplier in TCTeamInfo::getLoadBytes() is
-	// identically 1.0, so destination ranking degenerates to absolute bytes stored: a team with 10%
-	// free is preferred over one with 90% free as long as it holds slightly fewer bytes. Free space
-	// acts only as an eligibility floor, never as a gradient, so DD has no pressure to level
-	// utilization between two teams that are both nominally "healthy" on space.
+	// Above AVAILABLE_SPACE_RATIO_CUTOFF the free-space multiplier is identically 1.0, so destination
+	// ranking degenerates to absolute bytes: a team at 10% free is preferred over one at 90% free if it
+	// holds slightly fewer bytes. Free space is an eligibility floor, not a gradient, so nothing pushes
+	// DD to level utilization between two teams that both have room.
 	//
-	// This pins down present behaviour rather than desired behaviour. If the free-space term is ever
-	// given influence above the cutoff, this test is expected to fail: invert the expectation to the
-	// roomier team rather than deleting the case, so the change in policy stays visible.
+	// If free space is ever given influence above the cutoff this test should fail: invert the
+	// expectation to the roomier team rather than deleting the case, so the policy change stays visible.
 	static Future<Void> GetTeam_FreeSpaceIgnoredAboveCutoff() {
 		Reference<IReplicationPolicy> policy = makeReference<PolicyAcross>(3, "zoneid", makeReference<PolicyOne>());
 		int processSize = 6;
@@ -7098,14 +7098,12 @@ public:
 			collection->server_info[UID(id, 0)]->setMetrics(nearlyFull);
 		}
 
-		// updateTeamPivotValues() only refreshes once DD_TEAM_PIVOT_UPDATE_DELAY has elapsed, which
-		// never happens while now() is still near zero, so force the first refresh or destination
-		// eligibility is never computed and this exercises nothing.
+		// Force the first refresh, or destination eligibility is never computed and this asserts
+		// nothing: DD_TEAM_PIVOT_UPDATE_DELAY never elapses while now() is still near zero.
 		collection->teamPivots.lastPivotValuesUpdate = -100;
 
-		// Both teams are healthy, so the available-space pivot is the median of {0.90, 0.10} = 0.10,
-		// which the nearly-full team meets exactly by construction. Both are therefore eligible and
-		// the choice is made purely on bytes.
+		// Both teams are healthy, so the pivot is the median of {0.90, 0.10} = 0.10, which the
+		// nearly-full team meets exactly: both are eligible and the choice is made purely on bytes.
 		GetTeamRequest req(TeamSelect::WANT_TRUE_BEST,
 		                   PreferLowerDiskUtil::True,
 		                   TeamMustHaveShards::False,
@@ -7126,23 +7124,17 @@ public:
 		ASSERT_LT(resTeam.get()->getMinAvailableSpaceRatio(), 0.5);
 	}
 
-	// A destination team must be *fully* healthy. During a hardware migration every team that still
-	// contains an excluded server is unhealthy, so a brand-new empty server whose teams all include
-	// such a server has no eligible destination team and receives nothing at all — however much free
-	// space it has. DD prefers a half-full healthy team over an empty unhealthy one. Rebuilding those
-	// teams would relieve it, but team compaction is gated on processingUnhealthy, which stays set
-	// for as long as any exclusion-driven move is outstanding.
+	// A destination team must be *fully* healthy, so during a migration a brand-new empty server whose
+	// teams all still contain an excluded member has no eligible destination team and receives nothing,
+	// however much free space it has: DD prefers a half-full healthy team to an empty unhealthy one.
+	// Health filtering is right in itself; what this pins down is that per-team eligibility turns "not
+	// the best destination" into "not a destination at all" until those teams are rebuilt.
 	//
-	// The excluded -> isUndesired -> team-unhealthy link is established by trackTeamHealth, which
-	// does not run in these fixtures; server_status below is set only to document intent, and the
-	// team is marked unhealthy directly.
+	// trackTeamHealth does not run in these fixtures, so the team is marked unhealthy directly and
+	// server_status is set only to document intent.
 	//
-	// Health filtering is correct in itself — a team holding an excluded server is a bad destination.
-	// What this pins down is the consequence: because eligibility is decided per team and nothing
-	// rebuilds a new server's teams while the migration is in flight, "not the best destination"
-	// becomes "not a destination at all" for the whole migration. A change that lets such a server
-	// receive data, by rebuilding its teams or by admitting partially-healthy teams, is expected to
-	// fail this case: update the expectation rather than deleting it.
+	// A change that lets such a server receive data should fail this case: update the expectation
+	// rather than deleting it.
 	static Future<Void> GetTeam_UnhealthyTeamStrandsEmptyServer() {
 		Reference<IReplicationPolicy> policy = makeReference<PolicyAcross>(3, "zoneid", makeReference<PolicyOne>());
 		int processSize = 6;
@@ -7176,8 +7168,8 @@ public:
 			collection->server_info[UID(id, 0)]->setMetrics(empty);
 		}
 
-		// Server 4 stands in for a still-excluded old host that the new servers 5 and 6 happened to
-		// be teamed with; server 6 is the new host we expect to be stranded.
+		// Server 4 stands in for a still-excluded old host teamed with new servers 5 and 6; server 6 is
+		// the new host expected to be stranded.
 		const UID excludedServer(4, 0);
 		collection->server_status.set(
 		    excludedServer,
@@ -7187,8 +7179,8 @@ public:
 		                 collection->server_info[excludedServer]->getLastKnownInterface().locality));
 		collection->server_info[excludedServer]->markTeamUnhealthy(0);
 
-		// See the note in GetTeam_FreeSpaceIgnoredAboveCutoff: force the pivot refresh so the empty
-		// team is proven to be rejected on health, not merely left uncomputed.
+		// Force the pivot refresh, so the empty team is proven rejected on health rather than merely
+		// left uncomputed.
 		collection->teamPivots.lastPivotValuesUpdate = -100;
 
 		GetTeamRequest req(TeamSelect::WANT_TRUE_BEST,
@@ -7205,8 +7197,8 @@ public:
 		auto ids = resTeam.get()->getServerIDs();
 		const std::set<UID> selected(ids.begin(), ids.end());
 
-		// The half-full team is chosen and the empty one is not offered at all, so the empty servers
-		// cannot converge toward the rest of the cluster.
+		// The half-full team is chosen and the empty one is never offered, so the empty servers cannot
+		// converge toward the rest of the cluster.
 		const std::set<UID> loadedTeam{ UID(1, 0), UID(2, 0), UID(3, 0) };
 		ASSERT(selected == loadedTeam);
 		ASSERT(!selected.contains(UID(6, 0)));

--- a/fdbserver/datadistributor/DDTeamCollection.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.cpp
@@ -3697,6 +3697,8 @@ public:
 					// The track latest key we use here must match the key used in
 					// the holder.
 
+					self->traceServerEligibility();
+
 					loggingTrigger = delay(SERVER_KNOBS->DATA_DISTRIBUTION_LOGGING_INTERVAL, TaskPriority::FlushTrace);
 				}
 			}
@@ -4062,7 +4064,9 @@ void DDTeamCollection::updateTeamEligibility() {
 			team->resetEligibilityCount(data_distribution::EligibilityCounter::LOW_CPU);
 		}
 	}
+
 	TraceEvent("TeamEligibilityCount", distributorId)
+	    .detail("Primary", primary)
 	    .detail("TotalTeam", teams.size())
 	    .detail("HealthyTeam", healthyCount)
 	    .detail("AllMetricsLowTeam", allMetricsLow)
@@ -4070,6 +4074,73 @@ void DDTeamCollection::updateTeamEligibility() {
 	    .detail("LowCPUTeam", lowCpuTotal)
 	    .detail("PivotAvailableSpaceRatio", teamPivots.pivotAvailableSpaceRatio)
 	    .detail("PivotCpuRatio", teamPivots.pivotCPU);
+}
+
+// Per-server counterpart to TeamEligibilityCount's team-level tallies, and the reason it is reported
+// on a timer rather than alongside the eligibility survey: updateTeamEligibility() runs only when
+// something asks for a team, so a distributor that has stopped issuing requests emits nothing at all.
+// That is the state most worth observing, so these gauges must not share its trigger.
+//
+// Reads the eligibility counters the last survey left behind rather than recomputing them, so the
+// pivot may be up to DD_TEAM_PIVOT_UPDATE_DELAY stale here. That is immaterial for a gauge and keeps
+// this to one O(1) check per team membership, with nothing allocated.
+void DDTeamCollection::traceServerEligibility() const {
+	if (now() - lastServerEligibilityTrace < SERVER_KNOBS->DD_SERVER_ELIGIBILITY_LOGGING_INTERVAL) {
+		return;
+	}
+	lastServerEligibilityTrace = now();
+
+	const int targetTeamsPerServer = (SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER * (configuration.storageTeamSize + 1)) / 2;
+	int healthyServers = 0, serversWithoutEligibleTeam = 0, serversWithMetrics = 0;
+	int serversBelowTeamTarget = 0, minTeamsPerServer = std::numeric_limits<int>::max();
+	double minFreeRatio = 1.0, maxFreeRatio = 0.0;
+
+	for (auto const& [serverId, server] : server_info) {
+		if (server_status.get(serverId).isUnhealthy()) {
+			continue;
+		}
+		++healthyServers;
+
+		bool anyEligible = false;
+		for (auto const& team : server->getTeams()) {
+			if (team->getEligibilityCount(data_distribution::EligibilityCounter::LOW_DISK_UTIL) > 0) {
+				anyEligible = true;
+				break;
+			}
+		}
+		if (!anyEligible) {
+			++serversWithoutEligibleTeam;
+		}
+
+		const int serverTeams = server->getTeams().size();
+		if (serverTeams < targetTeamsPerServer) {
+			++serversBelowTeamTarget;
+		}
+		minTeamsPerServer = std::min(minTeamsPerServer, serverTeams);
+
+		if (server->metricsPresent()) {
+			auto [available, capacity] = server->spaceBytes();
+			if (capacity > 0) {
+				double freeRatio = std::max(0.0, (double)available / capacity);
+				minFreeRatio = std::min(minFreeRatio, freeRatio);
+				maxFreeRatio = std::max(maxFreeRatio, freeRatio);
+				++serversWithMetrics;
+			}
+		}
+	}
+
+	TraceEvent("DDServerEligibility", distributorId)
+	    .detail("Primary", primary)
+	    .detail("HealthyServers", healthyServers)
+	    .detail("ServersWithoutEligibleTeam", serversWithoutEligibleTeam)
+	    .detail("ServersBelowTeamTarget", serversBelowTeamTarget)
+	    .detail("TargetTeamsPerServer", targetTeamsPerServer)
+	    .detail("MinTeamsPerServer", healthyServers ? minTeamsPerServer : -1)
+	    .detail("LastBuildTeamsFailed", lastBuildTeamsFailed)
+	    .detail("TotalTeams", teams.size())
+	    .detail("MachineTeams", machineTeams.size())
+	    .detail("MinServerFreeRatio", serversWithMetrics ? minFreeRatio : -1.0)
+	    .detail("MaxServerFreeRatio", serversWithMetrics ? maxFreeRatio : -1.0);
 }
 
 void DDTeamCollection::updateTeamPivotValues() {
@@ -6891,6 +6962,11 @@ public:
 		collection->addTeam(std::set<UID>({ UID(2, 0), UID(3, 0), UID(4, 0) }), IsInitialTeam::True);
 		collection->disableBuildingTeams();
 		collection->setCheckTeamDelay();
+		// This case depends on the eligibility survey having run, and updateTeamPivotValues() only
+		// refreshes once DD_TEAM_PIVOT_UPDATE_DELAY has elapsed. Without forcing it the outcome depends
+		// on how much time earlier tests happened to consume, so the case passes in a full run and
+		// fails when run alone.
+		collection->teamPivots.lastPivotValuesUpdate = -100;
 
 		collection->server_info[UID(1, 0)]->setMetrics(high_avail);
 		collection->server_info[UID(2, 0)]->setMetrics(low_avail);
@@ -6947,6 +7023,9 @@ public:
 		collection->addTeam(std::set<UID>({ UID(3, 0), UID(4, 0), UID(5, 0) }), IsInitialTeam::True);
 		collection->disableBuildingTeams();
 		collection->setCheckTeamDelay();
+		// See the note in GetTeam_ServerUtilizationBelowCutoff: force the eligibility survey so this
+		// case does not depend on how much simulated time earlier tests consumed.
+		collection->teamPivots.lastPivotValuesUpdate = -100;
 
 		collection->server_info[UID(1, 0)]->setMetrics(high_avail);
 		collection->server_info[UID(2, 0)]->setMetrics(low_avail);
@@ -6974,6 +7053,164 @@ public:
 		const auto& [resTeam, srcTeamFound] = req.reply.getFuture().get();
 
 		ASSERT(!resTeam.present());
+	}
+
+	// Above AVAILABLE_SPACE_RATIO_CUTOFF the free-space multiplier in TCTeamInfo::getLoadBytes() is
+	// identically 1.0, so destination ranking degenerates to absolute bytes stored: a team with 10%
+	// free is preferred over one with 90% free as long as it holds slightly fewer bytes. Free space
+	// acts only as an eligibility floor, never as a gradient, so DD has no pressure to level
+	// utilization between two teams that are both nominally "healthy" on space.
+	//
+	// This pins down present behaviour rather than desired behaviour. If the free-space term is ever
+	// given influence above the cutoff, this test is expected to fail: invert the expectation to the
+	// roomier team rather than deleting the case, so the change in policy stays visible.
+	static Future<Void> GetTeam_FreeSpaceIgnoredAboveCutoff() {
+		Reference<IReplicationPolicy> policy = makeReference<PolicyAcross>(3, "zoneid", makeReference<PolicyOne>());
+		int processSize = 6;
+		int teamSize = 3;
+		std::unique_ptr<DDTeamCollection> collection = testTeamCollection(teamSize, policy, processSize);
+
+		const int64_t MB = 1024LL * 1024;
+		const int64_t capacity = 10000 * MB;
+
+		// 90% free, holding 100 MB.
+		GetStorageMetricsReply roomy;
+		roomy.capacity.bytes = capacity;
+		roomy.available.bytes = 9000 * MB;
+		roomy.load.bytes = 100 * MB;
+
+		// 10% free, holding 90 MB. Stays above MIN_AVAILABLE_SPACE_RATIO +
+		// MIN_AVAILABLE_SPACE_RATIO_SAFETY_BUFFER (0.06), so it remains an eligible destination.
+		GetStorageMetricsReply nearlyFull;
+		nearlyFull.capacity.bytes = capacity;
+		nearlyFull.available.bytes = 1000 * MB;
+		nearlyFull.load.bytes = 90 * MB;
+
+		collection->addTeam(std::set<UID>({ UID(1, 0), UID(2, 0), UID(3, 0) }), IsInitialTeam::True);
+		collection->addTeam(std::set<UID>({ UID(4, 0), UID(5, 0), UID(6, 0) }), IsInitialTeam::True);
+		collection->disableBuildingTeams();
+		collection->setCheckTeamDelay();
+
+		for (int id = 1; id <= 3; ++id) {
+			collection->server_info[UID(id, 0)]->setMetrics(roomy);
+		}
+		for (int id = 4; id <= 6; ++id) {
+			collection->server_info[UID(id, 0)]->setMetrics(nearlyFull);
+		}
+
+		// updateTeamPivotValues() only refreshes once DD_TEAM_PIVOT_UPDATE_DELAY has elapsed, which
+		// never happens while now() is still near zero, so force the first refresh or destination
+		// eligibility is never computed and this exercises nothing.
+		collection->teamPivots.lastPivotValuesUpdate = -100;
+
+		// Both teams are healthy, so the available-space pivot is the median of {0.90, 0.10} = 0.10,
+		// which the nearly-full team meets exactly by construction. Both are therefore eligible and
+		// the choice is made purely on bytes.
+		GetTeamRequest req(TeamSelect::WANT_TRUE_BEST,
+		                   PreferLowerDiskUtil::True,
+		                   TeamMustHaveShards::False,
+		                   PreferLowerReadUtil::False,
+		                   PreferWithinShardLimit::False);
+
+		co_await collection->getTeam(req);
+
+		const auto& [resTeam, srcFound] = req.reply.getFuture().get();
+
+		ASSERT(resTeam.present());
+		auto ids = resTeam.get()->getServerIDs();
+		const std::set<UID> selected(ids.begin(), ids.end());
+
+		// Asking for the least-utilized team yields the one with 10% free, not the one with 90%.
+		const std::set<UID> nearlyFullTeam{ UID(4, 0), UID(5, 0), UID(6, 0) };
+		ASSERT(selected == nearlyFullTeam);
+		ASSERT_LT(resTeam.get()->getMinAvailableSpaceRatio(), 0.5);
+	}
+
+	// A destination team must be *fully* healthy. During a hardware migration every team that still
+	// contains an excluded server is unhealthy, so a brand-new empty server whose teams all include
+	// such a server has no eligible destination team and receives nothing at all — however much free
+	// space it has. DD prefers a half-full healthy team over an empty unhealthy one. Rebuilding those
+	// teams would relieve it, but team compaction is gated on processingUnhealthy, which stays set
+	// for as long as any exclusion-driven move is outstanding.
+	//
+	// The excluded -> isUndesired -> team-unhealthy link is established by trackTeamHealth, which
+	// does not run in these fixtures; server_status below is set only to document intent, and the
+	// team is marked unhealthy directly.
+	//
+	// Health filtering is correct in itself — a team holding an excluded server is a bad destination.
+	// What this pins down is the consequence: because eligibility is decided per team and nothing
+	// rebuilds a new server's teams while the migration is in flight, "not the best destination"
+	// becomes "not a destination at all" for the whole migration. A change that lets such a server
+	// receive data, by rebuilding its teams or by admitting partially-healthy teams, is expected to
+	// fail this case: update the expectation rather than deleting it.
+	static Future<Void> GetTeam_UnhealthyTeamStrandsEmptyServer() {
+		Reference<IReplicationPolicy> policy = makeReference<PolicyAcross>(3, "zoneid", makeReference<PolicyOne>());
+		int processSize = 6;
+		int teamSize = 3;
+		std::unique_ptr<DDTeamCollection> collection = testTeamCollection(teamSize, policy, processSize);
+
+		const int64_t MB = 1024LL * 1024;
+		const int64_t capacity = 10000 * MB;
+
+		// Surviving old hosts: half full, and holding real data.
+		GetStorageMetricsReply loaded;
+		loaded.capacity.bytes = capacity;
+		loaded.available.bytes = 5000 * MB;
+		loaded.load.bytes = 500 * MB;
+
+		// Freshly added hosts: empty.
+		GetStorageMetricsReply empty;
+		empty.capacity.bytes = capacity;
+		empty.available.bytes = 9900 * MB;
+		empty.load.bytes = 0;
+
+		collection->addTeam(std::set<UID>({ UID(1, 0), UID(2, 0), UID(3, 0) }), IsInitialTeam::True);
+		collection->addTeam(std::set<UID>({ UID(4, 0), UID(5, 0), UID(6, 0) }), IsInitialTeam::True);
+		collection->disableBuildingTeams();
+		collection->setCheckTeamDelay();
+
+		for (int id = 1; id <= 3; ++id) {
+			collection->server_info[UID(id, 0)]->setMetrics(loaded);
+		}
+		for (int id = 4; id <= 6; ++id) {
+			collection->server_info[UID(id, 0)]->setMetrics(empty);
+		}
+
+		// Server 4 stands in for a still-excluded old host that the new servers 5 and 6 happened to
+		// be teamed with; server 6 is the new host we expect to be stranded.
+		const UID excludedServer(4, 0);
+		collection->server_status.set(
+		    excludedServer,
+		    ServerStatus(IsFailed::False,
+		                 IsUndesired::True,
+		                 IsWiggling::False,
+		                 collection->server_info[excludedServer]->getLastKnownInterface().locality));
+		collection->server_info[excludedServer]->markTeamUnhealthy(0);
+
+		// See the note in GetTeam_FreeSpaceIgnoredAboveCutoff: force the pivot refresh so the empty
+		// team is proven to be rejected on health, not merely left uncomputed.
+		collection->teamPivots.lastPivotValuesUpdate = -100;
+
+		GetTeamRequest req(TeamSelect::WANT_TRUE_BEST,
+		                   PreferLowerDiskUtil::True,
+		                   TeamMustHaveShards::False,
+		                   PreferLowerReadUtil::False,
+		                   PreferWithinShardLimit::False);
+
+		co_await collection->getTeam(req);
+
+		const auto& [resTeam, srcFound] = req.reply.getFuture().get();
+
+		ASSERT(resTeam.present());
+		auto ids = resTeam.get()->getServerIDs();
+		const std::set<UID> selected(ids.begin(), ids.end());
+
+		// The half-full team is chosen and the empty one is not offered at all, so the empty servers
+		// cannot converge toward the rest of the cluster.
+		const std::set<UID> loadedTeam{ UID(1, 0), UID(2, 0), UID(3, 0) };
+		ASSERT(selected == loadedTeam);
+		ASSERT(!selected.contains(UID(6, 0)));
+		ASSERT_GT(resTeam.get()->getLoadBytes(false), 0);
 	}
 
 	static Future<Void> GetTeam_TrueBestLeastReadBandwidth() {
@@ -7650,6 +7887,14 @@ TEST_CASE("/DataDistribution/GetTeam/ServerUtilizationBelowCutoff") {
 
 TEST_CASE("/DataDistribution/GetTeam/ServerUtilizationNearCutoff") {
 	co_await DDTeamCollectionUnitTest::GetTeam_ServerUtilizationNearCutoff();
+}
+
+TEST_CASE("/DataDistribution/GetTeam/FreeSpaceIgnoredAboveCutoff") {
+	co_await DDTeamCollectionUnitTest::GetTeam_FreeSpaceIgnoredAboveCutoff();
+}
+
+TEST_CASE("/DataDistribution/GetTeam/UnhealthyTeamStrandsEmptyServer") {
+	co_await DDTeamCollectionUnitTest::GetTeam_UnhealthyTeamStrandsEmptyServer();
 }
 
 TEST_CASE("/DataDistribution/GetTeam/TrueBestLeastReadBandwidth") {

--- a/fdbserver/datadistributor/DDTeamCollection.h
+++ b/fdbserver/datadistributor/DDTeamCollection.h
@@ -668,13 +668,16 @@ protected:
 
 	void updateTeamEligibility();
 
-	// Emits DDServerEligibility, no more often than DD_SERVER_ELIGIBILITY_LOGGING_INTERVAL. Called from
-	// the periodic logging path rather than from the eligibility survey, so the gauges keep arriving when
-	// nothing is asking for teams.
+	// Driven by its own loop, not by the eligibility survey: a distributor that has stopped asking for
+	// teams is the state most worth seeing.
+	Future<Void> serverEligibilityLogger();
 	void traceServerEligibility() const;
-	// Initialised well below any plausible now() so the first call always emits. A zero here would
-	// suppress the whole first interval whenever now() starts near zero, as it does under simulation.
-	mutable double lastServerEligibilityTrace = -1e9;
+
+	// When updateTeamEligibility() last ran, unset if never. It is the only writer of the eligibility
+	// counters, and a team it has not visited reads as maximally eligible, since getCount() returns an
+	// unsigned sentinel. Fail-open is harmless on the getTeam path, which always surveys first, but it
+	// would have this gauge report nothing stranded before it can know; unset is reported as unknown.
+	Optional<double> lastEligibilitySurvey;
 
 public:
 	Reference<IDDTxnProcessor> db;

--- a/fdbserver/datadistributor/DDTeamCollection.h
+++ b/fdbserver/datadistributor/DDTeamCollection.h
@@ -668,6 +668,14 @@ protected:
 
 	void updateTeamEligibility();
 
+	// Emits DDServerEligibility, no more often than DD_SERVER_ELIGIBILITY_LOGGING_INTERVAL. Called from
+	// the periodic logging path rather than from the eligibility survey, so the gauges keep arriving when
+	// nothing is asking for teams.
+	void traceServerEligibility() const;
+	// Initialised well below any plausible now() so the first call always emits. A zero here would
+	// suppress the whole first interval whenever now() starts near zero, as it does under simulation.
+	mutable double lastServerEligibilityTrace = -1e9;
+
 public:
 	Reference<IDDTxnProcessor> db;
 

--- a/fdbserver/datadistributor/TCInfo.cpp
+++ b/fdbserver/datadistributor/TCInfo.cpp
@@ -458,10 +458,10 @@ int64_t TCTeamInfo::getLoadBytes(bool includeInFlight, double inflightPenalty) c
 	    SERVER_KNOBS->AVAILABLE_SPACE_RATIO_CUTOFF /
 	    (std::max(std::min(SERVER_KNOBS->AVAILABLE_SPACE_RATIO_CUTOFF, minAvailableSpaceRatio), 0.000001));
 	if (servers.size() > 2) {
-		// Squaring sharpens the penalty once a member is below AVAILABLE_SPACE_RATIO_CUTOFF, where
-		// losing a replica is costliest. Note the min() above clamps the ratio, so the multiplier is
-		// exactly 1.0 for any team above the cutoff: free space is a cliff at the cutoff, not a
-		// gradient, and it does not order two teams that both have room.
+		// servers.size() is the replication factor, so this is triple replication or wider, where losing
+		// a replica costs most. Note the min() above clamps the ratio, so the multiplier is exactly 1.0
+		// for any team above the cutoff: free space is a cliff there, not a gradient, and it does not
+		// order two teams that both have room.
 		availableSpaceMultiplier = availableSpaceMultiplier * availableSpaceMultiplier;
 	}
 

--- a/fdbserver/datadistributor/TCInfo.cpp
+++ b/fdbserver/datadistributor/TCInfo.cpp
@@ -458,8 +458,10 @@ int64_t TCTeamInfo::getLoadBytes(bool includeInFlight, double inflightPenalty) c
 	    SERVER_KNOBS->AVAILABLE_SPACE_RATIO_CUTOFF /
 	    (std::max(std::min(SERVER_KNOBS->AVAILABLE_SPACE_RATIO_CUTOFF, minAvailableSpaceRatio), 0.000001));
 	if (servers.size() > 2) {
-		// make sure in triple replication the penalty is high enough that you will always avoid a team with a
-		// member at 20% free space
+		// Squaring sharpens the penalty once a member is below AVAILABLE_SPACE_RATIO_CUTOFF, where
+		// losing a replica is costliest. Note the min() above clamps the ratio, so the multiplier is
+		// exactly 1.0 for any team above the cutoff: free space is a cliff at the cutoff, not a
+		// gradient, and it does not order two teams that both have room.
 		availableSpaceMultiplier = availableSpaceMultiplier * availableSpaceMultiplier;
 	}
 


### PR DESCRIPTION
Add traces to a few areas of opaque DD operation.

1. Excluding a host marks every team holding it unhealthy, and destination eligibility is decided per team, so a newly added server can be healthy, hold a full complement of teams, and still receive nothing because each of them contains an excluded member. Neither that nor the resulting utilization spread was reported, so both had to be reconstructed from every storage server's metrics after the fact.

Add DDServerEligibility, one aggregate event per team collection, covering the servers with no space-eligible destination team, the utilization spread, and what team building still owes. It is emitted from the periodic logging path rather than the eligibility survey, which runs only when something asks for a team -- a distributor that has stopped asking is the state most worth seeing. Its own interval, DD_SERVER_ELIGIBILITY_LOGGING_INTERVAL, is 300s since it gauges conditions that persist for hours; a new collection emits immediately, so distributor restarts are captured regardless of it.

2. MovingData's InFlight and InQueue are counters and have been seen diverging from the work actually present by an order of magnitude, so also report the sizes of the structures memory consists of, notably FetchKeysComplete, which grows without bound when completion processing falls behind. TeamEligibilityCount gains Primary, without which the two collections could not be told apart.

Two tests pin down the selection behaviour described above. The comment on getLoadBytes()'s triple-replication branch claimed a team with a member at 20% free space is always avoided, which the cutoff makes untrue, and now describes what the code does. Two existing cutoff tests depended on the eligibility survey having run without forcing it, so they passed only when earlier tests happened to consume enough time.

`  20260904-050150-stack-dd-migration-observab-630fe632eba16da0 compressed=True data_size=38788247 duration=4262176 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:28:52 sanity=False started=100000 stopped=20260904-053042 submitted=20260904-050150 timeout=5400 username=stack-dd-migration-observability`

Failure was:

`RandomSeed="3082431764" SourceVersion="230a74984c04a79c368f8ca448bbd7b959a4d9cf" Time="1788498199" BuggifyEnabled="0" DeterminismCheck="0" FaultInjectionEnabled="1" TestFile="tests/rare/ClogRemoteTLog.toml"`