### PR TITLE
Fix RPM multi-version client installation

### DIFF
--- a/cmake/InstallLayout.cmake
+++ b/cmake/InstallLayout.cmake
@@ -261,6 +261,12 @@ set(CPACK_RPM_SERVER-VERSIONED_PACKAGE_REQUIRES            "${CPACK_COMPONENT_CL
 set(CPACK_RPM_SERVER-VERSIONED_POST_INSTALL_SCRIPT_FILE    ${CMAKE_BINARY_DIR}/packaging/multiversion/server/postinst-rpm)
 set(CPACK_RPM_SERVER-VERSIONED_PRE_UNINSTALL_SCRIPT_FILE   ${CMAKE_BINARY_DIR}/packaging/multiversion/server/prerm)
 
+# Versioned packages must not own RPM's global build-id links. Two otherwise
+# independent client packages can contain identical binaries, and those links
+# would make the packages conflict outside their versioned install tree.
+set(CPACK_RPM_SPEC_MORE_DEFINE
+    "%if \\\"%{name}\\\" == \\\"${CPACK_RPM_CLIENTS-VERSIONED_PACKAGE_NAME}\\\"\n%define _build_id_links none\n%endif")
+
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/packaging/emptydir")
 fdb_install(DIRECTORY "${CMAKE_BINARY_DIR}/packaging/emptydir/" DESTINATION data COMPONENT server)
 fdb_install(DIRECTORY "${CMAKE_BINARY_DIR}/packaging/emptydir/" DESTINATION log COMPONENT server)

--- a/documentation/sphinx/source/getting-started-linux.rst
+++ b/documentation/sphinx/source/getting-started-linux.rst
@@ -48,6 +48,31 @@ To install on **RHEL/CentOS 7** use the rpm command:
 |simple-installation-mode-warnings|
 
 |networking-clarification|
+
+Installing multiple client versions
+====================================
+
+The regular ``foundationdb-clients`` RPM installs files in shared system paths
+and is intended for a normal install or upgrade. Do not install two regular
+client RPMs with ``rpm -ivh``; they own the same files and RPM will report file
+conflicts.
+
+For multi-version client support, use the separately named CPack versioned
+client RPMs. Their names have the form
+``foundationdb<version>-clients-1.versioned.<architecture>.rpm`` and their
+files are installed below ``/usr/lib/foundationdb-<version>/``. Non-release
+builds may include build-time and prerelease text in the package name and
+directory. Install each versioned package with ``rpm -ivh`` so the packages
+can remain installed simultaneously. If a release does not publish its
+versioned RPM, build the
+``clients-versioned`` component from source with CPack (run ``cpack -G RPM``
+from the configured build directory).
+
+The active client is selected through the ``fdbclients`` alternatives group.
+Use ``update-alternatives --display fdbclients`` to inspect it and
+``update-alternatives --config fdbclients`` to select a version. The selected
+alternative applies consistently to the client tools, library, headers,
+pkg-config metadata, and CMake package metadata.
 	
 Testing your FoundationDB installation
 ======================================

--- a/packaging/multiversion/clients/postinst
+++ b/packaging/multiversion/clients/postinst
@@ -9,7 +9,7 @@ then
 fi
 if [ ! -d "${PKG_CONFIG_DIR}" ]
 then
-    mkdir ${PKG_CONFIG_DIR}
+    mkdir "${PKG_CONFIG_DIR}"
 fi
 
 update-alternatives --install /usr/bin/fdbcli fdbclients /usr/lib/foundationdb-@FDB_VERSION@@FDB_BUILDTIME_STRING@/bin/fdbcli @ALTERNATIVES_PRIORITY@ \
@@ -19,6 +19,7 @@ update-alternatives --install /usr/bin/fdbcli fdbclients /usr/lib/foundationdb-@
     --slave /usr/bin/fdbdr fdbdr /usr/lib/foundationdb-@FDB_VERSION@@FDB_BUILDTIME_STRING@/bin/fdbbackup \
     --slave /usr/bin/backup_agent backup_agent /usr/lib/foundationdb-@FDB_VERSION@@FDB_BUILDTIME_STRING@/bin/fdbbackup \
     --slave /usr/@LIB_DIR@/libfdb_c.so libfdb_c /usr/lib/foundationdb-@FDB_VERSION@@FDB_BUILDTIME_STRING@/lib/libfdb_c.so \
+    --slave /usr/@LIB_DIR@/libfdb_c_shim.so libfdb_c_shim /usr/lib/foundationdb-@FDB_VERSION@@FDB_BUILDTIME_STRING@/lib/libfdb_c_shim.so \
     --slave /usr/@LIB_DIR@/pkgconfig/foundationdb-client.pc foundationdb-client.pc /usr/lib/foundationdb-@FDB_VERSION@@FDB_BUILDTIME_STRING@/lib/pkgconfig/foundationdb-client.pc \
     --slave /usr/@LIB_DIR@/cmake/FoundationDB-Client FoundationDB-ClientConfig /usr/lib/foundationdb-@FDB_VERSION@@FDB_BUILDTIME_STRING@/lib/cmake/FoundationDB-Client \
     --slave /usr/include/foundationdb fdb-client-headers /usr/lib/foundationdb-@FDB_VERSION@@FDB_BUILDTIME_STRING@/include/foundationdb

--- a/packaging/multiversion/clients/prerm
+++ b/packaging/multiversion/clients/prerm
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-update-alternatives --remove fdbclients /usr/lib/foundationdb-@FDB_VERSION@@FDB_BUILDTIME_STRING@/bin/fdbcli
+case "${1:-remove}" in
+    0|remove)
+        update-alternatives --remove fdbclients /usr/lib/foundationdb-@FDB_VERSION@@FDB_BUILDTIME_STRING@/bin/fdbcli
+        ;;
+esac


