### PR TITLE
Preserve explicit memory-tracker knobs in simulation

### DIFF
--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -88,11 +88,11 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 
 	// Per-call-site sampled memory tracker. See design/memory-tracker.md.
 	// Initial rollout: prod default off (=0). Simulation defaults to 1-in-10 sampling so the path is exercised.
-	init( MEMORY_TRACKING_SAMPLE_INVERSE,                        0 ); if( isSimulated ) MEMORY_TRACKING_SAMPLE_INVERSE = 10;
+	init( MEMORY_TRACKING_SAMPLE_INVERSE,       isSimulated ? 10 : 0 );
 	init( MEMORY_TRACKING_FORCE_SAMPLE_BYTES,               100000 );
 	init( MEMORY_TRACKING_LIVE_TRACKING,                      true );
-	init( MEMORY_TRACKING_REPORT_INTERVAL,                   600.0 ); if( isSimulated ) MEMORY_TRACKING_REPORT_INTERVAL = 30.0;
-	init( MEMORY_TRACKING_REPORT_BYTES_THRESHOLD,         80000000 ); if( isSimulated ) MEMORY_TRACKING_REPORT_BYTES_THRESHOLD = 1000000;
+	init( MEMORY_TRACKING_REPORT_INTERVAL, isSimulated ? 30.0 : 600.0 );
+	init( MEMORY_TRACKING_REPORT_BYTES_THRESHOLD, isSimulated ? 1000000 : 80000000 );
 	init( MEMORY_TRACKING_FRAMES,                                6 );
 
 	// Chaos testing - enabled for simulation by default

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -552,29 +552,6 @@ void Knobs::trace() const {
 		TraceEvent("Knob").detail("Name", k.first.c_str()).detail("Value", *k.second.value);
 }
 
-TEST_CASE("/flow/Knobs/MemoryTrackingOverrides") {
-	for (IsSimulated simulated : { IsSimulated::False, IsSimulated::True }) {
-		FlowKnobs knobs(Randomize::False, simulated);
-		ASSERT_EQ(knobs.MEMORY_TRACKING_SAMPLE_INVERSE, simulated ? 10 : 0);
-		ASSERT_EQ(knobs.MEMORY_TRACKING_REPORT_INTERVAL, simulated ? 30.0 : 600.0);
-		ASSERT_EQ(knobs.MEMORY_TRACKING_REPORT_BYTES_THRESHOLD, simulated ? 1000000 : 80000000);
-
-		ASSERT(knobs.setKnob("memory_tracking_sample_inverse", 0));
-		ASSERT(knobs.setKnob("memory_tracking_report_interval", 0.0));
-		ASSERT(knobs.setKnob("memory_tracking_report_bytes_threshold", int64_t{ 123456 }));
-		knobs.initialize(Randomize::False, simulated);
-		ASSERT_EQ(knobs.MEMORY_TRACKING_SAMPLE_INVERSE, 0);
-		ASSERT_EQ(knobs.MEMORY_TRACKING_REPORT_INTERVAL, 0.0);
-		ASSERT_EQ(knobs.MEMORY_TRACKING_REPORT_BYTES_THRESHOLD, 123456);
-
-		knobs.reset(Randomize::False, simulated);
-		ASSERT_EQ(knobs.MEMORY_TRACKING_SAMPLE_INVERSE, simulated ? 10 : 0);
-		ASSERT_EQ(knobs.MEMORY_TRACKING_REPORT_INTERVAL, simulated ? 30.0 : 600.0);
-		ASSERT_EQ(knobs.MEMORY_TRACKING_REPORT_BYTES_THRESHOLD, simulated ? 1000000 : 80000000);
-	}
-	return Void();
-}
-
 TEST_CASE("/flow/Knobs/ParseKnobValue") {
 	// Test the safe conversion functions.
 	ASSERT_EQ(safe_stod("4.0"), 4.0);

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -552,6 +552,29 @@ void Knobs::trace() const {
 		TraceEvent("Knob").detail("Name", k.first.c_str()).detail("Value", *k.second.value);
 }
 
+TEST_CASE("/flow/Knobs/MemoryTrackingOverrides") {
+	for (IsSimulated simulated : { IsSimulated::False, IsSimulated::True }) {
+		FlowKnobs knobs(Randomize::False, simulated);
+		ASSERT_EQ(knobs.MEMORY_TRACKING_SAMPLE_INVERSE, simulated ? 10 : 0);
+		ASSERT_EQ(knobs.MEMORY_TRACKING_REPORT_INTERVAL, simulated ? 30.0 : 600.0);
+		ASSERT_EQ(knobs.MEMORY_TRACKING_REPORT_BYTES_THRESHOLD, simulated ? 1000000 : 80000000);
+
+		ASSERT(knobs.setKnob("memory_tracking_sample_inverse", 0));
+		ASSERT(knobs.setKnob("memory_tracking_report_interval", 0.0));
+		ASSERT(knobs.setKnob("memory_tracking_report_bytes_threshold", int64_t{ 123456 }));
+		knobs.initialize(Randomize::False, simulated);
+		ASSERT_EQ(knobs.MEMORY_TRACKING_SAMPLE_INVERSE, 0);
+		ASSERT_EQ(knobs.MEMORY_TRACKING_REPORT_INTERVAL, 0.0);
+		ASSERT_EQ(knobs.MEMORY_TRACKING_REPORT_BYTES_THRESHOLD, 123456);
+
+		knobs.reset(Randomize::False, simulated);
+		ASSERT_EQ(knobs.MEMORY_TRACKING_SAMPLE_INVERSE, simulated ? 10 : 0);
+		ASSERT_EQ(knobs.MEMORY_TRACKING_REPORT_INTERVAL, simulated ? 30.0 : 600.0);
+		ASSERT_EQ(knobs.MEMORY_TRACKING_REPORT_BYTES_THRESHOLD, simulated ? 1000000 : 80000000);
+	}
+	return Void();
+}
+
 TEST_CASE("/flow/Knobs/ParseKnobValue") {
 	// Test the safe conversion functions.
 	ASSERT_EQ(safe_stod("4.0"), 4.0);


### PR DESCRIPTION
## Summary

Simulation defaults for the memory-tracker sampling rate, reporting interval, and reporting threshold were assigned after knob initialization. Reinitializing the knobs therefore overwrote explicit settings, including a sampling rate of zero.

Choose the simulation-specific defaults through the existing knob initialization mechanism so explicit settings survive. Default values and reset behavior remain unchanged.

## Validation

The previous PR head passed Linux and macOS CI. The follow-up commit removes only the standalone unit test; the knob initialization change is unchanged.
