### PR TITLE
Decode versionstamp bytes without typed pointer casts

### DIFF
--- a/fdbclient/Tuple.cpp
+++ b/fdbclient/Tuple.cpp
@@ -21,6 +21,8 @@
 #include "fdbclient/Tuple.h"
 #include "flow/UnitTest.h"
 
+#include <cstring>
+
 const uint8_t VERSIONSTAMP_96_CODE = 0x33;
 const uint8_t USER_TYPE_START = 0x40;
 const uint8_t USER_TYPE_END = 0x4f;
@@ -596,6 +598,31 @@ TEST_CASE("/fdbclient/Tuple/unpack") {
 			throw e;
 		}
 	}
+
+	return Void();
+}
+
+TEST_CASE("/fdbclient/Tuple/versionstampBinaryLayout") {
+	const StringRef encoded = "\x01\x23\x45\x67\x89\xab\xcd\xef\x12\x34\x56\x78"_sr;
+	constexpr Version expectedVersion = 0x0123456789abcdef;
+	constexpr uint16_t expectedBatchNumber = 0x1234;
+	constexpr uint16_t expectedUserVersion = 0x5678;
+
+	TupleVersionstamp constructed(expectedVersion, expectedBatchNumber, expectedUserVersion);
+	ASSERT(StringRef(constructed.begin(), constructed.size()) == encoded);
+
+	Standalone<StringRef> storage = makeAlignedString(alignof(Version), encoded.size() + 1);
+	uint8_t* unaligned = mutateString(storage) + 1;
+	std::memcpy(unaligned, encoded.begin(), encoded.size());
+	TupleVersionstamp decoded{ StringRef(unaligned, encoded.size()) };
+	ASSERT(decoded.getVersion() == expectedVersion);
+	ASSERT(decoded.getBatchNumber() == expectedBatchNumber);
+	ASSERT(decoded.getUserVersion() == expectedUserVersion);
+
+	Versionstamp versionstamp{ Standalone<StringRef>(StringRef(unaligned, sizeof(Version) + sizeof(uint16_t)),
+		                                             storage.arena()) };
+	ASSERT(versionstamp.version == expectedVersion);
+	ASSERT(versionstamp.batchNumber == expectedBatchNumber);
 
 	return Void();
 }

--- a/fdbclient/Tuple.cpp
+++ b/fdbclient/Tuple.cpp
@@ -609,20 +609,20 @@ TEST_CASE("/fdbclient/Tuple/versionstampBinaryLayout") {
 	constexpr uint16_t expectedUserVersion = 0x5678;
 
 	TupleVersionstamp constructed(expectedVersion, expectedBatchNumber, expectedUserVersion);
-	ASSERT(StringRef(constructed.begin(), constructed.size()) == encoded);
+	ASSERT_EQ(StringRef(constructed.begin(), constructed.size()), encoded);
 
 	Standalone<StringRef> storage = makeAlignedString(alignof(Version), encoded.size() + 1);
 	uint8_t* unaligned = mutateString(storage) + 1;
 	std::memcpy(unaligned, encoded.begin(), encoded.size());
 	TupleVersionstamp decoded{ StringRef(unaligned, encoded.size()) };
-	ASSERT(decoded.getVersion() == expectedVersion);
-	ASSERT(decoded.getBatchNumber() == expectedBatchNumber);
-	ASSERT(decoded.getUserVersion() == expectedUserVersion);
+	ASSERT_EQ(decoded.getVersion(), expectedVersion);
+	ASSERT_EQ(decoded.getBatchNumber(), expectedBatchNumber);
+	ASSERT_EQ(decoded.getUserVersion(), expectedUserVersion);
 
 	Versionstamp versionstamp{ Standalone<StringRef>(StringRef(unaligned, sizeof(Version) + sizeof(uint16_t)),
 		                                             storage.arena()) };
-	ASSERT(versionstamp.version == expectedVersion);
-	ASSERT(versionstamp.batchNumber == expectedBatchNumber);
+	ASSERT_EQ(versionstamp.version, expectedVersion);
+	ASSERT_EQ(versionstamp.batchNumber, expectedBatchNumber);
 
 	return Void();
 }

--- a/fdbclient/TupleVersionstamp.cpp
+++ b/fdbclient/TupleVersionstamp.cpp
@@ -1,5 +1,7 @@
 #include "fdbclient/TupleVersionstamp.h"
 
