### PR TITLE
Use makeReference for audited reference constructions

### DIFF
--- a/fdbbackup/backup.cpp
+++ b/fdbbackup/backup.cpp
@@ -1513,7 +1513,7 @@ AsyncResult<std::string> getLayerStatus(Reference<ReadYourWritesTransaction> tr,
 		}
 	} else if (exe == ProgramExe::DR_AGENT) {
 		DatabaseBackupAgent dba;
-		Reference<ReadYourWritesTransaction> tr2(new ReadYourWritesTransaction(dest));
+		auto tr2 = makeReference<ReadYourWritesTransaction>(dest);
 		tr2->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 		tr2->setOption(FDBTransactionOptions::LOCK_AWARE);
 		RangeResult tagNames = co_await tr2->getRange(dba.tagNames.range(), 10000, snapshot);
@@ -1676,7 +1676,7 @@ Future<Void> statusUpdateActor(Database statusUpdateDest,
 	std::string metaKey = layerStatusMetaPrefixRange.begin.toString() + "json/" + name;
 	std::string rootKey = backupStatusPrefixRange.begin.toString() + name + "/json";
 	std::string instanceKey = rootKey + "/" + "agent-" + id;
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(statusUpdateDest));
+	auto tr = makeReference<ReadYourWritesTransaction>(statusUpdateDest);
 	Future<Void> pollRateUpdater;
 
 	// In order to report a useful networkAddress to the cluster's layer status JSON object, determine which local
@@ -2771,7 +2771,7 @@ Future<Void> modifyBackup(Database db, std::string tagName, BackupModifyOptions 
 
 	KeyBackedTag tag = makeBackupTag(tagName);
 
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(db));
+	auto tr = makeReference<ReadYourWritesTransaction>(db);
 	while (true) {
 		Error err;
 		try {

--- a/fdbclient/BackupAgentBase.cpp
+++ b/fdbclient/BackupAgentBase.cpp
@@ -1081,7 +1081,7 @@ Future<Void> eraseLogData(Reference<ReadYourWritesTransaction> tr,
 Future<Void> cleanupLogMutations(Database cx, Value destUidValue, bool deleteData) {
 	Key backupLatestVersionsPath = destUidValue.withPrefix(backupLatestVersionsPrefix);
 
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(cx);
 	Optional<Key> removingLogUid;
 	std::set<Key> loggedLogUids;
 
@@ -1172,7 +1172,7 @@ Future<Void> cleanupLogMutations(Database cx, Value destUidValue, bool deleteDat
 }
 
 Future<Void> cleanupBackup(Database cx, DeleteData deleteData) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(cx);
 	while (true) {
 		Error err;
 		try {

--- a/fdbclient/DatabaseBackupAgent.cpp
+++ b/fdbclient/DatabaseBackupAgent.cpp
@@ -633,7 +633,7 @@ struct EraseLogRangeTaskFunc : TaskFuncBase {
 
 		co_await checkTaskVersion(cx, task, EraseLogRangeTaskFunc::name, EraseLogRangeTaskFunc::version);
 
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(taskBucket->src));
+		auto tr = makeReference<ReadYourWritesTransaction>(taskBucket->src);
 		while (true) {
 			Error err;
 			bool hasErr = false;
@@ -1166,7 +1166,7 @@ struct FinishedFullBackupTaskFunc : TaskFuncBase {
 			}
 		}
 
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(taskBucket->src));
+		auto tr = makeReference<ReadYourWritesTransaction>(taskBucket->src);
 		Key logUidValue = task->params[DatabaseBackupAgent::keyConfigLogUid];
 		Key destUidValue = task->params[BackupAgentBase::destUid];
 		Version backupUid =
@@ -1649,7 +1649,7 @@ struct AbortOldBackupTaskFunc : TaskFuncBase {
 	                             Reference<FutureBucket> futureBucket,
 	                             Reference<Task> task) {
 		DatabaseBackupAgent srcDrAgent(taskBucket->src);
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		Key tagNameKey;
 
 		while (true) {
@@ -1742,7 +1742,7 @@ struct CopyDiffLogsUpgradeTaskFunc : TaskFuncBase {
 
 		// Retrieve backupRanges
 		Standalone<VectorRef<KeyRangeRef>> backupRanges;
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		while (true) {
 			Error err;
 			bool hasErr = false;
@@ -1771,7 +1771,7 @@ struct CopyDiffLogsUpgradeTaskFunc : TaskFuncBase {
 
 		// Set destUidValue and versionKey on src side
 		Key destUidValue(logUidValue);
-		Reference<ReadYourWritesTransaction> srcTr(new ReadYourWritesTransaction(taskBucket->src));
+		auto srcTr = makeReference<ReadYourWritesTransaction>(taskBucket->src);
 		while (true) {
 			Error err;
 			bool hasErr = false;
@@ -2020,7 +2020,7 @@ struct StartFullBackupTaskFunc : TaskFuncBase {
 		    task->params[DatabaseBackupAgent::keyConfigBackupRanges], IncludeVersion());
 		Key beginVersionKey;
 
-		Reference<ReadYourWritesTransaction> srcTr(new ReadYourWritesTransaction(taskBucket->src));
+		auto srcTr = makeReference<ReadYourWritesTransaction>(taskBucket->src);
 		while (true) {
 			Error err;
 			bool hasErr = false;
@@ -2077,7 +2077,7 @@ struct StartFullBackupTaskFunc : TaskFuncBase {
 		}
 
 		while (true) {
-			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+			auto tr = makeReference<ReadYourWritesTransaction>(cx);
 			Error err;
 			bool hasErr = false;
 			try {
@@ -2113,7 +2113,7 @@ struct StartFullBackupTaskFunc : TaskFuncBase {
 			}
 		}
 
-		Reference<ReadYourWritesTransaction> srcTr2(new ReadYourWritesTransaction(taskBucket->src));
+		auto srcTr2 = makeReference<ReadYourWritesTransaction>(taskBucket->src);
 		while (true) {
 			Error err;
 			bool hasErr = false;
@@ -2156,7 +2156,7 @@ struct StartFullBackupTaskFunc : TaskFuncBase {
 			}
 		}
 
-		Reference<ReadYourWritesTransaction> srcTr3(new ReadYourWritesTransaction(taskBucket->src));
+		auto srcTr3 = makeReference<ReadYourWritesTransaction>(taskBucket->src);
 		while (true) {
 			Error err;
 			bool hasErr = false;
@@ -2383,7 +2383,7 @@ public:
 		    .detail("LogUid", BinaryWriter::toValue(logUid, Unversioned()).printable());
 
 		while (true) {
-			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+			auto tr = makeReference<ReadYourWritesTransaction>(cx);
 
 			while (true) {
 				Error err;
@@ -2430,7 +2430,7 @@ public:
 		                    .pack(DatabaseBackupAgent::keyStateStatus);
 
 		while (true) {
-			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+			auto tr = makeReference<ReadYourWritesTransaction>(cx);
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -2469,7 +2469,7 @@ public:
 		                    .pack(DatabaseBackupAgent::keyStateStatus);
 
 		while (true) {
-			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+			auto tr = makeReference<ReadYourWritesTransaction>(cx);
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -2840,7 +2840,7 @@ public:
 	                                AbortOldBackup abortOldBackup,
 	                                DstOnly dstOnly,
 	                                WaitForDestUID waitForDestUID) {
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		Key logUidValue;
 		Key destUidValue;
 		UID logUid;
@@ -2954,7 +2954,7 @@ public:
 
 		if (!dstOnly) {
 			Future<Void> partialTimeout = partial ? delay(30.0) : Never();
-			Reference<ReadYourWritesTransaction> srcTr(new ReadYourWritesTransaction(backupAgent->taskBucket->src));
+			auto srcTr = makeReference<ReadYourWritesTransaction>(backupAgent->taskBucket->src);
 
 			while (true) {
 				Error err;
@@ -3054,7 +3054,7 @@ public:
 	}
 
 	static Future<std::string> getStatus(DatabaseBackupAgent* backupAgent, Database cx, int errorLimit, Key tagName) {
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 		std::string statusText;
 		int retries = 0;

--- a/fdbclient/DatabaseBackupAgent.cpp
+++ b/fdbclient/DatabaseBackupAgent.cpp
@@ -209,7 +209,7 @@ struct BackupRangeTaskFunc : TaskFuncBase {
 	                             Reference<TaskBucket> taskBucket,
 	                             Reference<FutureBucket> futureBucket,
 	                             Reference<Task> task) {
-		Reference<FlowLock> lock(new FlowLock(CLIENT_KNOBS->BACKUP_LOCK_BYTES));
+		auto lock = makeReference<FlowLock>(CLIENT_KNOBS->BACKUP_LOCK_BYTES);
 		Subspace conf = Subspace(databaseBackupPrefixRange.begin)
 		                    .get(BackupAgentBase::keyConfig)
 		                    .get(task->params[BackupAgentBase::keyConfigLogUid]);
@@ -1547,7 +1547,7 @@ struct OldCopyLogRangeTaskFunc : TaskFuncBase {
 	                             Reference<TaskBucket> taskBucket,
 	                             Reference<FutureBucket> futureBucket,
 	                             Reference<Task> task) {
-		Reference<FlowLock> lock(new FlowLock(CLIENT_KNOBS->BACKUP_LOCK_BYTES));
+		auto lock = makeReference<FlowLock>(CLIENT_KNOBS->BACKUP_LOCK_BYTES);
 
 		co_await checkTaskVersion(cx, task, OldCopyLogRangeTaskFunc::name, OldCopyLogRangeTaskFunc::version);
 

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -1860,7 +1860,7 @@ static Future<Key> addBackupTask(StringRef name,
 	tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
 	Key doneKey = co_await completionKey.get(tr, taskBucket);
-	Reference<Task> task(new Task(name, version, doneKey, priority));
+	auto task = makeReference<Task>(name, version, doneKey, priority);
 
 	// Bind backup config to new task
 	// allow this new task to find the config(keyspace) of the parent task
@@ -2078,7 +2078,7 @@ struct BackupRangeTaskFunc : BackupTaskFuncBase {
 	                             Reference<TaskBucket> taskBucket,
 	                             Reference<FutureBucket> futureBucket,
 	                             Reference<Task> task) {
-		Reference<FlowLock> lock(new FlowLock(CLIENT_KNOBS->BACKUP_LOCK_BYTES));
+		auto lock = makeReference<FlowLock>(CLIENT_KNOBS->BACKUP_LOCK_BYTES);
 
 		co_await checkTaskVersion(cx, task, BackupRangeTaskFunc::name, BackupRangeTaskFunc::version);
 
@@ -2364,7 +2364,7 @@ struct BackupSnapshotDispatchTask : BackupTaskFuncBase {
 	                             Reference<TaskBucket> taskBucket,
 	                             Reference<FutureBucket> futureBucket,
 	                             Reference<Task> task) {
-		Reference<FlowLock> lock(new FlowLock(CLIENT_KNOBS->BACKUP_LOCK_BYTES));
+		auto lock = makeReference<FlowLock>(CLIENT_KNOBS->BACKUP_LOCK_BYTES);
 		co_await checkTaskVersion(cx, task, name, version);
 
 		double startTime = timer();
@@ -2944,7 +2944,7 @@ struct BackupLogRangeTaskFunc : BackupTaskFuncBase {
 	                             Reference<TaskBucket> taskBucket,
 	                             Reference<FutureBucket> futureBucket,
 	                             Reference<Task> task) {
-		Reference<FlowLock> lock(new FlowLock(CLIENT_KNOBS->BACKUP_LOCK_BYTES));
+		auto lock = makeReference<FlowLock>(CLIENT_KNOBS->BACKUP_LOCK_BYTES);
 
 		co_await checkTaskVersion(cx, task, BackupLogRangeTaskFunc::name, BackupLogRangeTaskFunc::version);
 
@@ -4555,7 +4555,7 @@ struct BulkLoadRestoreTaskFunc : RestoreTaskFuncBase {
 	                           TaskCompletionKey completionKey,
 	                           Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 		Key doneKey = co_await completionKey.get(tr, taskBucket);
-		Reference<Task> task(new Task(BulkLoadRestoreTaskFunc::name, BulkLoadRestoreTaskFunc::version, doneKey));
+		auto task = makeReference<Task>(BulkLoadRestoreTaskFunc::name, BulkLoadRestoreTaskFunc::version, doneKey);
 
 		// Set task parameters
 		Params.restoreVersion().set(task, restoreVersion);
@@ -4617,7 +4617,7 @@ struct RestoreCompleteTaskFunc : RestoreTaskFuncBase {
 	                           TaskCompletionKey completionKey,
 	                           Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 		Key doneKey = co_await completionKey.get(tr, taskBucket);
-		Reference<Task> task(new Task(RestoreCompleteTaskFunc::name, RestoreCompleteTaskFunc::version, doneKey));
+		auto task = makeReference<Task>(RestoreCompleteTaskFunc::name, RestoreCompleteTaskFunc::version, doneKey);
 
 		// Get restore config from parent task and bind it to new task
 		co_await RestoreConfig(parentTask).toTask(tr, task);
@@ -4923,7 +4923,7 @@ struct RestoreRangeTaskFunc : RestoreFileTaskFuncBase {
 	                           TaskCompletionKey completionKey,
 	                           Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 		Key doneKey = co_await completionKey.get(tr, taskBucket);
-		Reference<Task> task(new Task(RestoreRangeTaskFunc::name, RestoreRangeTaskFunc::version, doneKey));
+		auto task = makeReference<Task>(RestoreRangeTaskFunc::name, RestoreRangeTaskFunc::version, doneKey);
 
 		// Create a restore config from the current task and bind it to the new task.
 		co_await RestoreConfig(parentTask).toTask(tr, task);
@@ -5269,7 +5269,7 @@ struct RestoreLogDataTaskFunc : RestoreFileTaskFuncBase {
 	                           TaskCompletionKey completionKey,
 	                           Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 		Key doneKey = co_await completionKey.get(tr, taskBucket);
-		Reference<Task> task(new Task(RestoreLogDataTaskFunc::name, RestoreLogDataTaskFunc::version, doneKey));
+		auto task = makeReference<Task>(RestoreLogDataTaskFunc::name, RestoreLogDataTaskFunc::version, doneKey);
 
 		// Create a restore config from the current task and bind it to the new task.
 		// RestoreConfig(parentTask) creates prefix of : fileRestorePrefixRange.begin/uid->config/[uid]
@@ -5710,8 +5710,8 @@ struct RestoreLogDataPartitionedTaskFunc : RestoreFileTaskFuncBase {
 	                           TaskCompletionKey completionKey,
 	                           Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 		Key doneKey = co_await completionKey.get(tr, taskBucket);
-		Reference<Task> task(
-		    new Task(RestoreLogDataPartitionedTaskFunc::name, RestoreLogDataPartitionedTaskFunc::version, doneKey));
+		auto task = makeReference<Task>(
+		    RestoreLogDataPartitionedTaskFunc::name, RestoreLogDataPartitionedTaskFunc::version, doneKey);
 
 		// Create a restore config from the current task and bind it to the new task.
 		// RestoreConfig(parentTask) createsa prefix of : fileRestorePrefixRange.begin/uid->config/[uid]
@@ -5960,8 +5960,8 @@ struct RestoreDispatchPartitionedTaskFunc : RestoreTaskFuncBase {
 
 		// Use high priority for dispatch tasks that have to queue more blocks for the current batch
 		unsigned int priority = 0;
-		Reference<Task> task(new Task(
-		    RestoreDispatchPartitionedTaskFunc::name, RestoreDispatchPartitionedTaskFunc::version, doneKey, priority));
+		auto task = makeReference<Task>(
+		    RestoreDispatchPartitionedTaskFunc::name, RestoreDispatchPartitionedTaskFunc::version, doneKey, priority);
 
 		// Create a config from the parent task and bind it to the new task
 		co_await RestoreConfig(parentTask).toTask(tr, task);
@@ -6351,8 +6351,7 @@ struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 
 		// Use high priority for dispatch tasks that have to queue more blocks for the current batch
 		auto priority = (remainingInBatch > 0) ? 1u : 0u;
-		Reference<Task> task(
-		    new Task(RestoreDispatchTaskFunc::name, RestoreDispatchTaskFunc::version, doneKey, priority));
+		auto task = makeReference<Task>(RestoreDispatchTaskFunc::name, RestoreDispatchTaskFunc::version, doneKey, priority);
 
 		// Create a config from the parent task and bind it to the new task
 		co_await RestoreConfig(parentTask).toTask(tr, task);
@@ -6891,7 +6890,7 @@ struct StartFullRestoreTaskFunc : RestoreTaskFuncBase {
 		tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
 		Key doneKey = co_await completionKey.get(tr, taskBucket);
-		Reference<Task> task(new Task(StartFullRestoreTaskFunc::name, StartFullRestoreTaskFunc::version, doneKey));
+		auto task = makeReference<Task>(StartFullRestoreTaskFunc::name, StartFullRestoreTaskFunc::version, doneKey);
 
 		RestoreConfig restore(uid);
 		// Bind the restore config to the new task

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -663,7 +663,7 @@ Future<std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>> getBulk
 // through the restore API. The commit retries because an unpersisted ABORTED loses both properties.
 Future<Void> abortBulkLoadRestore(Database cx, RestoreConfig restore, std::string message) {
 	co_await restore.logError(cx, restore_bulkload_failed(), message);
-	Reference<ReadYourWritesTransaction> abortTr(new ReadYourWritesTransaction(cx));
+	auto abortTr = makeReference<ReadYourWritesTransaction>(cx);
 	while (true) {
 		Error err;
 		try {
@@ -808,7 +808,7 @@ Future<bool> monitorBulkLoadJobCompletionWithProgress(Database cx,
 				int64_t blocksDispatched =
 				    totalBlocks > 0 ? (totalBlocks * (completed + inProgress)) / total : (completed + inProgress);
 
-				Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+				auto tr = makeReference<ReadYourWritesTransaction>(cx);
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				if (lockAware) {
 					tr->setOption(FDBTransactionOptions::LOCK_AWARE);
@@ -2000,7 +2000,7 @@ struct BackupRangeTaskFunc : BackupTaskFuncBase {
 		if (range.empty())
 			co_return false;
 
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		BackupConfig backup(task);
 		bool usedFile = false;
 
@@ -2196,7 +2196,7 @@ struct BackupRangeTaskFunc : BackupTaskFuncBase {
 				Version snapshotBeginVersion{ 0 };
 				int64_t snapshotRangeFileCount{ 0 };
 
-				Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+				auto tr = makeReference<ReadYourWritesTransaction>(cx);
 				while (true) {
 					Error err;
 					try {
@@ -2368,7 +2368,7 @@ struct BackupSnapshotDispatchTask : BackupTaskFuncBase {
 		co_await checkTaskVersion(cx, task, name, version);
 
 		double startTime = timer();
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 
 		// The shard map will use 3 values classes.  Exactly SKIP, exactly DONE, then any number >= NOT_DONE_MIN
 		// which will mean not done. This is to enable an efficient coalesce() call to squash adjacent ranges which
@@ -2954,7 +2954,7 @@ struct BackupLogRangeTaskFunc : BackupTaskFuncBase {
 		BackupConfig config(task);
 		Reference<IBackupContainer> bc;
 
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		while (true) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
@@ -3502,7 +3502,7 @@ struct BackupSnapshotManifest : BackupTaskFuncBase {
 		Reference<IBackupContainer> bc;
 		DatabaseConfiguration dbConfig;
 
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 
 		// Read the entire range file map into memory, then walk it backwards from its last entry to produce a list
 		// of non overlapping key range files
@@ -4031,7 +4031,7 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 	                             Reference<Task> task) {
 		co_await checkTaskVersion(cx, task, StartFullBackupTaskFunc::name, StartFullBackupTaskFunc::version);
 
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		BackupConfig config(task);
 		Future<Optional<MutationLogType>> mutationLogType;
 		while (true) {
@@ -4299,7 +4299,7 @@ struct BulkLoadRestoreTaskFunc : RestoreTaskFuncBase {
 				Reference<IBackupContainer> bcRef = IBackupContainer::openContainer(backupUrl, {}, {}, 0);
 
 				// Get restore ranges using a transaction
-				Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+				auto tr = makeReference<ReadYourWritesTransaction>(cx);
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 				std::vector<KeyRange> restoreRanges = co_await restore.getRestoreRangesOrDefault(tr);
@@ -4360,7 +4360,7 @@ struct BulkLoadRestoreTaskFunc : RestoreTaskFuncBase {
 					co_await restore.logError(
 					    cx, restore_missing_data(), "BulkLoad restore failed: backup has no bulkdump data", nullptr);
 					// Abort the restore by setting state to ABORTED
-					Reference<ReadYourWritesTransaction> abortTr(new ReadYourWritesTransaction(cx));
+					auto abortTr = makeReference<ReadYourWritesTransaction>(cx);
 					abortTr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 					abortTr->setOption(FDBTransactionOptions::LOCK_AWARE);
 					restore.stateEnum().set(abortTr, ERestoreState::ABORTED);
@@ -4380,7 +4380,7 @@ struct BulkLoadRestoreTaskFunc : RestoreTaskFuncBase {
 					co_await restore.logError(
 					    cx, restore_missing_data(), "BulkLoad restore failed: bulkdump dataset incomplete", nullptr);
 					// Abort the restore by setting state to ABORTED
-					Reference<ReadYourWritesTransaction> abortTr(new ReadYourWritesTransaction(cx));
+					auto abortTr = makeReference<ReadYourWritesTransaction>(cx);
 					abortTr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 					abortTr->setOption(FDBTransactionOptions::LOCK_AWARE);
 					restore.stateEnum().set(abortTr, ERestoreState::ABORTED);
@@ -4710,7 +4710,7 @@ struct RestoreRangeTaskFunc : RestoreFileTaskFuncBase {
 		    .detail("ReadOffset", readOffset)
 		    .detail("ReadLen", readLen);
 
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		Future<Reference<IBackupContainer>> bc;
 		Future<std::vector<KeyRange>> restoreRanges;
 		Future<Key> addPrefix;
@@ -5146,7 +5146,7 @@ struct RestoreLogDataTaskFunc : RestoreFileTaskFuncBase {
 		    .detail("ReadOffset", readOffset)
 		    .detail("ReadLen", readLen);
 
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		Reference<IBackupContainer> bc;
 		std::vector<KeyRange> ranges;
 
@@ -5498,7 +5498,7 @@ struct RestoreLogDataPartitionedTaskFunc : RestoreFileTaskFuncBase {
 	                                   Key mutationLogPrefix,
 	                                   Reference<Task> task,
 	                                   Reference<TaskBucket> taskBucket) {
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		Standalone<VectorRef<KeyValueRef>> oldFormatMutations;
 		int mutationIndex = 0;
 		int mutationCount = 0;
@@ -5569,7 +5569,7 @@ struct RestoreLogDataPartitionedTaskFunc : RestoreFileTaskFuncBase {
 		Version begin = Params.beginVersion().get(task);
 		Version end = Params.endVersion().get(task);
 
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		Reference<IBackupContainer> bc;
 		std::vector<KeyRange> ranges; // this is the actual KV, not version
 		while (true) {
@@ -6500,7 +6500,7 @@ struct StartFullRestoreTaskFunc : RestoreTaskFuncBase {
 	                             Reference<TaskBucket> taskBucket,
 	                             Reference<FutureBucket> futureBucket,
 	                             Reference<Task> task) {
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		RestoreConfig restore(task);
 		Version restoreVersion{ 0 };
 		Version beginVersion{ 0 };
@@ -6948,7 +6948,7 @@ public:
 		KeyBackedTag tag = makeBackupTag(tagName);
 
 		while (true) {
-			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+			auto tr = makeReference<ReadYourWritesTransaction>(cx);
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -7284,7 +7284,7 @@ public:
 	static Future<ERestoreState> waitRestore(Database cx, Key tagName, Verbose verbose) {
 		ERestoreState status;
 		while (true) {
-			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+			auto tr = makeReference<ReadYourWritesTransaction>(cx);
 			Error err;
 			try {
 				tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
@@ -7441,7 +7441,7 @@ public:
 	}
 
 	static Future<Void> changePause(FileBackupAgent* backupAgent, Database db, bool pause) {
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(db));
+		auto tr = makeReference<ReadYourWritesTransaction>(db);
 
 		while (true) {
 			Error err;
@@ -7497,7 +7497,7 @@ public:
 	}
 
 	static Future<std::string> getStatusJSON(FileBackupAgent* backupAgent, Database cx, std::string tagName) {
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 
 		while (true) {
 			Error err;
@@ -7721,7 +7721,7 @@ public:
 	                                     Database cx,
 	                                     ShowErrors showErrors,
 	                                     std::string tagName) {
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		std::string statusText;
 
 		while (true) {
@@ -8108,7 +8108,7 @@ public:
 			printf("Restoring backup to version: %lld\n", (long long)targetVersion);
 		}
 
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		while (true) {
 			Error err;
 			try {

--- a/fdbclient/FileBackupAgent.cpp
+++ b/fdbclient/FileBackupAgent.cpp
@@ -6351,7 +6351,8 @@ struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 
 		// Use high priority for dispatch tasks that have to queue more blocks for the current batch
 		auto priority = (remainingInBatch > 0) ? 1u : 0u;
-		auto task = makeReference<Task>(RestoreDispatchTaskFunc::name, RestoreDispatchTaskFunc::version, doneKey, priority);
+		auto task =
+		    makeReference<Task>(RestoreDispatchTaskFunc::name, RestoreDispatchTaskFunc::version, doneKey, priority);
 
 		// Create a config from the parent task and bind it to the new task
 		co_await RestoreConfig(parentTask).toTask(tr, task);

--- a/fdbclient/NativeAPI.cpp
+++ b/fdbclient/NativeAPI.cpp
@@ -7187,7 +7187,7 @@ static Future<int64_t> rebootWorkerActor(DatabaseContext* cx, ValueRef addr, boo
 	std::vector<std::string> addressesVec;
 	boost::algorithm::split(addressesVec, addr.toString(), boost::is_any_of(","));
 	// Note: reuse this knob from fdbcli, change it if necessary
-	Reference<FlowLock> connectLock(new FlowLock(CLIENT_KNOBS->CLI_CONNECT_PARALLELISM));
+	auto connectLock = makeReference<FlowLock>(CLIENT_KNOBS->CLI_CONNECT_PARALLELISM);
 	std::vector<Future<bool>> verifyInterfs;
 	for (const auto& requestedAddress : addressesVec) {
 		// step 1: check that the requested address is in the worker list provided by CC

--- a/fdbclient/SpecialKeySpace.cpp
+++ b/fdbclient/SpecialKeySpace.cpp
@@ -2904,7 +2904,7 @@ static Future<RangeResult> workerInterfacesImplGetRangeActor(ReadYourWritesTrans
 	RangeResult result;
 	if (verify) {
 		// if verify option is set, we try to talk to every worker and only returns those we can talk to
-		Reference<FlowLock> connectLock(new FlowLock(CLIENT_KNOBS->CLI_CONNECT_PARALLELISM));
+		auto connectLock = makeReference<FlowLock>(CLIENT_KNOBS->CLI_CONNECT_PARALLELISM);
 		std::vector<Future<bool>> verifyInterfs;
 		for (const auto& [k_, value] : interfs) {
 			auto k = k_.withPrefix(prefix);

--- a/fdbclient/TaskBucket.cpp
+++ b/fdbclient/TaskBucket.cpp
@@ -311,7 +311,7 @@ public:
 
 	static Future<bool> taskVerify(Reference<TaskBucket> tb, Database cx, Reference<Task> task) {
 		while (true) {
-			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+			auto tr = makeReference<ReadYourWritesTransaction>(cx);
 			Error err;
 			try {
 				bool verified = co_await taskVerify(tb, tr, task);
@@ -353,7 +353,7 @@ public:
 	}
 
 	static Future<Void> extendTimeoutRepeatedly(Database cx, Reference<TaskBucket> taskBucket, Reference<Task> task) {
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		double start = now();
 		Version versionNow = co_await runRYWTransaction(cx, [=](Reference<ReadYourWritesTransaction> tr) {
 			taskBucket->setOptions(tr);
@@ -417,7 +417,7 @@ public:
 
 				if (verifyTask) {
 					while (true) {
-						Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+						auto tr = makeReference<ReadYourWritesTransaction>(cx);
 						taskBucket->setOptions(tr);
 						Error innerErr;
 						try {
@@ -675,7 +675,7 @@ public:
 	}
 
 	static Future<bool> checkActive(Database cx, Reference<TaskBucket> taskBucket) {
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		Optional<Value> startingValue;
 
 		while (true) {

--- a/fdbclient/TaskBucket.cpp
+++ b/fdbclient/TaskBucket.cpp
@@ -239,7 +239,7 @@ public:
 		Key taskUID = t.getString(0);
 		Subspace taskAvailableSpace = availableSpace.get(taskUID);
 
-		Reference<Task> task(new Task());
+		auto task = makeReference<Task>();
 		task->key = taskUID;
 
 		RangeResult values = co_await tr->getRange(taskAvailableSpace.range(), CLIENT_KNOBS->TOO_MANY);
@@ -1177,7 +1177,7 @@ public:
 		std::vector<Future<Void>> actions;
 
 		if (!values.empty()) {
-			Reference<Task> task(new Task());
+			auto task = makeReference<Task>();
 			Key lastTaskID;
 			for (auto& s : values) {
 				Tuple t = taskFuture->callbacks.unpack(s.key);

--- a/fdbclient/include/fdbclient/RunRYWTransaction.h
+++ b/fdbclient/include/fdbclient/RunRYWTransaction.h
@@ -44,7 +44,7 @@ using RunRYWTransactionResult = decltype(std::declval<Function>()(Reference<Read
 // transaction is retried.
 template <class Function>
 Future<RunRYWTransactionResult<Function>> runRYWTransaction(Database cx, Function func, ExplicitVoid = {}) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(cx);
 	while (true) {
 		Error err;
 		try {
@@ -65,7 +65,7 @@ Future<RunRYWTransactionResult<Function>> runRYWTransactionDebug(Database cx,
                                                                  StringRef name,
                                                                  Function func,
                                                                  ExplicitVoid = {}) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(cx);
 	while (true) {
 		Error err;
 		try {
@@ -92,7 +92,7 @@ Future<RunRYWTransactionResult<Function>> runRYWTransactionDebug(Database cx,
 // transaction is retried.
 template <class Function>
 Future<Void> runRYWTransactionVoid(Database cx, Function func, const char* errorEvent = nullptr) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(cx);
 	while (true) {
 		Error err;
 		try {
@@ -111,7 +111,7 @@ Future<Void> runRYWTransactionVoid(Database cx, Function func, const char* error
 
 template <class Function>
 Future<RunRYWTransactionResult<Function>> runRYWTransactionFailIfLocked(Database cx, Function func, ExplicitVoid = {}) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(cx);
 	while (true) {
 		Error err;
 		try {
@@ -129,7 +129,7 @@ Future<RunRYWTransactionResult<Function>> runRYWTransactionFailIfLocked(Database
 
 template <class Function>
 Future<RunRYWTransactionResult<Function>> runRYWTransactionNoRetry(Database cx, Function func, ExplicitVoid = {}) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(cx);
 	auto const result = co_await func(tr);
 	co_await tr->commit();
 	co_return result;

--- a/fdbserver/backupworker/BackupWorker.cpp
+++ b/fdbserver/backupworker/BackupWorker.cpp
@@ -167,7 +167,7 @@ struct BackupData {
 			const bool firstWorker = info->self->tag.id == 0;
 			bool allUpdated = false;
 			Optional<std::vector<std::pair<int64_t, int64_t>>> workers;
-			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
+			auto tr = makeReference<ReadYourWritesTransaction>(self->cx);
 
 			while (true) {
 				Error err;
@@ -523,7 +523,7 @@ static Future<Void> monitorBackupStartedKeyChanges(BackupData* self) {
 
 // Set "latestBackupWorkerSavedVersion" key for backups
 Future<Void> setBackupKeys(BackupData* self, std::map<UID, Version> savedLogVersions) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(self->cx);
 
 	while (true) {
 		Error err;
@@ -687,7 +687,7 @@ Future<Void> addMutation(Reference<IBackupFile> logFile,
 static Future<Void> updateLogBytesWritten(BackupData* self,
                                           std::vector<UID> backupUids,
                                           std::vector<Reference<IBackupFile>> logFiles) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(self->cx);
 
 	ASSERT(backupUids.size() == logFiles.size());
 	while (true) {
@@ -1014,7 +1014,7 @@ Future<Void> checkRemoved(Reference<AsyncVar<ServerDBInfo> const> db, LogEpoch r
 }
 
 static Future<Void> monitorWorkerPause(BackupData* self) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(self->cx);
 	Future<Void> watch;
 
 	while (true) {

--- a/fdbserver/backupworker/RangePartitionedBackupWorker.cpp
+++ b/fdbserver/backupworker/RangePartitionedBackupWorker.cpp
@@ -393,7 +393,7 @@ Future<Version> pullPartitionMapFromTLog(RangePartitionedBackupData* self, Parti
 Future<Void> persistPartitionMapToSS(RangePartitionedBackupData* self,
                                      Version partitionMapVersion,
                                      PartitionMap const& partitionMap) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(self->cx);
 	Key key = backupPartitionMapHistoryKeyFor(self->backupEpoch, partitionMapVersion);
 
 	BinaryWriter valueWriter(IncludeVersion());
@@ -431,7 +431,7 @@ Future<Void> persistPartitionMapToSS(RangePartitionedBackupData* self,
 Future<Optional<std::pair<Version, PartitionMap>>> loadActivePartitionMapFromSS(RangePartitionedBackupData* self,
                                                                                 LogEpoch epoch,
                                                                                 Version startVersion) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(self->cx);
 	KeyRange range = backupPartitionMapHistoryRangeFor(epoch);
 
 	while (true) {
@@ -767,7 +767,7 @@ Future<Void> addMutation(Reference<IBackupFile> logFile,
 }
 
 static Future<Void> updateLogBytesWritten(RangePartitionedBackupData* self, std::map<UID, int64_t> bytesPerBackup) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(self->cx);
 
 	while (true) {
 		Error err;
@@ -1005,7 +1005,7 @@ static Future<Void> monitorBackupStartedKeyChanges(RangePartitionedBackupData* s
 
 // This function is used to set backup worker's saved version latestBackupWorkerSavedVersion in BackupConfig.
 Future<Void> setBackupKeys(RangePartitionedBackupData* self, std::map<UID, Version> savedLogVersions) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(self->cx);
 
 	while (true) {
 		Error err;
@@ -1052,7 +1052,7 @@ Future<Void> setBackupKeys(RangePartitionedBackupData* self, std::map<UID, Versi
 }
 
 static Future<Void> monitorWorkerPause(RangePartitionedBackupData* self) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(self->cx);
 	Future<Void> watch;
 
 	while (true) {

--- a/fdbserver/clustercontroller/ClusterRecovery.cpp
+++ b/fdbserver/clustercontroller/ClusterRecovery.cpp
@@ -724,8 +724,8 @@ static Future<Void> recruitRangePartitionedBackupWorkers(Reference<ClusterRecove
 	co_await delay(SERVER_KNOBS->SECONDS_BEFORE_RECRUIT_BACKUP_WORKER);
 
 	LogEpoch epoch = self->cstate.myDBState.recoveryCount;
-	Reference<BackupProgress> backupProgress(
-	    new BackupProgress(self->dbgid, self->logSystem->getOldEpochRangePartitionedBackupTagsInfo()));
+	auto backupProgress =
+	    makeReference<BackupProgress>(self->dbgid, self->logSystem->getOldEpochRangePartitionedBackupTagsInfo());
 	Future<Void> fBackupProgress = getBackupProgress(cx, self->dbgid, backupProgress, SevInfo);
 	std::vector<Future<InitializeRangePartitionedBackupReply>> initializationReplies;
 
@@ -813,8 +813,7 @@ static Future<Void> recruitBackupWorkers(Reference<ClusterRecoveryData> self, Da
 	co_await delay(SERVER_KNOBS->SECONDS_BEFORE_RECRUIT_BACKUP_WORKER);
 
 	LogEpoch epoch = self->cstate.myDBState.recoveryCount;
-	Reference<BackupProgress> backupProgress(
-	    new BackupProgress(self->dbgid, self->logSystem->getOldEpochLogRouterTagsInfo()));
+	auto backupProgress = makeReference<BackupProgress>(self->dbgid, self->logSystem->getOldEpochLogRouterTagsInfo());
 	Future<Void> fBackupProgress = getBackupProgress(cx, self->dbgid, backupProgress, SevInfo);
 	std::vector<Future<InitializeBackupReply>> initializationReplies;
 

--- a/fdbserver/clustercontroller/Status.cpp
+++ b/fdbserver/clustercontroller/Status.cpp
@@ -2874,7 +2874,7 @@ Future<Optional<Value>> getActivePrimaryDC(Database cx, int* fullyReplicatedRegi
 Future<std::pair<Optional<StorageWiggleMetrics>, Optional<StorageWiggleMetrics>>> readStorageWiggleMetrics(
     Database cx,
     bool use_system_priority) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(cx);
 	Optional<StorageWiggleMetrics> primaryV;
 	Optional<StorageWiggleMetrics> remoteV;
 	StorageWiggleData wiggleState;

--- a/fdbserver/datadistributor/DDTeamCollection.cpp
+++ b/fdbserver/datadistributor/DDTeamCollection.cpp
@@ -2349,7 +2349,7 @@ public:
 
 		UID nextId = co_await self->getNextWigglingServerID();
 		StorageWiggleValue value(nextId);
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(self->dbContext()));
+		auto tr = makeReference<ReadYourWritesTransaction>(self->dbContext());
 		while (true) {
 			counters->started->increment(1);
 			// write the next server id

--- a/fdbserver/worker/MetricLogger.cpp
+++ b/fdbserver/worker/MetricLogger.cpp
@@ -81,7 +81,7 @@ struct MetricsRule {
 	// For now this just returns true if pat is in subject.  Returns true if pat is empty.
 	// TODO:  Support more complex patterns?
 	static inline bool patternMatch(StringRef const& pat, StringRef const& subject) {
-		if (pat.size() == 0)
+		if (pat.empty())
 			return true;
 		for (int i = 0, iend = subject.size() - pat.size() + 1; i < iend; ++i)
 			if (subject.substr(i, pat.size()) == pat)
@@ -187,7 +187,7 @@ Future<Void> metricRuleUpdater(Database cx, MetricsConfig* config, TDMetricColle
 class MetricDB : public IMetricDB {
 public:
 	explicit MetricDB(ReadYourWritesTransaction* tr = nullptr) : tr(tr) {}
-	~MetricDB() override {}
+	~MetricDB() override = default;
 
 	// levelKey is the prefix for the entire level, no timestamp at the end
 	static Future<Optional<Standalone<StringRef>>> getLastBlock_impl(ReadYourWritesTransaction* tr,
@@ -215,7 +215,7 @@ Future<Void> dumpMetrics(Database cx, MetricsConfig* config, TDMetricCollection*
 	while (true) {
 		batch.clear();
 		uint64_t rollTime = std::numeric_limits<uint64_t>::max();
-		if (collection->rollTimes.size()) {
+		if (!collection->rollTimes.empty()) {
 			rollTime = collection->rollTimes.front();
 			collection->rollTimes.pop_front();
 		}
@@ -272,7 +272,7 @@ Future<Void> dumpMetrics(Database cx, MetricsConfig* config, TDMetricCollection*
 		// If there are more rolltimes then next dump is now, otherwise if no metrics are enabled then it is
 		// whenever the next metric is enabled but if there are metrics enabled then it is in 1 second.
 		Future<Void> nextDump;
-		if (collection->rollTimes.size() > 0)
+		if (!collection->rollTimes.empty())
 			nextDump = Void();
 		else {
 			nextDump = collection->metricEnabled.onTrigger();
@@ -388,7 +388,7 @@ Future<Void> updateMetricRegistration(Database cx, MetricsConfig* config, TDMetr
 
 Future<Void> runMetrics(Future<Database> fcx, Key prefix) {
 	// Never log to an empty prefix, it's pretty much always a bad idea.
-	if (prefix.size() == 0) {
+	if (prefix.empty()) {
 		TraceEvent(SevWarnAlways, "TDMetricsRefusingEmptyPrefix").log();
 		co_return;
 	}
@@ -493,7 +493,7 @@ TEST_CASE("/fdbserver/metrics/TraceEvents") {
 	};
 	std::string metricsConnFile = getenv2("METRICS_CONNFILE");
 	std::string metricsPrefix = getenv2("METRICS_PREFIX");
-	if (metricsConnFile == "") {
+	if (metricsConnFile.empty()) {
 		fprintf(stdout, "Metrics cluster file must be specified in environment variable METRICS_CONNFILE\n");
 		co_return;
 	}

--- a/fdbserver/worker/MetricLogger.cpp
+++ b/fdbserver/worker/MetricLogger.cpp
@@ -154,7 +154,7 @@ struct MetricsConfig {
       Go back to wait for rule change
 */
 Future<Void> metricRuleUpdater(Database cx, MetricsConfig* config, TDMetricCollection* collection) {
-	Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+	auto tr = makeReference<ReadYourWritesTransaction>(cx);
 
 	while (true) {
 		Future<Void> newMetric = collection->metricAdded.onTrigger();

--- a/fdbserver/workloads/BackupCorrectness.cpp
+++ b/fdbserver/workloads/BackupCorrectness.cpp
@@ -857,7 +857,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 
 			// Ensure that there is no left over key within the backup subspace
 			while (true) {
-				Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+				auto tr = makeReference<ReadYourWritesTransaction>(cx);
 
 				TraceEvent("BARW_CheckLeftoverKeys", randomID).detail("BackupTag", printable(backupTag));
 

--- a/fdbserver/workloads/BackupCorrectnessPartitioned.cpp
+++ b/fdbserver/workloads/BackupCorrectnessPartitioned.cpp
@@ -634,7 +634,7 @@ struct BackupAndRestorePartitionedCorrectnessWorkload : TestWorkload {
 
 			// Ensure that there is no left over key within the backup subspace
 			while (true) {
-				Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+				auto tr = makeReference<ReadYourWritesTransaction>(cx);
 
 				TraceEvent("BARW_CheckLeftoverKeys", randomID).detail("BackupTag", printable(backupTag));
 

--- a/fdbserver/workloads/BackupToDBCorrectness.cpp
+++ b/fdbserver/workloads/BackupToDBCorrectness.cpp
@@ -449,7 +449,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 
 		// Ensure that there is no left over key within the backup subspace
 		while (true) {
-			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+			auto tr = makeReference<ReadYourWritesTransaction>(cx);
 
 			TraceEvent("BARW_CheckLeftoverKeys", randomID).detail("BackupTag", printable(tag));
 

--- a/fdbserver/workloads/BackupToDBUpgrade.cpp
+++ b/fdbserver/workloads/BackupToDBUpgrade.cpp
@@ -112,7 +112,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 	                      Key tag,
 	                      Standalone<VectorRef<KeyRangeRef>> backupRanges) {
 		try {
-			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(extraDB));
+			auto tr = makeReference<ReadYourWritesTransaction>(extraDB);
 			while (true) {
 				Error err;
 				try {
@@ -156,7 +156,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 
 		// Ensure that there is no left over key within the backup subspace
 		while (true) {
-			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+			auto tr = makeReference<ReadYourWritesTransaction>(cx);
 
 			TraceEvent("DRU_CheckLeftoverkeys").detail("BackupTag", printable(tag));
 
@@ -398,7 +398,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 
 		try {
 			// Get restore ranges before aborting
-			Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(extraDB));
+			auto tr = makeReference<ReadYourWritesTransaction>(extraDB);
 			while (true) {
 				Error err;
 				try {
@@ -469,7 +469,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 
 			// restore database
 			TraceEvent("DRU_PrepareRestore").detail("RestoreTag", printable(restoreTag));
-			Reference<ReadYourWritesTransaction> tr2(new ReadYourWritesTransaction(cx));
+			auto tr2 = makeReference<ReadYourWritesTransaction>(cx);
 			while (true) {
 				Error err;
 				try {

--- a/fdbserver/workloads/IncrementalBackup.cpp
+++ b/fdbserver/workloads/IncrementalBackup.cpp
@@ -242,7 +242,7 @@ struct IncrementalBackupWorkload : TestWorkload {
 
 			if (checkBeginVersion) {
 				TraceEvent("IBackupReadSystemKeys").log();
-				Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+				auto tr = makeReference<ReadYourWritesTransaction>(cx);
 				while (true) {
 					Error err;
 					try {

--- a/fdbserver/workloads/ReportConflictingKeys.cpp
+++ b/fdbserver/workloads/ReportConflictingKeys.cpp
@@ -133,8 +133,8 @@ struct ReportConflictingKeysWorkload : TestWorkload {
 
 	Future<Void> conflictingClient(Database cx, ReportConflictingKeysWorkload* self) {
 
-		Reference<ReadYourWritesTransaction> tr1(new ReadYourWritesTransaction(cx));
-		Reference<ReadYourWritesTransaction> tr2(new ReadYourWritesTransaction(cx));
+		auto tr1 = makeReference<ReadYourWritesTransaction>(cx);
+		auto tr2 = makeReference<ReadYourWritesTransaction>(cx);
 		std::vector<KeyRange> readConflictRanges;
 		std::vector<KeyRange> writeConflictRanges;
 

--- a/fdbserver/workloads/Restore.cpp
+++ b/fdbserver/workloads/Restore.cpp
@@ -245,7 +245,7 @@ struct RestoreWorkload : TestWorkload {
 
 			// Ensure that there is no left over key within the backup subspace
 			while (true) {
-				Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+				auto tr = makeReference<ReadYourWritesTransaction>(cx);
 
 				TraceEvent("RW_CheckLeftoverKeys", randomID).detail("BackupTag", printable(backupTag));
 

--- a/fdbserver/workloads/SkewedReadWrite.cpp
+++ b/fdbserver/workloads/SkewedReadWrite.cpp
@@ -95,7 +95,7 @@ struct SkewedReadWriteWorkload : ReadWriteCommon {
 	Future<Void> updateServerShards(Database cx) {
 		RangeResult serverList;
 		RangeResult range;
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		while (true) {
 			// read in transaction to ensure two key ranges are transactionally consistent
 			Error err;

--- a/fdbserver/workloads/SpecialKeySpaceRobustness.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceRobustness.cpp
@@ -604,8 +604,8 @@ struct SpecialKeySpaceRobustnessWorkload : TestWorkload {
 		// make sure when we change dd related special keys, we grab the two system keys,
 		// i.e. moveKeysLockOwnerKey and moveKeysLockWriteKey
 		{
-			Reference<ReadYourWritesTransaction> tr1(new ReadYourWritesTransaction(cx));
-			Reference<ReadYourWritesTransaction> tr2(new ReadYourWritesTransaction(cx));
+			auto tr1 = makeReference<ReadYourWritesTransaction>(cx);
+			auto tr2 = makeReference<ReadYourWritesTransaction>(cx);
 			while (true) {
 				Error err;
 				try {

--- a/fdbserver/workloads/TaskBucketCorrectness.cpp
+++ b/fdbserver/workloads/TaskBucketCorrectness.cpp
@@ -254,7 +254,7 @@ struct TaskBucketCorrectnessWorkload : TestWorkload {
 	}
 
 	Future<Void> start(Database const& cx) override {
-		Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		Subspace taskSubspace("backup-agent"_sr);
 		Reference<TaskBucket> taskBucket(new TaskBucket(taskSubspace.get("tasks"_sr)));
 		Reference<FutureBucket> futureBucket(new FutureBucket(taskSubspace.get("futures"_sr)));

--- a/fdbserver/workloads/TaskBucketCorrectness.cpp
+++ b/fdbserver/workloads/TaskBucketCorrectness.cpp
@@ -256,8 +256,8 @@ struct TaskBucketCorrectnessWorkload : TestWorkload {
 	Future<Void> start(Database const& cx) override {
 		auto tr = makeReference<ReadYourWritesTransaction>(cx);
 		Subspace taskSubspace("backup-agent"_sr);
-		Reference<TaskBucket> taskBucket(new TaskBucket(taskSubspace.get("tasks"_sr)));
-		Reference<FutureBucket> futureBucket(new FutureBucket(taskSubspace.get("futures"_sr)));
+		auto taskBucket = makeReference<TaskBucket>(taskSubspace.get("tasks"_sr));
+		auto futureBucket = makeReference<FutureBucket>(taskSubspace.get("futures"_sr));
 
 		Error err;
 		try {


### PR DESCRIPTION
## Summary

Replace 100 direct local `Reference<T>(new T(...))` declarations with `makeReference<T>(...)` across 24 files. The changes cover `ReadYourWritesTransaction`, `Task`, `FlowLock`, `TaskBucket`, `FutureBucket`, and `BackupProgress`, whose constructors are public at these sites. The helper returns the same reference type. Braced initializer arguments and types with inaccessible constructors are excluded.

This includes five declarations in `RunRYWTransaction.h` that the accompanying ast-grep configuration now parses as C++.

## Validation

- The focused ast-grep rule reports zero remaining matches across the checkout, including headers.
- `fdbclient_test`: 108 passed, 0 failed.
- `fdbbackup`: compiled and linked with zero compilation failures; `fdbbackup --version` succeeded.
- `fdbserver`: compiled and linked with zero compilation failures; `fdbserver --version` succeeded.
- `clang-format` CI passed on the final PR head.
