### PR TITLE
test(status): respect timer equivalence in timeout assertions

### DIFF
--- a/fdbclient/StatusClient.cpp
+++ b/fdbclient/StatusClient.cpp
@@ -481,7 +481,7 @@ TEST_CASE("/fdbclient/status/clientCoordinatorTimeoutBudget") {
 	double elapsed = now() - startTime;
 	ASSERT(status.present());
 	ASSERT(!quorumReachable);
-	ASSERT_GE(elapsed, timeout);
+	ASSERT_GE(elapsed + INetwork::TIME_EPS, timeout);
 	ASSERT_LT(elapsed, timeout + 0.05);
 	co_return;
 }
@@ -502,7 +502,7 @@ TEST_CASE("/fdbclient/status/overallTimeoutBudget") {
 	ASSERT(!status.present());
 	ASSERT_EQ(messages.size(), 1);
 	ASSERT_EQ(messages.front().get_obj().at("name").get_str(), "status_incomplete_timeout");
-	ASSERT_GE(elapsed, overallTimeout);
+	ASSERT_GE(elapsed + INetwork::TIME_EPS, overallTimeout);
 	ASSERT_LT(elapsed, overallTimeout + 0.05);
 	co_return;
 }


### PR DESCRIPTION
## Summary

- Account for Flow's timer equivalence when checking the lower elapsed time bound in the two status timeout tests.
- Keep the coordinator and cluster status results, timeout message, and upper elapsed bounds unchanged.
- The existing tests exercise both phases and reproduced the failure, so no duplicate test fixture is needed.

## Validation

- Focused `fdbclient_test -f /fdbclient/status/`: 2 passed.
- Exact `RandomUnitTests.toml` simulation replays: the original package failed at each lower-bound assertion; both paths pass with this change, with their test configuration and buggify sections preserved.