### PR DESCRIPTION
## Problem

Installing multiple regular `foundationdb-clients` RPMs with `rpm -ivh` fails because each package directly owns shared paths such as `/usr/bin/fdbcli`, `libfdb_c.so`, headers, pkg-config metadata, and CMake metadata.

FoundationDB already provides separately named `clients-versioned` RPMs for multi-version client support, but RPM generation was broken by incorrect CMake escaping in the `_build_id_links` conditional. Versioned client packages could also conflict through identical `.build-id` links, and RPM upgrades could incorrectly remove alternatives.

## Solution

- Fix escaping of `CPACK_RPM_SPEC_MORE_DEFINE` so the generated RPM spec contains a valid `%if` expression.
- Disable RPM `.build-id` links only for the versioned client package.
- Add `libfdb_c_shim.so` to the `fdbclients` alternatives group.
- Prevent the versioned client `prerm` script from removing alternatives during RPM upgrades.
- Document the difference between regular RPM upgrades and versioned client package coexistence.

Regular `foundationdb-clients` RPM semantics remain unchanged.

## Testing

Validated with freshly generated RPMs from the current source:

- `cpack -G RPM --config CPackConfig.cmake -V` in `foundationdb/build:rockylinux9-latest`
- `cmake --build build --target fdbcli`
- Documentation build via `cmake --build build --target html`
- Shell syntax checks for both client scriptlets
- Reproduced regular 7.4.5 → 7.4.7 RPM file conflicts
- Verified regular RPM upgrade with `rpm -Uvh`
- Installed two separately named versioned client RPMs simultaneously in a clean Rocky Linux 9 container
- Tested alternatives switching in both directions
- Verified binaries, libraries, `libfdb_c_shim.so`, headers, pkg-config, and CMake metadata switch consistently
- Tested `rpm -Uvh --replacepkgs` upgrade/preun behavior
- Tested inactive-package removal, active-package fallback, and final alternatives cleanup
- Confirmed no dangling alternatives symlinks remain

Fixes #12610
