### PR TITLE
Enable clang-tidy checks for argument comments and infinite loops

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,12 +1,14 @@
 ---
 Checks: >
   -*,
+  bugprone-argument-comment,
   bugprone-assignment-in-if-condition,
   bugprone-chained-comparison,
   bugprone-copy-constructor-init,
   bugprone-dangling-handle,
   bugprone-implicit-widening-of-multiplication-result,
   bugprone-inaccurate-erase,
+  bugprone-infinite-loop,
   bugprone-macro-repeated-side-effects,
   bugprone-misplaced-widening-cast,
   bugprone-move-forwarding-reference,

--- a/documentation/sphinx/source/clang-tidy.rst
+++ b/documentation/sphinx/source/clang-tidy.rst
@@ -10,11 +10,11 @@ This guide explains how to run ``clang-tidy`` locally so you can fix issues befo
 What clang-tidy checks
 ======================
 
-FoundationDB configures 48 named checks in the ``.clang-tidy`` file at the repository root. The
+FoundationDB configures 50 named checks in the ``.clang-tidy`` file at the repository root. The
 active set depends on the clang-tidy version and can be inspected with ``clang-tidy --list-checks``.
 The intent is to enable more as we go forward. Here are some example rules:
 
-* **29 Bugprone rules** -- catch potential runtime errors, including chained comparisons, swapped arguments, missed base-class copy construction, repeated macro argument evaluation, near-miss virtual overrides, dangling returned references, and incorrect erase/remove calls
+* **31 Bugprone rules** -- catch potential runtime errors, including mismatched argument comments, obvious infinite loops, chained comparisons, swapped arguments, missed base-class copy construction, repeated macro argument evaluation, near-miss virtual overrides, dangling returned references, and incorrect erase/remove calls
 * **1 C++ Core Guidelines rule** -- catch unsafe captures in coroutine lambdas (``cppcoreguidelines-avoid-capturing-lambda-coroutines``)
 * **2 Misc rules** -- catch redundant expressions and RAII objects held across coroutine suspension points
 * **4 Modernize rules** -- encourage modern C++ practices (e.g., ``modernize-use-auto``, ``modernize-use-override``)

--- a/fdbbackup/FileConverter.cpp
+++ b/fdbbackup/FileConverter.cpp
@@ -282,7 +282,7 @@ struct MutationFilesReadProgress : public ReferenceCounted<MutationFilesReadProg
 		fp->mutations.erase(fp->mutations.begin());
 		if (fp->mutations.empty()) {
 			// decode one more block
-			co_await decodeToVersion(fp, /*version=*/0, endVersion, getLogFile(fp->idx));
+			co_await decodeToVersion(fp, /*minVersion=*/0, endVersion, getLogFile(fp->idx));
 		}
 
 		if (fp->empty()) {

--- a/fdbbackup/backup.cpp
+++ b/fdbbackup/backup.cpp
@@ -2658,7 +2658,7 @@ Future<Void> queryBackup(const char* name,
 			}
 
 			// We only need to know all the mutation logs from `snapshotVersion` to `restoreVersion`.
-			fileSet = co_await bc->getRestoreSet(restoreVersion, keyRangesFilter, /*logOnly=*/true, snapshotVersion);
+			fileSet = co_await bc->getRestoreSet(restoreVersion, keyRangesFilter, /*logsOnly=*/true, snapshotVersion);
 		} else {
 			// When a snapshot version is not specified, we use the latest snapshot to restore to the `restoreVersion`.
 			fileSet = co_await bc->getRestoreSet(restoreVersion, keyRangesFilter);

--- a/fdbclient/BackupContainer.cpp
+++ b/fdbclient/BackupContainer.cpp
@@ -365,8 +365,8 @@ Future<std::vector<std::string>> listContainers_impl(std::string baseURL, Option
 			                               "dummy",
 			                               backupParams,
 			                               /*encryptionKeyFileName=*/{},
-			                               /*isBackup=*/true,
-			                               /*encryptionBlockSize=*/0);
+			                               /*encryptionBlockSize=*/0,
+			                               /*isBackup=*/true);
 
 			std::vector<std::string> results =
 			    co_await BackupContainerBlobStore::listURLs(bstore, dummy.getBucket(), dummy.getPrefix());

