### PR TITLE
Scope keepalive test allocations to their thread

### DIFF
--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -31,6 +31,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <thread>
 #include <unordered_map>
 
 #ifdef WIN32
@@ -309,10 +310,10 @@ namespace keepalive_allocator {
 
 namespace detail {
 
-std::set<void*> g_allocatedSet;
-std::set<void*> g_freedSet;
-std::vector<std::pair<const uint8_t*, int>> g_wipedSet;
-bool g_active = false;
+thread_local std::set<void*> g_allocatedSet;
+thread_local std::set<void*> g_freedSet;
+thread_local std::vector<std::pair<const uint8_t*, int>> g_wipedSet;
+thread_local bool g_active = false;
 
 } // namespace detail
 
@@ -368,6 +369,33 @@ std::vector<std::pair<const uint8_t*, int>> const& getWipedAreaSet() {
 }
 
 } // namespace keepalive_allocator
+
+TEST_CASE("/flow/FastAlloc/KeepaliveScopeThreadIsolation") {
+	std::atomic<bool> start{ false };
+	std::atomic<bool> allocated{ false };
+	std::atomic<bool> release{ false };
+	std::thread otherThread([&] {
+		while (!start.load(std::memory_order_acquire)) {
+			std::this_thread::yield();
+		}
+		auto* memory = allocateAndMaybeKeepalive(64);
+		allocated.store(true, std::memory_order_release);
+		while (!release.load(std::memory_order_acquire)) {
+			std::this_thread::yield();
+		}
+		freeOrMaybeKeepalive(memory);
+	});
+	{
+		keepalive_allocator::ActiveScope scope;
+		start.store(true, std::memory_order_release);
+		while (!allocated.load(std::memory_order_acquire)) {
+			std::this_thread::yield();
+		}
+	}
+	release.store(true, std::memory_order_release);
+	otherThread.join();
+	return Void();
+}
 
 template <int Size>
 void* FastAllocator<Size>::allocate() {

--- a/flow/include/flow/FastAlloc.h
+++ b/flow/include/flow/FastAlloc.h
@@ -186,19 +186,16 @@ void countedDelete(size_t nbytes, void* ptr);
 namespace keepalive_allocator {
 
 namespace detail {
-extern bool g_active;
+extern thread_local bool g_active;
 } // namespace detail
 
 inline bool isActive() noexcept {
 	return detail::g_active;
 }
 
-// While this scope is active, default allocate() and free() function is overridden for Arena and PacketBuffer to test
-// correct post-use memory policy: e.g. secure deletion of sensitive contents. Any (de)allocation of ArenaBlock and
-// PacketBuffer is tracked while this scope is active. To ensure correct state management, at most one instance of this
-// object may exist at any given time. Any tracked allocation during this scope must be freed BEFORE the scope
-// destructs. Any trackable (ArenaBlock, PacketBuffer) allocation before the scope must be freed AFTER the scope
-// destructs.
+// While this scope is active on the current thread, ArenaBlock and PacketBuffer allocations are kept alive to test
+// post-use memory policy, such as secure deletion of sensitive contents. At most one scope may exist per thread.
+// Tracked allocations must be freed before the scope destructs; allocations made before it must be freed afterward.
 class ActiveScope {
 public:
 	ActiveScope();


### PR DESCRIPTION
## Summary

- Keep the test-only keepalive allocator's active flag and tracked allocations on the thread that owns the scope. An unrelated runtime thread can otherwise allocate during a scope and release afterward, making the scope's allocation check fail.
- Add a regression that holds an allocation on another thread across the scope boundary.

## Validation

- Clang `flow_test --filter /flow/FastAlloc/KeepaliveScopeThreadIsolation --seed 1`: 1 passed.
- Clang `flow_test --seed 1`: 195 passed, including `/flow/Arena/Secure`.
- `clang-format --dry-run --Werror` on the changed files.
