### PR TITLE
Make database backup copy deadlines deterministic in simulation

### DIFF
--- a/fdbclient/DatabaseBackupAgent.cpp
+++ b/fdbclient/DatabaseBackupAgent.cpp
@@ -827,7 +827,7 @@ struct CopyLogRangeTaskFunc : TaskFuncBase {
 				if (nextVersionAfterBreak.present()) {
 					co_return nextVersionAfterBreak;
 				}
-				if (!isTimeoutOccurred && timer_monotonic() >= breakTime && lastKey.present()) {
+				if (!isTimeoutOccurred && g_network->timer_monotonic() >= breakTime && lastKey.present()) {
 					// timeout occurred
 					// continue to copy mutations with the
 					// same version before break because
@@ -879,7 +879,7 @@ struct CopyLogRangeTaskFunc : TaskFuncBase {
 		std::vector<Future<Void>> rc;
 		std::vector<Reference<FlowLock>> locks;
 		Version nextVersion = beginVersion;
-		double breakTime = timer_monotonic() + CLIENT_KNOBS->COPY_LOG_TASK_DURATION_SECONDS;
+		double breakTime = g_network->timer_monotonic() + CLIENT_KNOBS->COPY_LOG_TASK_DURATION_SECONDS;
 		int rangeN = 0;
 
 		while (true) {


### PR DESCRIPTION
Database backup log-copy tasks used the host monotonic clock for their deadline. Different execution speeds could change when a simulation split a task, producing an `UnseedMismatch` in `AtomicBackupToDBCorrectness`.

Use the network monotonic clock for both deadline creation and checking. Simulation follows deterministic time; Net2 uses the same production clock. Copy, retry, cancellation, and continuation logic are unchanged.

Validation:
- 23 focused client unit tests passed.
- The existing workload reproduced the mismatch before the fix and passed its paired determinism check with the fix while the second phase ran at roughly one-quarter speed.
- A supplemental paired run with a 1ms deadline and 10KB write batches passed with 125 matching deadline-driven splits per phase, including a slower second phase.

The existing workload supplies the regression coverage; no test source changes or new abstractions are needed.
