### PR TITLE
Reconcile uncertain S3 multipart completion

### DIFF
--- a/fdbclient/AsyncFileBlobStore.h
+++ b/fdbclient/AsyncFileBlobStore.h
@@ -155,7 +155,7 @@ public:
 		co_return etag;
 	}
 
-	Future<Void> doFinishUpload() {
+	Future<Void> doFinishUpload(int64_t totalSize) {
 		// If there is only 1 part then it has not yet been uploaded so just write the whole file at once.
 		if (m_parts.size() == 1) {
 			Reference<Part> part = m_parts.back();
@@ -183,7 +183,7 @@ public:
 		// No need to wait for the upload ID here because the above loop waited for all the parts and each part required
 		// the upload ID so it is ready
 		Optional<std::string> checksumSHA256 =
-		    co_await m_bstore->finishMultiPartUpload(m_bucket, m_object, m_upload_id.get(), partSet, m_cursor);
+		    co_await m_bstore->finishMultiPartUpload(m_bucket, m_object, m_upload_id.get(), partSet, totalSize);
 
 		// Log the checksum if present - this is just a hash of the multipart structure, not the object content
 		if (checksumSHA256.present()) {
@@ -199,7 +199,7 @@ public:
 	Future<Void> sync() override {
 		// Only initiate the finish operation once, and also prevent further writing.
 		if (!m_finished.isValid()) {
-			m_finished = doFinishUpload();
+			m_finished = doFinishUpload(m_cursor);
 			m_cursor = -1; // Cause future write attempts to fail
 		}
 

--- a/fdbclient/S3BlobStore.cpp
+++ b/fdbclient/S3BlobStore.cpp
@@ -20,6 +20,7 @@
 
 #include "fdbclient/S3BlobStore.h"
 
+#include <algorithm>
 #include <sstream>
 #include "fdbrpc/HTTP.h"
 #include "fdbclient/Knobs.h"
@@ -54,6 +55,8 @@
 #include "flow/CoroUtils.h"
 
 using namespace rapidxml;
+
+static constexpr const char* multipartUploadTokenHeader = "x-amz-meta-fdb-multipart-upload-token";
 
 std::string S3BlobStoreEndpoint::guessRegionFromDomain(std::string domain) {
 	// Special case for localhost/127.0.0.1 to prevent basic_string exception
@@ -115,6 +118,26 @@ S3BlobStoreEndpoint::S3BlobStoreEndpoint(std::string const& host,
 		throw std::string(
 		    "Failed to get region from host or parameter in url, region is required for aws v4 signature");
 	}
+}
+
+void S3BlobStoreEndpoint::rememberMultipartUploadToken(std::string const& uploadID, std::string const& token) {
+	if (!multipartUploadTokens.contains(uploadID) && multipartUploadTokens.size() == maxTrackedMultipartUploads) {
+		auto oldest =
+		    std::min_element(multipartUploadTokens.begin(),
+		                     multipartUploadTokens.end(),
+		                     [](auto const& a, auto const& b) { return a.second.sequence < b.second.sequence; });
+		multipartUploadTokens.erase(oldest);
+	}
+	multipartUploadTokens[uploadID] = { token, nextMultipartUploadSequence++ };
+}
+
+Optional<std::string> S3BlobStoreEndpoint::multipartUploadToken(std::string const& uploadID) const {
+	auto it = multipartUploadTokens.find(uploadID);
+	return it == multipartUploadTokens.end() ? Optional<std::string>() : Optional<std::string>(it->second.token);
+}
+
+void S3BlobStoreEndpoint::forgetMultipartUploadToken(std::string const& uploadID) {
+	multipartUploadTokens.erase(uploadID);
 }
 
 std::string S3BlobStoreEndpoint::getResourceURL(std::string resource, std::string params) const {
@@ -491,12 +514,15 @@ void S3BlobStoreEndpoint::simulateRequestFailure(std::string const& verb,
 	if (!g_network->isSimulated() || !buggify() || deterministicRandom()->random01() >= 0.1) {
 		return;
 	}
-	// Don't simulate token errors for multipart complete operations (POST with uploadId but no partNumber)
-	// because changing a successful 200 to 400 after the server has already completed and removed
-	// the upload causes the client to infinitely retry with a phantom upload ID.
+	// A completion response can be lost after the server commits and removes the upload ID.
+	// Model the next retry's NoSuchUpload response so reconciliation runs in simulation.
 	bool isMultipartComplete = verb == "POST" && resource.find("uploadId=") != std::string::npos &&
 	                           resource.find("partNumber=") == std::string::npos;
-	if (!isMultipartComplete) {
+	if (isMultipartComplete && r->code == 200 &&
+	    r->data.content.find("<CompleteMultipartUploadResult") != std::string::npos) {
+		r->code = 404;
+		r->data.content = "<Error><Code>NoSuchUpload</Code></Error>";
+	} else if (!isMultipartComplete) {
 		r->code = s3BadRequestCode;
 		simulatedTokenError = true;
 	}
@@ -1173,6 +1199,9 @@ static Future<std::string> beginMultiPartUpload_impl(Reference<S3BlobStoreEndpoi
 	std::string resource = bstore->constructResourcePath(bucket, object);
 	resource += "?uploads";
 	HTTP::Headers headers;
+	std::string token =
+	    (g_network->isSimulated() ? debugRandom() : nondeterministicRandom())->randomUniqueID().toString();
+	headers[multipartUploadTokenHeader] = token;
 	if (!CLIENT_KNOBS->BLOBSTORE_ENCRYPTION_TYPE.empty())
 		headers["x-amz-server-side-encryption"] = CLIENT_KNOBS->BLOBSTORE_ENCRYPTION_TYPE;
 	if (bstore->knobs.enable_object_integrity_check) {
@@ -1195,6 +1224,7 @@ static Future<std::string> beginMultiPartUpload_impl(Reference<S3BlobStoreEndpoi
 		if (result != nullptr && strcmp(result->name(), "InitiateMultipartUploadResult") == 0) {
 			xml_node<>* id = result->first_node("UploadId");
 			if (id != nullptr) {
+				bstore->rememberMultipartUploadToken(id->value(), token);
 				co_return id->value();
 			}
 		}
@@ -1270,12 +1300,62 @@ Future<std::string> S3BlobStoreEndpoint::uploadPart(std::string const& bucket,
 	                       contentMD5);
 }
 
+enum class MultipartCompletionStatus { Success, NoSuchUpload, Failure };
+
+static MultipartCompletionStatus parseMultipartCompletionResponse(int code, std::string const& body) {
+	if (code == 404) {
+		return parseErrorCodeFromS3(body) == "NoSuchUpload" ? MultipartCompletionStatus::NoSuchUpload
+		                                                    : MultipartCompletionStatus::Failure;
+	}
+	if (code != 200) {
+		return MultipartCompletionStatus::Failure;
+	}
+
+	try {
+		std::string content = body; // rapidxml modifies its input
+		xml_document<> doc;
+		doc.parse<0>(content.data());
+		xml_node<>* result = doc.first_node();
+		if (result != nullptr && strcmp(result->name(), "CompleteMultipartUploadResult") == 0 &&
+		    result->first_node("ETag") != nullptr && result->first_node("ETag")->value_size() > 0) {
+			return MultipartCompletionStatus::Success;
+		}
+	} catch (const rapidxml::parse_error&) {
+	}
+	return parseErrorCodeFromS3(body) == "NoSuchUpload" ? MultipartCompletionStatus::NoSuchUpload
+	                                                    : MultipartCompletionStatus::Failure;
+}
+
+static bool multipartObjectMatches(HTTP::IncomingResponse const& response,
+                                   std::string const& token,
+                                   int64_t totalSize) {
+	if (response.code != 200) {
+		return false;
+	}
+	auto it = response.data.headers.find(multipartUploadTokenHeader);
+	return it != response.data.headers.end() && it->second == token &&
+	       (totalSize <= 0 || response.data.contentLen == totalSize);
+}
+
+static Future<bool> completedMultipartObjectMatches(Reference<S3BlobStoreEndpoint> bstore,
+                                                    std::string bucket,
+                                                    std::string object,
+                                                    std::string token,
+                                                    int64_t totalSize) {
+	co_await bstore->requestRateRead->getAllowance(1);
+	HTTP::Headers headers;
+	std::string resource = bstore->constructResourcePath(bucket, object);
+	Reference<HTTP::IncomingResponse> r =
+	    co_await bstore->doRequest("HEAD", resource, headers, nullptr, 0, { 200, 404 });
+	co_return multipartObjectMatches(*r, token, totalSize);
+}
+
 Future<Optional<std::string>> finishMultiPartUpload_impl(Reference<S3BlobStoreEndpoint> bstore,
                                                          std::string bucket,
                                                          std::string object,
                                                          std::string uploadID,
                                                          S3BlobStoreEndpoint::MultiPartSetT parts,
-                                                         int64_t /*totalSize*/) {
+                                                         int64_t totalSize) {
 	UnsentPacketQueue part_list; // NonCopyable state var so must be declared at top of actor
 	co_await bstore->requestRateWrite->getAllowance(1);
 
@@ -1295,18 +1375,44 @@ Future<Optional<std::string>> finishMultiPartUpload_impl(Reference<S3BlobStoreEn
 	HTTP::Headers headers;
 	PacketWriter pw(part_list.getWriteBuffer(manifest.size()), nullptr, Unversioned());
 	pw.serializeBytes(manifest);
-	Reference<HTTP::IncomingResponse> r =
-	    co_await bstore->doRequest("POST", resource, headers, &part_list, manifest.size(), { 200 });
+	Optional<std::string> token = bstore->multipartUploadToken(uploadID);
+	Optional<Error> completionError;
+	MultipartCompletionStatus status = MultipartCompletionStatus::Failure;
+	try {
+		Reference<HTTP::IncomingResponse> r =
+		    co_await bstore->doRequest("POST", resource, headers, &part_list, manifest.size(), { 200, 404 });
+		status = parseMultipartCompletionResponse(r->code, r->data.content);
+	} catch (Error& e) {
+		if (e.code() == error_code_actor_cancelled || e.code() == error_code_broken_promise) {
+			throw;
+		}
+		completionError = e;
+	}
 
-	// The XML response contains a ChecksumSHA256 field, but this is just a hash of the multipart
-	// structure, not the actual object content, so it's useless for integrity verification.
-	// We skip parsing it to avoid wasted CPU cycles.
+	if (status == MultipartCompletionStatus::Success) {
+		bstore->forgetMultipartUploadToken(uploadID);
+		co_return Optional<std::string>();
+	}
 
-	// TODO:  In the event that the client times out just before the request completes (so the client is unaware) then
-	// the next retry will see error 400.  That could be detected and handled gracefully by HEAD'ing the object before
-	// upload to get its (possibly nonexistent) eTag, then if an error 400 is seen then retrieve the eTag again and if
-	// it has changed then consider the finish complete.
-	co_return Optional<std::string>();
+	if (token.present() && (status == MultipartCompletionStatus::NoSuchUpload || completionError.present())) {
+		try {
+			if (co_await completedMultipartObjectMatches(bstore, bucket, object, token.get(), totalSize)) {
+				bstore->forgetMultipartUploadToken(uploadID);
+				TraceEvent("S3MultipartCompletionReconciled").detail("Bucket", bucket).detail("Object", object);
+				co_return Optional<std::string>();
+			}
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled || e.code() == error_code_broken_promise) {
+				throw;
+			}
+			// A failed HEAD cannot establish that the object belongs to this upload.
+		}
+	}
+
+	if (completionError.present()) {
+		throw completionError.get();
+	}
+	throw http_request_failed();
 }
 
 Future<Optional<std::string>> S3BlobStoreEndpoint::finishMultiPartUpload(std::string const& bucket,
@@ -1322,6 +1428,7 @@ Future<Void> abortMultiPartUpload_impl(Reference<S3BlobStoreEndpoint> bstore,
                                        std::string bucket,
                                        std::string object,
                                        std::string uploadID) {
+	bstore->forgetMultipartUploadToken(uploadID);
 	co_await bstore->requestRateWrite->getAllowance(1);
 
 	std::string resource = bstore->constructResourcePath(bucket, object);
@@ -1695,5 +1802,42 @@ TEST_CASE("/backup/s3/parseErrorCodeFromS3") {
 		ASSERT(parseErrorCodeFromS3("Internal Server Error").empty());
 	}
 
+	return Void();
+}
+
+TEST_CASE("/backup/s3/multipartCompletionResponse") {
+	const std::string success = "<CompleteMultipartUploadResult><ETag>\"etag\"</ETag>"
+	                            "</CompleteMultipartUploadResult>";
+	const std::string noSuchUpload = "<Error><Code>NoSuchUpload</Code></Error>";
+	const std::string invalidPart = "<Error><Code>InvalidPart</Code></Error>";
+
+	ASSERT(parseMultipartCompletionResponse(200, success) == MultipartCompletionStatus::Success);
+	ASSERT(parseMultipartCompletionResponse(200, noSuchUpload) == MultipartCompletionStatus::NoSuchUpload);
+	ASSERT(parseMultipartCompletionResponse(200, invalidPart) == MultipartCompletionStatus::Failure);
+	ASSERT(parseMultipartCompletionResponse(404, noSuchUpload) == MultipartCompletionStatus::NoSuchUpload);
+	ASSERT(parseMultipartCompletionResponse(404, invalidPart) == MultipartCompletionStatus::Failure);
+	ASSERT(parseMultipartCompletionResponse(200, "<CompleteMultipartUploadResult/>") ==
+	       MultipartCompletionStatus::Failure);
+	ASSERT(parseMultipartCompletionResponse(200,
+	                                        "<CompleteMultipartUploadResult><ETag/></CompleteMultipartUploadResult>") ==
+	       MultipartCompletionStatus::Failure);
+	ASSERT(parseMultipartCompletionResponse(200, "<CompleteMultipartUploadResult") ==
+	       MultipartCompletionStatus::Failure);
+	return Void();
+}
+
+TEST_CASE("/backup/s3/multipartCompletionIdentity") {
+	HTTP::IncomingResponse response;
+	response.code = 404;
+	response.data.contentLen = 10;
+	response.data.headers[multipartUploadTokenHeader] = "our-upload";
+	ASSERT(!multipartObjectMatches(response, "our-upload", 10));
+
+	response.code = 200;
+	ASSERT(multipartObjectMatches(response, "our-upload", 10));
+	ASSERT(!multipartObjectMatches(response, "other-upload", 10));
+	ASSERT(!multipartObjectMatches(response, "our-upload", 11));
+	response.data.headers.erase(multipartUploadTokenHeader);
+	ASSERT(!multipartObjectMatches(response, "our-upload", 10));
 	return Void();
 }

--- a/fdbclient/S3Client.cpp
+++ b/fdbclient/S3Client.cpp
@@ -492,7 +492,7 @@ static Future<Void> copyUpFile(Reference<S3BlobStoreEndpoint> endpoint,
 			}
 
 			Optional<std::string> s3Checksum =
-			    co_await endpoint->finishMultiPartUpload(bucket, objectName, uploadID, etagMap);
+			    co_await endpoint->finishMultiPartUpload(bucket, objectName, uploadID, etagMap, size);
 
 			// Log the S3 checksum if present
 			if (s3Checksum.present()) {

--- a/fdbclient/include/fdbclient/S3BlobStore.h
+++ b/fdbclient/include/fdbclient/S3BlobStore.h
@@ -183,4 +183,19 @@ public:
 	                           std::string const& object,
 	                           std::map<std::string, std::string> const& tags);
 	Future<std::map<std::string, std::string>> getObjectTags(std::string const& bucket, std::string const& object);
+
+	void rememberMultipartUploadToken(std::string const& uploadID, std::string const& token);
+	Optional<std::string> multipartUploadToken(std::string const& uploadID) const;
+	void forgetMultipartUploadToken(std::string const& uploadID);
+
+private:
+	// A completion retry may outlive the response to the original request. Only this upload's
+	// metadata token can identify the committed object after S3 removes its upload ID.
+	struct MultipartUploadToken {
+		std::string token;
+		uint64_t sequence;
+	};
+	static constexpr size_t maxTrackedMultipartUploads = 4096;
+	std::map<std::string, MultipartUploadToken> multipartUploadTokens;
+	uint64_t nextMultipartUploadSequence = 0;
 };

--- a/fdbserver/mocks3/MockS3Server.cpp
+++ b/fdbserver/mocks3/MockS3Server.cpp
@@ -1666,8 +1666,10 @@ TEST_CASE("/MockS3Server/multipartCompletionMetadata") {
 	UnsentPacketQueue completeBody;
 	auto completeResponse = makeReference<HTTP::OutgoingResponse>();
 	completeResponse->data.content = &completeBody;
+	std::map<std::string, std::string> firstQueryParams;
+	firstQueryParams["uploadId"] = firstID;
 	co_await MockS3ServerImpl::handleMultipartComplete(
-	    &server, complete, completeResponse, "bucket", "object", { { "uploadId", firstID } });
+	    &server, complete, completeResponse, "bucket", "object", firstQueryParams);
 	ASSERT_EQ(completeResponse->code, 200);
 	ASSERT(storage.multipartUploads.find(firstID) == storage.multipartUploads.end());
 
@@ -1687,8 +1689,10 @@ TEST_CASE("/MockS3Server/multipartCompletionMetadata") {
 
 	// A later same-key completion must not be attributed to the first upload.
 	storage.multipartUploads[secondID].parts[1] = { "etag", "other data" };
+	std::map<std::string, std::string> secondQueryParams;
+	secondQueryParams["uploadId"] = secondID;
 	co_await MockS3ServerImpl::handleMultipartComplete(
-	    &server, complete, completeResponse, "bucket", "object", { { "uploadId", secondID } });
+	    &server, complete, completeResponse, "bucket", "object", secondQueryParams);
 	UnsentPacketQueue secondHeadBody;
 	auto secondHeadResponse = makeReference<HTTP::OutgoingResponse>();
 	secondHeadResponse->data.content = &secondHeadBody;

--- a/fdbserver/mocks3/MockS3Server.cpp
+++ b/fdbserver/mocks3/MockS3Server.cpp
@@ -255,6 +255,12 @@ static std::string serializeObjectMeta(const MockS3GlobalStorage::ObjectData& ob
 
 	doc.AddMember("etag", Value(obj.etag.c_str(), allocator), allocator);
 	doc.AddMember("lastModified", obj.lastModified, allocator);
+	Value headersObj(kObjectType);
+	for (const auto& header : obj.headers) {
+		headersObj.AddMember(
+		    Value(header.first.c_str(), allocator), Value(header.second.c_str(), allocator), allocator);
+	}
+	doc.AddMember("headers", headersObj, allocator);
 
 	Value tagsObj(kObjectType);
 	for (const auto& tag : obj.tags) {
@@ -278,6 +284,12 @@ static void deserializeObjectMeta(const std::string& jsonStr, MockS3GlobalStorag
 		obj.etag = doc["etag"].GetString();
 	if (doc.HasMember("lastModified") && doc["lastModified"].IsNumber())
 		obj.lastModified = doc["lastModified"].GetDouble();
+	if (doc.HasMember("headers") && doc["headers"].IsObject()) {
+		for (auto& h : doc["headers"].GetObject()) {
+			if (h.value.IsString())
+				obj.headers[h.name.GetString()] = h.value.GetString();
+		}
+	}
 	if (doc.HasMember("tags") && doc["tags"].IsObject()) {
 		for (auto& m : doc["tags"].GetObject()) {
 			if (m.value.IsString())
@@ -296,6 +308,12 @@ static std::string serializeMultipartState(const MockS3GlobalStorage::MultipartU
 	doc.AddMember("bucket", Value(upload.bucket.c_str(), allocator), allocator);
 	doc.AddMember("object", Value(upload.object.c_str(), allocator), allocator);
 	doc.AddMember("initiated", upload.initiated, allocator);
+	Value metadataObj(kObjectType);
+	for (const auto& header : upload.metadata) {
+		metadataObj.AddMember(
+		    Value(header.first.c_str(), allocator), Value(header.second.c_str(), allocator), allocator);
+	}
+	doc.AddMember("metadata", metadataObj, allocator);
 
 	Value partsArray(kArrayType);
 	for (const auto& part : upload.parts) {
@@ -325,6 +343,12 @@ static void deserializeMultipartState(const std::string& jsonStr, MockS3GlobalSt
 		upload.object = doc["object"].GetString();
 	if (doc.HasMember("initiated") && doc["initiated"].IsNumber())
 		upload.initiated = doc["initiated"].GetDouble();
+	if (doc.HasMember("metadata") && doc["metadata"].IsObject()) {
+		for (auto& h : doc["metadata"].GetObject()) {
+			if (h.value.IsString())
+				upload.metadata[h.name.GetString()] = h.value.GetString();
+		}
+	}
 	if (doc.HasMember("parts") && doc["parts"].IsArray()) {
 		for (auto& partVal : doc["parts"].GetArray()) {
 			if (partVal.HasMember("partNum") && partVal["partNum"].IsInt() && partVal.HasMember("etag") &&
@@ -755,12 +779,14 @@ public:
 
 		TraceEvent("MockS3MultipartStart").detail("Bucket", bucket).detail("Object", object);
 
-		// Check if there's already an in-progress upload for this bucket/object
-		// This makes multipart initiation idempotent - retries return the same upload ID
-		// This matches real S3 behavior where you can have multiple concurrent uploads for the same object
+		// A retry of the same initiation can reuse its upload ID. A different token must
+		// create a separate upload, even when the object key is the same.
+		auto token = req->data.headers.find("x-amz-meta-fdb-multipart-upload-token");
 		std::string existingUploadId;
 		for (const auto& pair : getGlobalStorage().multipartUploads) {
-			if (pair.second.bucket == bucket && pair.second.object == object) {
+			if (pair.second.bucket == bucket && pair.second.object == object &&
+			    (token == req->data.headers.end() || (pair.second.metadata.contains(token->first) &&
+			                                          pair.second.metadata.at(token->first) == token->second))) {
 				existingUploadId = pair.first;
 				TraceEvent("MockS3MultipartStartIdempotent")
 				    .detail("Bucket", bucket)
@@ -776,6 +802,9 @@ public:
 			// No need to persist - already exists and was persisted on first creation
 		} else {
 			MultipartUpload upload(bucket, object);
+			if (token != req->data.headers.end()) {
+				upload.metadata[token->first] = token->second;
+			}
 			uploadId = upload.uploadId;
 			getGlobalStorage().multipartUploads[uploadId] = std::move(upload);
 			TraceEvent("MockS3MultipartStarted").detail("UploadId", uploadId);
@@ -880,6 +909,7 @@ public:
 
 		// Create final object
 		ObjectData obj(combinedContent);
+		obj.headers = uploadIter->second.metadata;
 		getGlobalStorage().buckets[bucket][object] = std::move(obj);
 
 		TraceEvent("MockS3MultipartFinalObject")
@@ -1218,6 +1248,9 @@ public:
 		response->data.headers["ETag"] = etag;
 		response->data.headers["Content-Length"] = std::to_string(contentSize);
 		response->data.headers["Content-Type"] = "binary/octet-stream";
+		for (const auto& header : obj.headers) {
+			response->data.headers[header.first] = header.second;
+		}
 		// HEAD requests need contentLen set to actual size for headers
 		response->data.contentLen = contentSize; // This controls ResponseContentSize in HTTP logs
 
@@ -1587,6 +1620,84 @@ Future<Void> startMockS3Server(NetworkAddress listenAddress) {
 		TraceEvent(SevError, "MockS3ServerStartError").error(e).detail("ListenAddress", listenAddress.toString());
 		throw;
 	}
+}
+
+TEST_CASE("/MockS3Server/multipartCompletionMetadata") {
+	auto& storage = getGlobalStorage();
+	storage.clearStorage();
+	bool persistenceEnabled = storage.persistenceEnabled;
+	storage.persistenceEnabled = false;
+	MockS3ServerImpl server;
+	const std::string header = "x-amz-meta-fdb-multipart-upload-token";
+	storage.buckets["bucket"]["object"] = MockS3GlobalStorage::ObjectData("old object");
+	ASSERT(!storage.buckets.at("bucket").at("object").headers.contains(header));
+
+	auto start = makeReference<HTTP::IncomingRequest>();
+	start->data.headers[header] = "first-token";
+	UnsentPacketQueue startBody;
+	auto startResponse = makeReference<HTTP::OutgoingResponse>();
+	startResponse->data.content = &startBody;
+	co_await MockS3ServerImpl::handleMultipartStart(&server, start, startResponse, "bucket", "object");
+	ASSERT_EQ(storage.multipartUploads.size(), 1);
+	std::string firstID = storage.multipartUploads.begin()->first;
+
+	// A lost initiation response returns the same upload, but an independent upload
+	// for the same key must retain a different identity.
+	co_await MockS3ServerImpl::handleMultipartStart(&server, start, startResponse, "bucket", "object");
+	ASSERT_EQ(storage.multipartUploads.size(), 1);
+	start->data.headers[header] = "second-token";
+	co_await MockS3ServerImpl::handleMultipartStart(&server, start, startResponse, "bucket", "object");
+	ASSERT_EQ(storage.multipartUploads.size(), 2);
+	std::string secondID;
+	for (const auto& upload : storage.multipartUploads) {
+		if (upload.first != firstID) {
+			secondID = upload.first;
+		}
+	}
+	ASSERT(!secondID.empty());
+
+	MockS3GlobalStorage::MultipartUpload restored;
+	deserializeMultipartState(serializeMultipartState(storage.multipartUploads.at(firstID)), restored);
+	ASSERT_EQ(restored.metadata.at(header), "first-token");
+	restored.parts[1] = { "etag", "new object" };
+	storage.multipartUploads[firstID] = std::move(restored);
+
+	auto complete = makeReference<HTTP::IncomingRequest>();
+	UnsentPacketQueue completeBody;
+	auto completeResponse = makeReference<HTTP::OutgoingResponse>();
+	completeResponse->data.content = &completeBody;
+	co_await MockS3ServerImpl::handleMultipartComplete(
+	    &server, complete, completeResponse, "bucket", "object", { { "uploadId", firstID } });
+	ASSERT_EQ(completeResponse->code, 200);
+	ASSERT(storage.multipartUploads.find(firstID) == storage.multipartUploads.end());
+
+	MockS3GlobalStorage::ObjectData restoredObject("new object");
+	deserializeObjectMeta(serializeObjectMeta(storage.buckets.at("bucket").at("object")), restoredObject);
+	ASSERT_EQ(restoredObject.headers.at(header), "first-token");
+	storage.buckets["bucket"]["object"] = std::move(restoredObject);
+
+	auto head = makeReference<HTTP::IncomingRequest>();
+	UnsentPacketQueue headBody;
+	auto headResponse = makeReference<HTTP::OutgoingResponse>();
+	headResponse->data.content = &headBody;
+	co_await MockS3ServerImpl::handleHeadObject(&server, head, headResponse, "bucket", "object");
+	ASSERT_EQ(headResponse->code, 200);
+	ASSERT_EQ(headResponse->data.headers.at(header), "first-token");
+	ASSERT_EQ(headResponse->data.contentLen, 10);
+
+	// A later same-key completion must not be attributed to the first upload.
+	storage.multipartUploads[secondID].parts[1] = { "etag", "other data" };
+	co_await MockS3ServerImpl::handleMultipartComplete(
+	    &server, complete, completeResponse, "bucket", "object", { { "uploadId", secondID } });
+	UnsentPacketQueue secondHeadBody;
+	auto secondHeadResponse = makeReference<HTTP::OutgoingResponse>();
+	secondHeadResponse->data.content = &secondHeadBody;
+	co_await MockS3ServerImpl::handleHeadObject(&server, head, secondHeadResponse, "bucket", "object");
+	ASSERT_EQ(secondHeadResponse->data.headers.at(header), "second-token");
+	ASSERT_EQ(secondHeadResponse->data.contentLen, 10);
+	storage.clearStorage();
+	storage.persistenceEnabled = persistenceEnabled;
+	co_return;
 }
 
 // Clear all MockS3 global storage - called at the start of each simulation test


### PR DESCRIPTION
## Summary

- Attach a unique upload token as S3 object metadata at multipart initiation. If completion returns `NoSuchUpload` or a transport error, confirm the committed object with a HEAD request that matches the token and known object size before reporting success.
- Parse the completion XML even when HTTP returns 200, since S3 can embed an error in that response. Preserve a retryable failure when completion cannot be established.
- Persist and expose the metadata in MockS3, including distinct concurrent uploads for the same object key.

## Validation

- `fdbclient_test -f /backup/s3/multipartCompletion`: 2 passed.
- `fdbserver_mocks3_test -f /MockS3Server/multipartCompletionMetadata`: 1 passed.
- S3Client simulation with buggify enabled: 20 passes. These runs did not trigger the synthetic lost-completion-response branch; the unit tests cover response classification, identity checks, and MockS3 metadata lifecycle.

Reconciliation requires permission to HEAD the object. A missing or different metadata token, a mismatched known size, or a failed HEAD preserves the failure for the caller rather than treating another object as this upload.
