### PR TITLE
remove SECURITY.md in this repo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,0 @@
-# Security issues
-
-To report a security issue, please **DO NOT** start by filing a public issue or posting to the forums. Instead, use GitHub's private vulnerability reporting to [report a vulnerability](https://github.com/apple/foundationdb/security/advisories/new). Only the maintainers can see the report, and we will follow up with you there.


### PR DESCRIPTION
this repo should inherit the organization-wide policy in https://github.com/apple/.github/blob/main/SECURITY.md