### PR TITLE
Simplify Flow awaits and reference declarations

### DIFF
--- a/fdbclient/NativeAPI.cpp
+++ b/fdbclient/NativeAPI.cpp
@@ -1614,7 +1614,7 @@ Reference<TransactionState> TransactionState::cloneAndReset(Reference<Transactio
 
 Future<Void> startTransaction(Reference<TransactionState> trStateInput) {
 	Reference<TransactionState> trState(std::move(trStateInput));
-	co_await success(trState->readVersionFuture);
+	co_await trState->readVersionFuture;
 }
 
 TEST_CASE("/fdbclient/NativeAPI/startTransaction/releasesStateOnCompletion") {

--- a/fdbclient/include/fdbclient/StorageServerLoadBalance.h
+++ b/fdbclient/include/fdbclient/StorageServerLoadBalance.h
@@ -195,7 +195,7 @@ Future<Void> replicaComparison(Req req,
 		co_return;
 	}
 
-	co_await store(src, fSource);
+	src = co_await fSource;
 
 	if (src.isError()) {
 		ASSERT_WE_THINK(false); // TODO: Change this into an ASSERT after getting enough test coverage.

--- a/fdbrpc/FlowTests.cpp
+++ b/fdbrpc/FlowTests.cpp
@@ -1694,7 +1694,7 @@ TEST_CASE("/flow/flow/FlowMutex") {
 					if (verbose) {
 						printf("Final wait in case error was injected by the last actor to finish\n");
 					}
-					co_await success(mutex.take());
+					co_await mutex.take();
 				}
 			} catch (Error& e) {
 				if (verbose) {
@@ -1838,7 +1838,7 @@ TEST_CASE("/fdbrpc/waitValueOrSignal/peerDisconnect") {
 	// peer->disconnect, and PeerHolder only touches outstandingReplies. Note that Peer construction
 	// also updates the global failure monitor status for fakeAddr.
 	NetworkAddress fakeAddr = NetworkAddress::parse("1.2.3.4:1234");
-	Reference<Peer> peer = makeReference<Peer>(nullptr, fakeAddr);
+	auto peer = makeReference<Peer>(nullptr, fakeAddr);
 
 	// Create a value future that never resolves (simulating a stuck RPC to unreachable storage server)
 	Promise<Void> neverReply;
@@ -1967,8 +1967,8 @@ TEST_CASE("/fdbrpc/waitValueOrSignal/retryOnDisconnect") {
 
 	NetworkAddress addr1 = NetworkAddress::parse("1.2.3.4:1234");
 	NetworkAddress addr2 = NetworkAddress::parse("1.2.3.5:1234");
-	Reference<Peer> peer1 = makeReference<Peer>(nullptr, addr1);
-	Reference<Peer> peer2 = makeReference<Peer>(nullptr, addr2);
+	auto peer1 = makeReference<Peer>(nullptr, addr1);
+	auto peer2 = makeReference<Peer>(nullptr, addr2);
 
 	int numAttempts = 0;
 

--- a/fdbserver/kvstore/VersionedBTree.cpp
+++ b/fdbserver/kvstore/VersionedBTree.cpp
@@ -9979,7 +9979,7 @@ TEST_CASE("/redwood/correctness/unit/readOnlyPageFuture") {
 	Future<Reference<const ArenaPage>> survivingRead;
 	{
 		DWALPager::PageCacheEntry entry;
-		Reference<ArenaPage> firstPage = makeReference<ArenaPage>(4096, 4096);
+		auto firstPage = makeReference<ArenaPage>(4096, 4096);
 		ArenaPage* firstPagePtr = firstPage.getPtr();
 		entry.setReadFuture(firstPage);
 
@@ -9989,7 +9989,7 @@ TEST_CASE("/redwood/correctness/unit/readOnlyPageFuture") {
 		ASSERT(firstRead == entry.getReadFuture<true>());
 		ASSERT(entry.getReadFuture<false>().get().getPtr() == firstPagePtr);
 
-		Reference<ArenaPage> updatedPage = makeReference<ArenaPage>(4096, 4096);
+		auto updatedPage = makeReference<ArenaPage>(4096, 4096);
 		updatedPage->init(EncodingType::XXHash64, PageType::BTreeNode, 1);
 		memcpy(updatedPage->mutateData(), expectedPageContents.begin(), expectedPageContents.size());
 		ArenaPage* updatedPagePtr = updatedPage.getPtr();
@@ -10008,7 +10008,7 @@ TEST_CASE("/redwood/correctness/unit/readOnlyPageFuture") {
 		ASSERT(pendingRead.isReady() && pendingRead.isError());
 		ASSERT_EQ(pendingRead.getError().code(), error_code_actor_cancelled);
 		ASSERT(!secondPendingRead.isReady());
-		Reference<ArenaPage> pendingPage = makeReference<ArenaPage>(4096, 4096);
+		auto pendingPage = makeReference<ArenaPage>(4096, 4096);
 		ArenaPage* pendingPagePtr = pendingPage.getPtr();
 		pendingPromise.send(pendingPage);
 		ASSERT(secondPendingRead.isReady() && !secondPendingRead.isError());


### PR DESCRIPTION
## Summary

- Await futures directly in coroutine paths where `success` and `store` wrappers are redundant.
- Infer the exact `Reference<T>` type from `makeReference<T>` in RPC and Redwood unit tests.

## Validation

- AST-grep rule and snapshot tests: 11 passed; full source scan: no findings.
- `fdbclient_test -f /fdbclient/NativeAPI/startTransaction` (1 passed)
- `fdbclient_test -f /fdbclient/LoadBalance` (1 passed)
- `fdbclient_test -f /fdbclient/BasicLoadBalance` (1 passed)
- `fdbrpc_test -f /fdbrpc/waitValueOrSignal` (3 passed)
- `fdbrpc_test -f /flow/flow/FlowMutex` (1 passed)
- `fdbserver_kvstore_test` read-only page future case (1 passed)
