### PR TITLE
Register the shared Python test fixture once

### DIFF
--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -595,12 +595,6 @@ string(APPEND test_venv_cmd "&& ${test_venv_activate} ")
 string(APPEND test_venv_cmd "&& pip install --retries 9 -r ${CMAKE_SOURCE_DIR}/tests/TestRunner/requirements.txt ")
 string(APPEND test_venv_cmd "&& pip install ${CMAKE_SOURCE_DIR}/tests/TestRunner ")
 string(APPEND test_venv_cmd "&& pip install ${CMAKE_BINARY_DIR}/bindings/python ")
-add_test(
-  NAME test_venv_setup
-  COMMAND bash -c ${test_venv_cmd}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-set_tests_properties(test_venv_setup PROPERTIES FIXTURES_SETUP test_virtual_env_setup TIMEOUT 120)
-set_tests_properties(test_venv_setup PROPERTIES RESOURCE_LOCK TEST_VENV_SETUP)
 
 # Run the test command under Python venv as a cmd (Windows) or bash (Linux/Apple) script, which allows && or || chaining.
 function(add_python_venv_test)

--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -576,9 +576,7 @@ function(package_bindingtester)
   add_custom_target(bindingtester ALL DEPENDS ${tar_file} copy_bindingtester_binaries)
 endfunction()
 
-# Test for setting up Python venv for client tests.
-# Adding this test as a fixture to another test allows the use of non-native Python packages within client test scripts
-# by installing dependencies from requirements.txt
+# The test_venv_setup fixture is registered in tests/CMakeLists.txt.
 set(test_venv_dir ${CMAKE_BINARY_DIR}/tests/test_venv)
 if (WIN32)
   set(shell_cmd "cmd" CACHE INTERNAL "")
@@ -589,12 +587,6 @@ else()
   set(shell_opt "-c" CACHE INTERNAL "")
   set(test_venv_activate ". ${test_venv_dir}/bin/activate" CACHE INTERNAL "")
 endif()
-set(test_venv_cmd "")
-string(APPEND test_venv_cmd "${Python3_EXECUTABLE} -m venv ${test_venv_dir} ")
-string(APPEND test_venv_cmd "&& ${test_venv_activate} ")
-string(APPEND test_venv_cmd "&& pip install --retries 9 -r ${CMAKE_SOURCE_DIR}/tests/TestRunner/requirements.txt ")
-string(APPEND test_venv_cmd "&& pip install ${CMAKE_SOURCE_DIR}/tests/TestRunner ")
-string(APPEND test_venv_cmd "&& pip install ${CMAKE_BINARY_DIR}/bindings/python ")
 
 # Run the test command under Python venv as a cmd (Windows) or bash (Linux/Apple) script, which allows && or || chaining.
 function(add_python_venv_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,13 @@
 include(AddFdbTest)
 
+# The module is also included by fdbcli; register this shared fixture only once.
+add_test(
+  NAME test_venv_setup
+  COMMAND bash -c ${test_venv_cmd}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(test_venv_setup PROPERTIES FIXTURES_SETUP test_virtual_env_setup TIMEOUT 120)
+set_tests_properties(test_venv_setup PROPERTIES RESOURCE_LOCK TEST_VENV_SETUP)
+
 # We need some variables to configure the test setup
 set(ENABLE_BUGGIFY ON CACHE BOOL "Enable buggify for tests")
 set(ENABLE_SIMULATION_TESTS OFF CACHE BOOL "Enable simulation tests (useful if you can't run Joshua)")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,15 @@
 include(AddFdbTest)
 
+# Test for setting up Python venv for client tests.
+# Adding this test as a fixture to another test allows the use of non-native Python packages within client test scripts
+# by installing dependencies from requirements.txt
+set(test_venv_cmd "")
+string(APPEND test_venv_cmd "${Python3_EXECUTABLE} -m venv ${test_venv_dir} ")
+string(APPEND test_venv_cmd "&& ${test_venv_activate} ")
+string(APPEND test_venv_cmd "&& pip install --retries 9 -r ${CMAKE_SOURCE_DIR}/tests/TestRunner/requirements.txt ")
+string(APPEND test_venv_cmd "&& pip install ${CMAKE_SOURCE_DIR}/tests/TestRunner ")
+string(APPEND test_venv_cmd "&& pip install ${CMAKE_BINARY_DIR}/bindings/python ")
+
 # The module is also included by fdbcli; register this shared fixture only once.
 add_test(
   NAME test_venv_setup


### PR DESCRIPTION
## Summary

Register `test_venv_setup` once in `tests/CMakeLists.txt`. Both `fdbcli` and the client tests continue to require the same CTest fixture.

## Why

`AddFdbTest.cmake` is included by both `fdbcli` and `tests`. In the [Linux RHEL 9 run on #14017](https://github.com/apple/foundationdb/pull/14017#issuecomment-5561011533), two setup tests reinstalled into the same virtual environment. The second overlapped `trace_partial_file_suffix_test`, which failed importing `fdb_test_runner.cluster_args` before its test logic ran. This is independent of that PR's backup deadline change.

## Validation

- Linux Clang builds of the trace test and its cluster dependencies succeeded.
- `ctest -N -R '^test_venv_setup$'` lists one setup.
- `ctest -j 4 -R '^trace_partial_file_suffix_test$' --output-on-failure` passed both setup and the test (2/2).
- Selecting `single_process_fdbcli_tests` still includes the setup fixture.
