### PR TITLE
Avoid publishing transient DD pipeline capacity

### DIFF
--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -648,7 +648,8 @@ void DDQueue::updatePipelineFull() {
 		    .detail("PendingGateRelocations", pendingGateRelocations)
 		    .detail("PipelineLimit", SERVER_KNOBS->DD_MAX_PIPELINE_MOVES);
 		CODE_PROBE(true, "DD Pipeline Full");
-	} else if (pipelineSize() < SERVER_KNOBS->DD_MAX_PIPELINE_MOVES && pipelineFull->get()) {
+	} else if (pipelineMutationDepth == 0 && pipelineSize() < SERVER_KNOBS->DD_MAX_PIPELINE_MOVES &&
+	           pipelineFull->get()) {
 		pipelineFull->set(false);
 		TraceEvent("DDPipelineFullCleared", distributorId)
 		    .suppressFor(30.0)
@@ -863,6 +864,7 @@ void DDQueue::processRelocationComplete(const RelocateData& done) {
 }
 
 void DDQueue::queueRelocation(RelocateShard rs, std::set<UID>& serversToLaunchFrom) {
+	PipelineMutation mutation(*this);
 	//TraceEvent("QueueRelocationBegin").detail("Begin", rd.keys.begin).detail("End", rd.keys.end);
 
 	// remove all items from both queues that are fully contained in the new relocation (i.e. will be overwritten)
@@ -1158,6 +1160,7 @@ bool runPendingBulkLoadTaskWithRelocateData(DDQueue* self, RelocateData& rd) {
 // canceled inflight relocateData. Launch the relocation for the rd.
 void DDQueue::launchQueuedWork(std::set<RelocateData, std::greater<RelocateData>> combined,
                                const DDEnabledState* ddEnabledState) {
+	PipelineMutation mutation(*this);
 	[[maybe_unused]] int startedHere = 0;
 	double startTime = now();
 	// kick off relocators from items in the queue as need be
@@ -3017,6 +3020,7 @@ struct DDQueueImpl {
 			RelocateShard rs = co_await input;
 			co_await state->queueMutationLock.take(TaskPriority::DataDistributionLaunch);
 			FlowLock::Releaser lockGuard(state->queueMutationLock);
+			DDQueue::PipelineMutation mutation(*state->self);
 			state->self->pendingGateRelocations--;
 			state->self->updatePipelineFull();
 			if (rs.isRestore()) {
@@ -3375,6 +3379,23 @@ TEST_CASE("/DataDistribution/DDQueue/ReplacementPreservesPipelineCapacity") {
 	ASSERT(self.pipelineFull->get());
 	// Replacing one queued move must not advertise a slot that another producer can consume.
 	ASSERT(!capacityChanged.isReady());
+
+	RelocateData adjacent(RelocateShard(
+	    KeyRangeRef("b"_sr, "c"_sr), priority, RelocateReason::OTHER, UID(3, 0)));
+	self.queueMap.insert(adjacent.keys, adjacent);
+	self.fetchingSourcesQueue.insert(adjacent);
+	self.activeRelocations--;
+	self.queuedRelocations++;
+	self.startRelocation(priority, priority);
+	request.keys = KeyRangeRef("a"_sr, "c"_sr);
+	request.traceId = UID(4, 0);
+	self.queueRelocation(request, serversToLaunchFrom);
+
+	// Coalescing two queued ranges really releases one slot.
+	ASSERT_EQ(self.queuedRelocations, 1);
+	ASSERT_EQ(self.pipelineSize(), SERVER_KNOBS->DD_MAX_PIPELINE_MOVES - 1);
+	ASSERT(!self.pipelineFull->get());
+	ASSERT(capacityChanged.isReady());
 	return Void();
 }
 

--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -3380,8 +3380,7 @@ TEST_CASE("/DataDistribution/DDQueue/ReplacementPreservesPipelineCapacity") {
 	// Replacing one queued move must not advertise a slot that another producer can consume.
 	ASSERT(!capacityChanged.isReady());
 
-	RelocateData adjacent(RelocateShard(
-	    KeyRangeRef("b"_sr, "c"_sr), priority, RelocateReason::OTHER, UID(3, 0)));
+	RelocateData adjacent(RelocateShard(KeyRangeRef("b"_sr, "c"_sr), priority, RelocateReason::OTHER, UID(3, 0)));
 	self.queueMap.insert(adjacent.keys, adjacent);
 	self.fetchingSourcesQueue.insert(adjacent);
 	self.activeRelocations--;

--- a/fdbserver/datadistributor/DDRelocationQueue.cpp
+++ b/fdbserver/datadistributor/DDRelocationQueue.cpp
@@ -3345,6 +3345,39 @@ TEST_CASE("/DataDistribution/DDQueue/ServerCounterTrace") {
 	std::cout << "Finished.";
 }
 
+TEST_CASE("/DataDistribution/DDQueue/ReplacementPreservesPipelineCapacity") {
+	DDQueue self;
+	self.activeRelocations = SERVER_KNOBS->DD_MAX_PIPELINE_MOVES - 1;
+	self.queuedRelocations = 1;
+	self.pendingGateRelocations = 0;
+	self.unhealthyRelocations = 0;
+	self.pipelineFull = makeReference<AsyncVar<bool>>(false);
+	self.rawProcessingUnhealthy = makeReference<AsyncVar<bool>>(false);
+	self.rawProcessingWiggle = makeReference<AsyncVar<bool>>(false);
+	// Keep source discovery pending so this exercises queue replacement without a database.
+	self.fetchSourceLock = makeReference<FlowLock>(0);
+	const int priority = SERVER_KNOBS->PRIORITY_PERPETUAL_STORAGE_WIGGLE;
+	RelocateShard request(KeyRangeRef("a"_sr, "b"_sr), priority, RelocateReason::OTHER, UID(1, 0));
+	RelocateData queued(request);
+	self.queueMap.insert(queued.keys, queued);
+	self.fetchingSourcesQueue.insert(queued);
+	self.startRelocation(priority, priority);
+	ASSERT(self.pipelineFull->get());
+	Future<Void> capacityChanged = self.pipelineFull->onChange();
+
+	std::set<UID> serversToLaunchFrom;
+	request.traceId = UID(2, 0);
+	self.queueRelocation(request, serversToLaunchFrom);
+
+	ASSERT_EQ(self.queuedRelocations, 1);
+	ASSERT_EQ(self.fetchingSourcesQueue.size(), 1);
+	ASSERT_EQ(self.pipelineSize(), SERVER_KNOBS->DD_MAX_PIPELINE_MOVES);
+	ASSERT(self.pipelineFull->get());
+	// Replacing one queued move must not advertise a slot that another producer can consume.
+	ASSERT(!capacityChanged.isReady());
+	return Void();
+}
+
 TEST_CASE("/DataDistribution/DDQueue/SourceDiscoveryPreservesReadRebalanceCooldown") {
 	DDQueue self;
 	const std::vector<UID> primary{ UID(1, 0), UID(2, 0), UID(3, 0) };

--- a/fdbserver/datadistributor/DDRelocationQueue.h
+++ b/fdbserver/datadistributor/DDRelocationQueue.h
@@ -263,6 +263,20 @@ public:
 
 	void updatePipelineFull();
 
+	// Intermediate counter changes must not wake producers with a slot that a replacement still needs.
+	class PipelineMutation : NonCopyable {
+	public:
+		explicit PipelineMutation(DDQueue& queue) : queue(queue) { ++queue.pipelineMutationDepth; }
+		~PipelineMutation() {
+			if (--queue.pipelineMutationDepth == 0) {
+				queue.updatePipelineFull();
+			}
+		}
+
+	private:
+		DDQueue& queue;
+	};
+
 	Reference<AsyncVar<bool>> pipelineFull;
 
 	std::map<UID, Busyness> busymap; // UID is serverID
@@ -407,6 +421,9 @@ public:
 	                        const DDEnabledState* ddEnabledState);
 
 	explicit DDQueue(DDQueueInitParams const& params);
+
+private:
+	int pipelineMutationDepth = 0;
 };
 
 #endif // FOUNDATIONDB_DDRELOCATIONQUEUE_H

--- a/fdbserver/datadistributor/DDRelocationQueue.h
+++ b/fdbserver/datadistributor/DDRelocationQueue.h
@@ -266,15 +266,15 @@ public:
 	// Intermediate counter changes must not wake producers with a slot that a replacement still needs.
 	class PipelineMutation : NonCopyable {
 	public:
-		explicit PipelineMutation(DDQueue& queue) : queue(queue) { ++queue.pipelineMutationDepth; }
+		explicit PipelineMutation(DDQueue& queue) : queue(&queue) { ++queue.pipelineMutationDepth; }
 		~PipelineMutation() {
-			if (--queue.pipelineMutationDepth == 0) {
-				queue.updatePipelineFull();
+			if (--queue->pipelineMutationDepth == 0) {
+				queue->updatePipelineFull();
 			}
 		}
 
 	private:
-		DDQueue& queue;
+		DDQueue* queue;
 	};
 
 	Reference<AsyncVar<bool>> pipelineFull;


### PR DESCRIPTION
## Summary

Keep Data Distributor pipeline-capacity notifications consistent while a relocation is admitted, replaces queued work, or moves from queued to active accounting.

Those operations can temporarily lower a counter before restoring it. Publishing available capacity at that intermediate point wakes producers even though no slot has actually been released. Defer only the available-capacity notification until the outermost accounting mutation finishes; continue publishing saturation immediately.

## Regression coverage

Extend the existing DD queue tests at the production queue-replacement boundary. A replacement that preserves the pipeline size must not notify waiting producers. Coalescing two queued ranges must still publish the genuinely released slot.

The focused regression fails at the intended notification assertion without the fix and passes with it. All seven DDQueue native tests pass. The paired ClientTransactionProfilingCorrectness restart test also passes with fault injection and buggify enabled.

## Scope

The nesting counter is needed because gated admission calls queue replacement or launch accounting internally. It spans no suspension point and leaves the existing mutation lock, cancellation paths, and workload settings intact.
