### PR TITLE
[release-7.4] serialize executable debuglink updates with stripping

### DIFF
--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -245,6 +245,7 @@ function(stage_correctness_package)
             ${CMAKE_BINARY_DIR}/lib/coverage.flow.xml
             # ${CMAKE_BINARY_DIR}/packages/bin/TestHarness.exe
             # ${CMAKE_BINARY_DIR}/packages/bin/TraceLogHelper.dll
+            strip_only_fdbserver
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/CMakeCache.txt ${STAGE_OUT_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/packages/bin/fdbserver
                                      ${CMAKE_BINARY_DIR}/bin/coverage.fdbserver.xml

--- a/cmake/FlowCommands.cmake
+++ b/cmake/FlowCommands.cmake
@@ -108,22 +108,30 @@ function(strip_debug_symbols target)
   endif()
   set(out_file "${path}/${out_name}")
   list(APPEND strip_command -o "${out_file}")
-  add_custom_command(OUTPUT "${out_file}"
-    COMMAND ${strip_command} $<TARGET_FILE:${target}>
-    DEPENDS ${target}
-    COMMENT "Stripping symbols from ${target}")
-  add_custom_target(strip_only_${target} DEPENDS ${out_file})
   if(is_exec AND NOT APPLE)
-    add_custom_command(OUTPUT "${out_file}.debug"
-      DEPENDS strip_only_${target}
+    # The debuglink command rewrites out_file, so it must finish before consumers copy it.
+    add_custom_command(
+      OUTPUT "${out_file}" "${out_file}.debug"
+      COMMAND ${strip_command} $<TARGET_FILE:${target}>
       COMMAND objcopy --verbose --only-keep-debug $<TARGET_FILE:${target}> "${out_file}.debug"
       COMMAND objcopy --verbose --add-gnu-debuglink="${out_file}.debug" "${out_file}"
-      COMMENT "Copy debug symbols to ${out_name}.debug")
-    add_custom_target(strip_${target} DEPENDS "${out_file}.debug")
+      DEPENDS ${target}
+      COMMENT "Stripping symbols and copying debug symbols from ${target}")
   else()
-    add_custom_target(strip_${target})
-    add_dependencies(strip_${target} strip_only_${target})
+    add_custom_command(
+      OUTPUT "${out_file}"
+      COMMAND ${strip_command} $<TARGET_FILE:${target}>
+      DEPENDS ${target}
+      COMMENT "Stripping symbols from ${target}")
   endif()
+  if(is_exec AND NOT APPLE)
+    # Keep both outputs in one target so Makefile builds cannot run this command twice.
+    add_custom_target(strip_only_${target} DEPENDS "${out_file}" "${out_file}.debug")
+  else()
+    add_custom_target(strip_only_${target} DEPENDS "${out_file}")
+  endif()
+  add_custom_target(strip_${target})
+  add_dependencies(strip_${target} strip_only_${target})
   add_dependencies(strip_targets strip_${target})
 endfunction()
 


### PR DESCRIPTION
Run Linux executable stripping, debug symbol extraction, and the in-place GNU debuglink update in one CMake custom command.

Declare both the stripped executable and .debug file as outputs, so package consumers wait until the executable is complete.

Correctness packaging could copy packages/bin/fdbserver while objcopy --add-gnu-debuglink rewrote it. In a Clang CI run, the staged executable was 14.4 MB while the completed producer file was 92.5 MB, so simulation tests could not start or produce traces.

backport from main branch #14030 a12b41d09118 to release-7.4