### PR TITLE
Watch replacement ratekeeper immediately and verify health metrics

### DIFF
--- a/fdbserver/clustercontroller/ClusterController.cpp
+++ b/fdbserver/clustercontroller/ClusterController.cpp
@@ -3063,7 +3063,8 @@ Future<Void> monitorRatekeeper(ClusterControllerData* self) {
 			const UID monitoredRatekeeperID = self->db.serverInfo->get().ratekeeper.get().id();
 			auto res = co_await race(waitFailureClient(self->db.serverInfo->get().ratekeeper.get().waitFailure,
 			                                           SERVER_KNOBS->RATEKEEPER_FAILURE_TIME),
-			                         self->recruitRatekeeper.onChange());
+			                         self->recruitRatekeeper.onChange(),
+			                         self->db.serverInfo->onChange());
 			if (res.index() == 0) {
 				const auto& ratekeeper = self->db.serverInfo->get().ratekeeper;
 				if (!ratekeeper.present() || ratekeeper.get().id() != monitoredRatekeeperID) {
@@ -3890,6 +3891,72 @@ TEST_CASE("/fdbserver/clustercontroller/replacedRatekeeperSurvivesPreviousFailur
 	ASSERT_EQ(newWaitOrTimeout.index(), 0);
 	ASSERT(data.db.serverInfo->get().ratekeeper.get().id() == newRatekeeper.id());
 	ASSERT(!newHalts.isReady());
+	monitor.cancel();
+}
+
+TEST_CASE("/fdbserver/clustercontroller/ratekeeperReplacementRefreshesMonitors") {
+	LocalityData controllerLocality;
+	controllerLocality.set(LocalityData::keyDcId, "primary"_sr);
+	ClusterControllerData data(ClusterControllerFullInterface(),
+	                           controllerLocality,
+	                           ServerCoordinators(Reference<IClusterConnectionRecord>(
+	                               new ClusterConnectionMemoryRecord(ClusterConnectionString()))),
+	                           makeReference<AsyncVar<Optional<UID>>>());
+	WorkerInterface oldWorker = addSingletonTestWorker(data, "old-ratekeeper"_sr, "primary"_sr);
+	WorkerInterface newWorker = addSingletonTestWorker(data, "new-ratekeeper"_sr, "primary"_sr);
+	RatekeeperInterface oldRatekeeper(oldWorker.locality, UID(1, 1));
+	RatekeeperInterface newRatekeeper(newWorker.locality, UID(1, 2));
+	FutureStream<ReplyPromise<Void>> oldFailures = oldRatekeeper.waitFailure.getFuture();
+	FutureStream<ReplyPromise<Void>> newFailures = newRatekeeper.waitFailure.getFuture();
+	FutureStream<HaltRatekeeperRequest> oldHalts = oldRatekeeper.haltRatekeeper.getFuture();
+	FutureStream<HaltRatekeeperRequest> newHalts = newRatekeeper.haltRatekeeper.getFuture();
+	FutureStream<EventLogRequest> oldEvents = oldWorker.eventLogRequest.getFuture();
+	FutureStream<EventLogRequest> newEvents = newWorker.eventLogRequest.getFuture();
+
+	auto serverInfo = data.db.serverInfo->get();
+	serverInfo.recoveryState = RecoveryState::ACCEPTING_COMMITS;
+	serverInfo.id = UID(3, 1);
+	data.db.serverInfo->set(serverInfo);
+	data.db.setRatekeeper(oldRatekeeper);
+	Future<Void> monitor = monitorRatekeeper(&data);
+	auto oldWaitOrTimeout = co_await race(oldFailures, delay(2.0));
+	ASSERT_EQ(oldWaitOrTimeout.index(), 0);
+	ReplyPromise<Void> oldFailure = std::get<0>(std::move(oldWaitOrTimeout));
+
+	processRegisteredSingletons(&data, newWorker, {}, newRatekeeper, {});
+	ASSERT(data.db.serverInfo->get().ratekeeper.get().id() == newRatekeeper.id());
+	auto oldHaltOrTimeout = co_await race(oldHalts, delay(2.0));
+	ASSERT_EQ(oldHaltOrTimeout.index(), 0);
+	HaltRatekeeperRequest oldHalt = std::get<0>(std::move(oldHaltOrTimeout));
+	auto newWaitOrTimeout = co_await race(newFailures, delay(2.0));
+	ASSERT_EQ(newWaitOrTimeout.index(), 0);
+	ReplyPromise<Void> newFailure = std::get<0>(std::move(newWaitOrTimeout));
+
+	auto latestEvents = data.clusterHealthWorkerEventProvider->getLatestRatekeeperEvents("RkUpdate");
+	auto eventOrTimeout = co_await race(oldEvents, newEvents, delay(2.0));
+	ASSERT_EQ(eventOrTimeout.index(), 1);
+	EventLogRequest request = std::get<1>(std::move(eventOrTimeout));
+	ASSERT(request.eventName == "RkUpdate"_sr);
+	TraceEventFields fields;
+	fields.addField("ReleasedTPS", "100");
+	fields.addField("TPSLimit", "125");
+	request.reply.send(fields);
+	auto events = co_await latestEvents;
+	ASSERT(events.present());
+	ASSERT_EQ(events.get().first.size(), 1);
+	ASSERT(events.get().second.empty());
+	ASSERT_EQ(events.get().first.begin()->second.getDouble("TPSLimit"), 125.0);
+
+	newFailure.sendError(connection_failed());
+	auto newHaltOrTimeout = co_await race(newHalts, delay(2.0));
+	ASSERT_EQ(newHaltOrTimeout.index(), 0);
+	HaltRatekeeperRequest newHalt = std::get<0>(std::move(newHaltOrTimeout));
+	newHalt.reply.send(Void());
+	ASSERT(!data.db.serverInfo->get().ratekeeper.present());
+	auto clearedEvents = co_await data.clusterHealthWorkerEventProvider->getLatestRatekeeperEvents("RkUpdate");
+	ASSERT(!clearedEvents.present());
+	oldHalt.reply.send(Void());
+	oldFailure.sendError(connection_failed());
 	monitor.cancel();
 }
 


### PR DESCRIPTION
## Summary

- Wake the ratekeeper failure monitor when published server information changes, so it begins watching a replacement even if the old ratekeeper still responds to failure requests.
- Add a cluster-controller regression test that keeps the old failure request pending, checks that `RkUpdate` comes from the replacement worker, and verifies that failure of the replacement clears both the role and the health-monitor input.

The prerequisite change from https://github.com/apple/foundationdb/pull/14034 is merged into `main`. This PR contains only the follow-up change.

## Validation

- `fdbserver_clustercontroller_test` (36 tests passed on the exact commit in this PR).