--- a/fdbclient/include/fdbclient/MutationLogReader.h
+++ b/fdbclient/include/fdbclient/MutationLogReader.h
@@ -106,8 +106,8 @@ public:
 	                                                   Version ev,
 	                                                   Key uid,
 	                                                   Key beginKey,
-	                                                   unsigned pd) {
-		Reference<MutationLogReader> self(new MutationLogReader(cx, bv, ev, uid, beginKey, pd));
+	                                                   unsigned pipelineDepth) {
+		Reference<MutationLogReader> self(new MutationLogReader(cx, bv, ev, uid, beginKey, pipelineDepth));
 		co_await self->initializePQ();
 		co_return self;
 	}

--- a/fdbserver/core/BulkLoadUtil.cpp
+++ b/fdbserver/core/BulkLoadUtil.cpp
@@ -607,7 +607,7 @@ Future<KeyRange> getBulkLoadJobFileManifestEntryFromJobManifestFile(
 						BulkLoadJobManifestFileHeader header(line);
 						headerProcessed = true;
 					} else {
-						mapRange = updateManifestEntryMap(line, range, mapRange, /*output=*/manifestEntryMap);
+						mapRange = updateManifestEntryMap(line, range, mapRange, /*manifestEntryMap=*/manifestEntryMap);
 					}
 				}
 				lineStart = pos + 1;
@@ -630,7 +630,7 @@ Future<KeyRange> getBulkLoadJobFileManifestEntryFromJobManifestFile(
 				// If we somehow only have one line and it's the header
 				BulkLoadJobManifestFileHeader header(leftover);
 			} else {
-				mapRange = updateManifestEntryMap(leftover, range, mapRange, /*output=*/manifestEntryMap);
+				mapRange = updateManifestEntryMap(leftover, range, mapRange, /*manifestEntryMap=*/manifestEntryMap);
 			}
 		}
 	} catch (Error& e) {

--- a/fdbserver/core/MoveKeys.cpp
+++ b/fdbserver/core/MoveKeys.cpp
@@ -3998,7 +3998,7 @@ Future<Void> cleanUpDataMove(Database occ,
 				                                                             cleanUpDataMoveParallelismLock,
 				                                                             keys,
 				                                                             ddEnabledState,
-				                                                             /*backgroundDelaySeconds=*/10));
+				                                                             /*delaySeconds=*/10));
 			} else {
 				TraceEvent(SevWarn, "CleanUpDataMoveNotFound", dataMoveId).errorUnsuppressed(e);
 			}

--- a/fdbserver/datadistributor/DataDistribution.cpp
+++ b/fdbserver/datadistributor/DataDistribution.cpp
@@ -2155,7 +2155,7 @@ Future<Void> fetchBulkLoadTaskManifestEntryMap(Reference<DataDistributor> self,
 		    localJobManifestFilePath,
 		    jobRange,
 		    self->ddId,
-		    /*output=*/self->bulkLoadJobManager.get().manifestEntryMap);
+		    /*manifestMap=*/self->bulkLoadJobManager.get().manifestEntryMap);
 		// It is possible that the bulkload job is using a data set that does not entirely contain the bulkload job
 		// range. In this case, we give up the bulkload job immediately without loading any range..
 		if (self->bulkLoadJobManager.get().jobState.getJobRange() != manifestMapRange) {

--- a/fdbserver/kvstore/VersionedBTree.cpp
+++ b/fdbserver/kvstore/VersionedBTree.cpp
@@ -10414,7 +10414,7 @@ TEST_CASE("Lredwood/correctness/btree") {
 	pager = new DWALPager(
 	    pageSize, extentSize, file, pageCacheBytes, remapCleanupWindowBytes, concurrentExtentReads, pagerMemoryOnly);
 
-	auto* btree = new VersionedBTree(pager, file, UID(), /*ServerDBInfo blah */ {});
+	auto* btree = new VersionedBTree(pager, file, UID(), /*db=*/{});
 	co_await btree->init();
 
 	DecodeBoundaryVerifier* pBoundaries = DecodeBoundaryVerifier::getVerifier(file);
@@ -10651,7 +10651,7 @@ TEST_CASE("Lredwood/correctness/btree") {
 				IPager2* pager = new DWALPager(
 				    pageSize, extentSize, file, pageCacheBytes, remapCleanupWindowBytes, concurrentExtentReads, false);
 
-				btree = new VersionedBTree(pager, file, UID(), /* something blah = */ {});
+				btree = new VersionedBTree(pager, file, UID(), /*db=*/{});
 
 				co_await btree->init();
 
@@ -10701,7 +10701,7 @@ TEST_CASE("Lredwood/correctness/btree") {
 		                                         pagerMemoryOnly),
 		                           file,
 		                           UID(),
-		                           /* blah = */ {});
+		                           /*db=*/{});
 
 		co_await btree->init();
 	}

