### PR TITLE
Account for overflow pages in SQLite lazy deletion

### DIFF
--- a/contrib/sqlite/btree.c
+++ b/contrib/sqlite/btree.c
@@ -7093,7 +7093,7 @@ SQLITE_PRIVATE int sqlite3BtreeLazyDelete(BtCursor* cursor,
                                           int* pagesDeleted) {
 	int pageNumber, cell, rc, subtree, count;
 	MemPage* page;
-	int empty;
+	int empty, reclaimedPages;
 	const void* ptr;
 	i64 tableKey = 0;
 	u32 freePagesBefore;
@@ -7169,7 +7169,8 @@ SQLITE_PRIVATE int sqlite3BtreeLazyDelete(BtCursor* cursor,
 		}
 
 		releasePage(page); // Required after getAndInitPage() above
-		*pagesDeleted += (int)(get4byte(&cursor->pBt->pPage1->aData[36]) - freePagesBefore);
+		reclaimedPages = get4byte(&cursor->pBt->pPage1->aData[36]) - freePagesBefore;
+		*pagesDeleted += reclaimedPages;
 	}
 
 	if (stackBegin[0]) {

--- a/contrib/sqlite/btree.c
+++ b/contrib/sqlite/btree.c
@@ -7096,10 +7096,11 @@ SQLITE_PRIVATE int sqlite3BtreeLazyDelete(BtCursor* cursor,
 	int empty;
 	const void* ptr;
 	i64 tableKey = 0;
+	u32 freePagesBefore;
 
 	*pagesDeleted = 0;
 
-	while (desiredPages--) {
+	while (*pagesDeleted < desiredPages) {
 		if (!stackBegin[0]) {
 			// Read one or more items from the back of cursor table into stack
 			rc = sqlite3BtreeLast(cursor, &empty);
@@ -7149,6 +7150,8 @@ SQLITE_PRIVATE int sqlite3BtreeLazyDelete(BtCursor* cursor,
 				}
 			}
 
+		// Reclaim a complete B-tree page, charging its overflow pages to the budget too.
+		freePagesBefore = get4byte(&cursor->pBt->pPage1->aData[36]);
 		// Free overflow pages
 		for (cell = 0; cell < page->nCell; cell++) {
 			rc = clearCell(page, findCell(page, cell));
@@ -7166,7 +7169,7 @@ SQLITE_PRIVATE int sqlite3BtreeLazyDelete(BtCursor* cursor,
 		}
 
 		releasePage(page); // Required after getAndInitPage() above
-		++(*pagesDeleted);
+		*pagesDeleted += (int)(get4byte(&cursor->pBt->pPage1->aData[36]) - freePagesBefore);
 	}
 
 	if (stackBegin[0]) {

--- a/contrib/sqlite/btree.h
+++ b/contrib/sqlite/btree.h
@@ -150,6 +150,7 @@ int sqlite3BtreeMovetoUnpacked(BtCursor*, UnpackedRecord* pUnKey, i64 intKey, in
 int sqlite3BtreeCursorHasMoved(BtCursor*, int*);
 int sqlite3BtreeDelete(BtCursor*);
 int sqlite3BtreeDeleteRange(BtCursor*, BtCursor*, int* stackBegin, int* stackEnd);
+// Counts reclaimed overflow pages too; completing one B-tree page may exceed desiredPages.
 int sqlite3BtreeLazyDelete(BtCursor*, int* stackBegin, int* stackEnd, int desiredPages, int* pagesDeleted);
 int sqlite3BtreeInsert(BtCursor*,
                        const void* pKey,

--- a/fdbserver/kvstore/KeyValueStoreSQLite.cpp
+++ b/fdbserver/kvstore/KeyValueStoreSQLite.cpp
@@ -1645,6 +1645,72 @@ void SQLiteDB::createFromScratch() {
 	}
 }
 
+TEST_CASE("/fdbserver/kvstore/SQLite/LazyDelete/OverflowBudgetAndResume") {
+	// The in-memory backend exercises the real cursor and lazy-free table without background cleanup races.
+	SQLiteDB db(":memory:", false, false);
+	db.createFromScratch();
+	const std::string value(32768, 'v');
+	{
+		Cursor cursor(db, true);
+		cursor.set(KeyValueRef("before"_sr, "left"_sr));
+		cursor.set(KeyValueRef("zzzz"_sr, "right"_sr));
+		for (int i = 0; i < 128; ++i) {
+			const std::string key = format("key/%04d", i);
+			cursor.set(KeyValueRef(StringRef(key), StringRef(value)));
+		}
+		cursor.commit();
+	}
+	{
+		Cursor cursor(db, true);
+		bool empty = true;
+		cursor.fastClear(KeyRangeRef("key/"_sr, "key0"_sr), empty);
+		ASSERT(!empty);
+		cursor.commit();
+	}
+	constexpr int budget = 2;
+	uint32_t freeBefore;
+	int firstBatch;
+	{
+		Cursor cursor(db, true);
+		freeBefore = db.freePages();
+		ASSERT(cursor.lazyDelete(0) == 0);
+		firstBatch = cursor.lazyDelete(budget);
+		ASSERT(firstBatch > budget);
+		IntKeyCursor pending(db, db.freetable, false);
+		int empty = 1;
+		db.checkError("BtreeFirst", sqlite3BtreeFirst(pending.cursor, &empty));
+		ASSERT(!empty);
+		// Roll back the partial reclamation, then repeat it in a new transaction.
+	}
+	{
+		Cursor cursor(db, true);
+		ASSERT(db.freePages() == freeBefore);
+		ASSERT(cursor.lazyDelete(budget) == firstBatch);
+		cursor.commit();
+	}
+	bool finished = false;
+	for (int batch = 0; batch < 256 && !finished; ++batch) {
+		Cursor cursor(db, true);
+		finished = cursor.lazyDelete(budget) < budget;
+		cursor.commit();
+	}
+	ASSERT(finished);
+	{
+		Cursor cursor(db, false);
+		ASSERT(cursor.moveTo("before"_sr) == 0);
+		ASSERT(decodeKV(cursor.getEncodedRow()).value == "left"_sr);
+		ASSERT(cursor.moveTo("zzzz"_sr) == 0);
+		ASSERT(decodeKV(cursor.getEncodedRow()).value == "right"_sr);
+		ASSERT(cursor.moveTo("key/0000"_sr) != 0);
+		IntKeyCursor pending(db, db.freetable, false);
+		int empty = 0;
+		db.checkError("BtreeFirst", sqlite3BtreeFirst(pending.cursor, &empty));
+		ASSERT(empty);
+		ASSERT(db.check(false) == 0);
+	}
+	return Void();
+}
+
 struct ThreadSafeCounter {
 	volatile int64_t counter;
 	ThreadSafeCounter() : counter(0) {}
@@ -1972,7 +2038,7 @@ private:
 			int64_t freeListSize = freeListPages;
 			while (!freeTableEmpty && freeListSize < SERVER_KNOBS->CHECK_FREE_PAGE_AMOUNT) {
 				int deletedPages = cursor->lazyDelete(SERVER_KNOBS->CHECK_FREE_PAGE_AMOUNT);
-				freeTableEmpty = (deletedPages != SERVER_KNOBS->CHECK_FREE_PAGE_AMOUNT);
+				freeTableEmpty = (deletedPages < SERVER_KNOBS->CHECK_FREE_PAGE_AMOUNT);
 				springCleaningStats.lazyDeletePages += deletedPages;
 
 				freeListSize = conn.freePages();
@@ -2031,7 +2097,7 @@ private:
 					    std::min(SERVER_KNOBS->SPRING_CLEANING_LAZY_DELETE_BATCH_SIZE,
 					             SERVER_KNOBS->SPRING_CLEANING_MAX_LAZY_DELETE_PAGES - workPerformed.lazyDeletePages));
 					int pagesDeleted = cursor->lazyDelete(pagesToDelete);
-					freeTableEmpty = (pagesDeleted != pagesToDelete);
+					freeTableEmpty = (pagesDeleted < pagesToDelete);
 					workPerformed.lazyDeletePages += pagesDeleted;
 					lazyDeleteTime += now() - begin;
 				} else {


### PR DESCRIPTION
SQLite lazy deletion budgets B-tree pages but previously did not charge the overflow pages reclaimed with them. Large values could therefore make one cleanup batch do much more work than requested and hold the writer for too long.

Count all pages reclaimed while completing each B-tree page, including its overflow chains. A complete page can still exceed the requested budget; callers now treat only a short batch as evidence that the lazy-free table is empty. Transaction boundaries, error handling, and fault injection are unchanged.

The focused regression uses the existing SQLiteDB and Cursor production paths with an in-memory backend, avoiding background-cleanup races without adding test hooks. It covers overflow accounting, zero-budget behavior, partial progress, rollback and resume, preservation of unrelated data, and B-tree integrity.

Validation: the regression passes with this change and fails on the original accounting at its overflow-budget assertion. The original SwizzledLargeApiCorrectness test configuration also passes with buggify and fault injection enabled. Its execution schedule changes, so the paired deterministic regression provides the narrow causal check.