+#include <cstring>
+
 TupleVersionstamp::TupleVersionstamp(StringRef str) {
 	if (str.size() != VERSIONSTAMP_TUPLE_SIZE) {
 		throw invalid_versionstamp_size();
@@ -10,23 +12,25 @@ TupleVersionstamp::TupleVersionstamp(StringRef str) {
 TupleVersionstamp::TupleVersionstamp(int64_t version, uint16_t batchNumber, uint16_t userVersion) {
 	data = makeString(VERSIONSTAMP_TUPLE_SIZE);
 	uint8_t* buf = mutateString(data);
-	*reinterpret_cast<int64_t*>(buf) = bigEndian64(version);
-	*reinterpret_cast<uint16_t*>(buf + sizeof(int64_t)) = bigEndian16(batchNumber);
-	*reinterpret_cast<uint16_t*>(buf + sizeof(int64_t) + sizeof(uint16_t)) = bigEndian16(userVersion);
+	const int64_t encodedVersion = bigEndian64(version);
+	const uint16_t encodedBatchNumber = bigEndian16(batchNumber);
+	const uint16_t encodedUserVersion = bigEndian16(userVersion);
+	std::memcpy(buf, &encodedVersion, sizeof(encodedVersion));
+	std::memcpy(buf + sizeof(encodedVersion), &encodedBatchNumber, sizeof(encodedBatchNumber));
+	std::memcpy(
+	    buf + sizeof(encodedVersion) + sizeof(encodedBatchNumber), &encodedUserVersion, sizeof(encodedUserVersion));
 }
 
 int16_t TupleVersionstamp::getBatchNumber() const {
-	const uint8_t* begin = data.begin();
-	begin += 8;
-	int16_t batchNumber = *(int16_t*)(begin);
+	int16_t batchNumber;
+	std::memcpy(&batchNumber, data.begin() + sizeof(int64_t), sizeof(batchNumber));
 	batchNumber = bigEndian16(batchNumber);
 	return batchNumber;
 }
 
 int16_t TupleVersionstamp::getUserVersion() const {
-	const uint8_t* begin = data.begin();
-	begin += 10;
-	int16_t userVersion = *(int16_t*)(begin);
+	int16_t userVersion;
+	std::memcpy(&userVersion, data.begin() + sizeof(int64_t) + sizeof(uint16_t), sizeof(userVersion));
 	userVersion = bigEndian16(userVersion);
 	return userVersion;
 }
@@ -36,8 +40,8 @@ const uint8_t* TupleVersionstamp::begin() const {
 }
 
 int64_t TupleVersionstamp::getVersion() const {
-	const uint8_t* begin = data.begin();
-	int64_t version = *(int64_t*)begin;
+	int64_t version;
+	std::memcpy(&version, data.begin(), sizeof(version));
 	version = bigEndian64(version);
 	return version;
 }

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <array>
 #include <cinttypes>
+#include <cstring>
 #include <regex>
 #include <set>
 #include <string>
@@ -1711,8 +1712,12 @@ struct Versionstamp {
 	Versionstamp(Version version, uint16_t batchNumber) : version(version), batchNumber(batchNumber) {}
 	explicit Versionstamp(Standalone<StringRef> str) {
 		ASSERT(str.size() == sizeof(Version) + sizeof(batchNumber));
-		version = bigEndian64(*reinterpret_cast<const Version*>(str.begin()));
-		batchNumber = bigEndian16(*reinterpret_cast<const uint16_t*>(str.begin() + sizeof(Version)));
+		Version encodedVersion;
+		uint16_t encodedBatchNumber;
+		std::memcpy(&encodedVersion, str.begin(), sizeof(encodedVersion));
+		std::memcpy(&encodedBatchNumber, str.begin() + sizeof(encodedVersion), sizeof(encodedBatchNumber));
+		version = bigEndian64(encodedVersion);
+		batchNumber = bigEndian16(encodedBatchNumber);
 	}
 
 	std::string toString() const { return fmt::format("{}.{}", version, batchNumber); }


### PR DESCRIPTION
## Summary

- Decode versionstamp fields by copying bytes into integer locals before the existing endian conversions, avoiding typed reads from byte buffers.
- Write tuple versionstamp fields with byte copies as well, preserving the 10-byte and 12-byte layouts.
- Add a known-byte round trip and an offset input case for both versionstamp representations.

## Validation

- `fdbclient_test -f /fdbclient/Tuple/`: 3/3 passed.
- `fdbclient_test`: 109/109 passed.
- Strict clang-tidy on the changed client files and clang-format checks passed.