--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -7585,7 +7585,7 @@ Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 				// A bulkload task can do file ingestion if the task range is aligned with manifests' range.
 				bool bulkloadCanIngestSSTFile = bulkLoadTaskState.canIngestFile();
 				co_await bulkLoadFetchKeyValueFileToLoad(
-				    data, bulkLoadLocalDir, bulkLoadTaskState, /*output=*/localBulkLoadFileSets);
+				    data, bulkLoadLocalDir, bulkLoadTaskState, /*localFileSets=*/localBulkLoadFileSets);
 				TraceEvent(bulkLoadVerboseEventSev(), "SSBulkLoadTaskFetchKey", data->thisServerID)
 				    .detail("DataMoveId", dataMoveId.toString())
 				    .detail("Range", keys)

--- a/fdbserver/workloads/GetEstimatedRangeSize.cpp
+++ b/fdbserver/workloads/GetEstimatedRangeSize.cpp
@@ -56,7 +56,7 @@ struct GetEstimatedRangeSizeWorkload : TestWorkload {
 		                 /*ratesAtKeyCounts=*/Promise<std::vector<std::pair<uint64_t, double>>>(),
 		                 /*keySaveIncrement=*/0,
 		                 /*keyCheckInterval=*/0.1,
-		                 /*startNodeIndex=*/0,
+		                 /*startNodeIdx=*/0,
 		                 /*endNodeIdx=*/0);
 	}
 

--- a/fdbserver/workloads/ValidateStorage.cpp
+++ b/fdbserver/workloads/ValidateStorage.cpp
@@ -116,7 +116,7 @@ struct ValidateStorage : TestWorkload {
 				                                     auditRange,
 				                                     type,
 				                                     storageEngine,
-				                                     /*timeoutSecond=*/300);
+				                                     /*timeoutSeconds=*/300);
 				auditId = auditId_;
 				TraceEvent("TestAuditStorageTriggered")
 				    .detail("Context", context)
@@ -257,7 +257,7 @@ struct ValidateStorage : TestWorkload {
 				UID auditId_ = co_await cancelAuditStorage(cx->getConnectionRecord(),
 				                                           type,
 				                                           auditId,
-				                                           /*timeoutSecond=*/300);
+				                                           /*timeoutSeconds=*/300);
 				ASSERT(auditId == auditId_);
 				TraceEvent("TestAuditStorageWaitCancelAuditStorageUntilComplete")
 				    .detail("AuditID", auditId)


### PR DESCRIPTION
## Summary

- Enable `bugprone-argument-comment` and `bugprone-infinite-loop` in `.clang-tidy` and update the documented check counts. `bugprone-macro-repeated-side-effects` is already enabled.
- Fix mismatched argument comments exposed by the new check. One call passed `true` as `encryptionBlockSize` and `0` as `isBackup`; pass the intended `0, true` instead.

## Validation

- LLVM 19 clang-tidy inventory of 596 translation units found 14 argument-comment warnings; all were addressed. Three unchanged AWS/RocksDB translation units could not parse without optional dependency headers in this inventory.
- The full configured clang-tidy policy with warnings as errors passed on all 12 changed or directly affected C++ files.
- `fdbclient_test --filter /backup/containers/blobstore/prefix --seed 12345`: 1 passed. The focused unit target was built with `BUILD_AWS_BACKUP=OFF`.
