### PR TITLE
Give b2 the macOS SDK when building bundled boost

### DIFF
--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -33,7 +33,14 @@ function(compile_boost)
   message(STATUS "Use ${BOOST_TOOLSET} to build boost")
 
   # Configure b2 command
-  set(B2_COMMAND "./b2")
+  # b2's clang-darwin toolset passes an explicit --target, which suppresses Apple
+  # clang's SDK inference, and macOS keeps no C++ headers outside the SDK. Hand b2
+  # the same sysroot the main build uses so boost compiles against an identical SDK.
+  if(APPLE AND CMAKE_OSX_SYSROOT)
+    set(B2_COMMAND ${CMAKE_COMMAND} -E env "SDKROOT=${CMAKE_OSX_SYSROOT}" ./b2)
+  else()
+    set(B2_COMMAND "./b2")
+  endif()
   set(BOOST_COMPILER_FLAGS -fvisibility=hidden -fPIC -std=c++17 --no-warnings)
   set(BOOST_LINK_FLAGS "")
   if(APPLE OR ICX OR USE_LIBCXX)

--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -36,10 +36,9 @@ function(compile_boost)
   # b2's clang-darwin toolset passes an explicit --target, which suppresses Apple
   # clang's SDK inference, and macOS keeps no C++ headers outside the SDK. Hand b2
   # the same sysroot the main build uses so boost compiles against an identical SDK.
+  set(B2_COMMAND "./b2")
   if(APPLE AND CMAKE_OSX_SYSROOT)
-    set(B2_COMMAND ${CMAKE_COMMAND} -E env "SDKROOT=${CMAKE_OSX_SYSROOT}" ./b2)
-  else()
-    set(B2_COMMAND "./b2")
+    set(B2_COMMAND env "SDKROOT=${CMAKE_OSX_SYSROOT}" "./b2")
   endif()
   set(BOOST_COMPILER_FLAGS -fvisibility=hidden -fPIC -std=c++17 --no-warnings)
   set(BOOST_LINK_FLAGS "")


### PR DESCRIPTION
This helped building locally.

b2's clang-darwin toolset passes an explicit --target, which suppresses Apple clang's SDK inference. Recent macOS keeps no C++ standard library headers outside the SDK, so every boost translation unit failed with "'cstddef' file not found" and the bundled boost build could not complete at all.

Pass the main build's CMAKE_OSX_SYSROOT to b2 through SDKROOT so boost compiles against an identical SDK.

Note for anyone hitting a partial boost build: b2 caches its feature probes, so a run that failed before the SDK was available leaves cxx11_rvalue_references, cxx11_constexpr and zlib cached as "no". Boost gates libraries on those, after which b2 exits successfully while silently skipping filesystem and url. Deleting bin.v2 forces the probes to re-run.