### PR TITLE
Serialize debuglink updates before packaging executables

### DIFF
--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -249,7 +249,7 @@ function(stage_correctness_package)
 
   add_custom_command(
     OUTPUT ${package_files}
-    DEPENDS ${package_dependencies}
+    DEPENDS strip_only_fdbserver ${package_dependencies}
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/CMakeCache.txt ${STAGE_OUT_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy ${copy_sources} ${STAGE_OUT_DIR}/bin
     COMMENT "Copying files for ${STAGE_CONTEXT} package"

--- a/cmake/FlowCommands.cmake
+++ b/cmake/FlowCommands.cmake
@@ -129,21 +129,26 @@ function(strip_debug_symbols target)
   endif()
   set(out_file "${path}/${out_name}")
   list(APPEND strip_command -o "${out_file}")
-  add_custom_command(
-    OUTPUT "${out_file}"
-    COMMAND ${strip_command} $<TARGET_FILE:${target}>
-    DEPENDS ${target}
-    COMMENT "Stripping symbols from ${target}")
-  add_custom_target(strip_only_${target} DEPENDS ${out_file})
   if(is_exec AND NOT APPLE)
+    # The debuglink command rewrites out_file, so it must finish before consumers copy it.
     add_custom_command(
-      OUTPUT "${out_file}.debug"
-      DEPENDS strip_only_${target}
+      OUTPUT "${out_file}" "${out_file}.debug"
+      COMMAND ${strip_command} $<TARGET_FILE:${target}>
       COMMAND objcopy --verbose --only-keep-debug $<TARGET_FILE:${target}>
               "${out_file}.debug"
       COMMAND objcopy --verbose --add-gnu-debuglink="${out_file}.debug"
               "${out_file}"
-      COMMENT "Copy debug symbols to ${out_name}.debug")
+      DEPENDS ${target}
+      COMMENT "Stripping symbols and copying debug symbols from ${target}")
+  else()
+    add_custom_command(
+      OUTPUT "${out_file}"
+      COMMAND ${strip_command} $<TARGET_FILE:${target}>
+      DEPENDS ${target}
+      COMMENT "Stripping symbols from ${target}")
+  endif()
+  add_custom_target(strip_only_${target} DEPENDS "${out_file}")
+  if(is_exec AND NOT APPLE)
     add_custom_target(strip_${target} DEPENDS "${out_file}.debug")
   else()
     add_custom_target(strip_${target})

--- a/cmake/FlowCommands.cmake
+++ b/cmake/FlowCommands.cmake
@@ -147,13 +147,14 @@ function(strip_debug_symbols target)
       DEPENDS ${target}
       COMMENT "Stripping symbols from ${target}")
   endif()
-  add_custom_target(strip_only_${target} DEPENDS "${out_file}")
   if(is_exec AND NOT APPLE)
-    add_custom_target(strip_${target} DEPENDS "${out_file}.debug")
+    # Keep both outputs in one target so Makefile builds cannot run this command twice.
+    add_custom_target(strip_only_${target} DEPENDS "${out_file}" "${out_file}.debug")
   else()
-    add_custom_target(strip_${target})
-    add_dependencies(strip_${target} strip_only_${target})
+    add_custom_target(strip_only_${target} DEPENDS "${out_file}")
   endif()
+  add_custom_target(strip_${target})
+  add_dependencies(strip_${target} strip_only_${target})
   add_dependencies(strip_targets strip_${target})
 endfunction()
 


### PR DESCRIPTION
## Summary

- Run Linux executable stripping, debug symbol extraction, and the in-place GNU debuglink update in one CMake custom command.
- Declare both the stripped executable and `.debug` file as outputs, so package consumers wait until the executable is complete.

## Motivation

Correctness packaging could copy `packages/bin/fdbserver` while `objcopy --add-gnu-debuglink` rewrote it. In a Clang CI run, the staged executable was 14.4 MB while the completed producer file was 92.5 MB, so simulation tests could not start or produce traces.

## Validation

- Clang `package_tests_u` reached the combined debuglink command before correctness staging and archived the resulting executable with zero compilation failures. The outer build wrapper returned 1 after packaging.
- The archive's `bin/fdbserver` matched the completed producer byte for byte and started successfully.
- The packaged `NativeCdcReplyChunking.toml` simulation with seed `3625122440`, buggify on, and fault injection on passed (1 test, 0 failures).
