### PR TITLE
Expose opt-in Mako Prometheus metrics

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -119,9 +119,12 @@ if(NOT WIN32)
     test/mako/logger.hpp
     test/mako/mako.cpp
     test/mako/mako.hpp
+    test/mako/native_latency.hpp
     test/mako/operations.hpp
     test/mako/operations.cpp
     test/mako/process.hpp
+    test/mako/prometheus.hpp
+    test/mako/prometheus_server.hpp
     test/mako/shm.hpp
     test/mako/stats.hpp
     test/mako/time.hpp
@@ -193,6 +196,9 @@ if(NOT WIN32)
     add_executable(fdb_c_client_memory_test test/client_memory_test.cpp test/unit/fdb_api.cpp test/unit/fdb_api.hpp)
     if(BUILD_MAKO)
       add_executable(mako ${MAKO_SRCS})
+      add_executable(mako_native_latency_test test/mako/native_latency_test.cpp)
+      target_link_libraries(mako_native_latency_test PRIVATE fmt::fmt boost_target Threads::Threads)
+      add_test(NAME mako_native_latency_test COMMAND $<TARGET_FILE:mako_native_latency_test>)
     endif()
     add_executable(fdb_c_setup_tests test/unit/setup_tests.cpp)
     add_executable(fdb_c_unit_tests)

--- a/bindings/c/test/mako/async.cpp
+++ b/bindings/c/test/mako/async.cpp
@@ -101,6 +101,9 @@ void ResumableStateForRunWorkload::postNextTick() {
 
 void ResumableStateForRunWorkload::runOneTick() {
 	assert(iter != OpEnd);
+	if (iter == getOpBegin(args)) {
+		stats.incrTransactionAttempt();
+	}
 	if (iter.step == 0 /* first step */)
 		prepareKeys(iter.op, key1, key2, args);
 	watch_step.start();

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -29,6 +30,7 @@
 #include <cstring>
 #include <fstream>
 #include <map>
+#include <memory>
 #include <new>
 #include <numeric>
 #include <optional>
@@ -62,6 +64,8 @@
 #include "mako.hpp"
 #include "operations.hpp"
 #include "process.hpp"
+#include "prometheus.hpp"
+#include "prometheus_server.hpp"
 #include "utils.hpp"
 #include "shm.hpp"
 #include "stats.hpp"
@@ -267,6 +271,7 @@ int runOneTransaction(Transaction& tx,
 	auto op_iter = getOpBegin(args);
 	auto needs_commit = false;
 transaction_begin:
+	stats.incrTransactionAttempt();
 	while (op_iter != OpEnd) {
 		const auto& [op, count, step] = op_iter;
 		const auto step_kind = opTable[op].stepKind(step);
@@ -297,6 +302,7 @@ transaction_begin:
 				tx.setOption(FDB_TR_OPTION_AUTHORIZATION_TOKEN, *token);
 			// retry from first op
 			op_iter = getOpBegin(args);
+			stats.incrTransactionAttempt();
 			needs_commit = false;
 			continue;
 		}
@@ -800,6 +806,7 @@ Arguments::Arguments() {
 	tpsinterval = 10;
 	tpschange = TPS_SIN;
 	sampling = 1000;
+	prometheus_port = 0;
 	key_length = 32;
 	value_length = 16;
 	zipf = 0;
@@ -1108,6 +1115,7 @@ void usage() {
 	printf("%-24s %s\n", "    --tpsinterval=SEC", "Specify the TPS change interval (Default: 10 seconds)");
 	printf("%-24s %s\n", "    --tpschange=<sin|square|pulse>", "Specify the TPS change type (Default: sin)");
 	printf("%-24s %s\n", "    --sampling=RATE", "Specify the sampling rate for latency stats");
+	printf("%-24s %s\n", "    --prometheus_port=PORT", "Serve native Mako metrics on /metrics (disabled by default)");
 	printf("%-24s %s\n", "-m, --mode=MODE", "Specify the mode (build, run, clean, report)");
 	printf("%-24s %s\n", "-z, --zipf", "Use zipfian distribution instead of uniform distribution");
 	printf("%-24s %s\n", "    --commitget", "Commit GETs");
@@ -1184,6 +1192,7 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 			{ "tpsinterval", required_argument, nullptr, ARG_TPSINTERVAL },
 			{ "tpschange", required_argument, nullptr, ARG_TPSCHANGE },
 			{ "sampling", required_argument, nullptr, ARG_SAMPLING },
+			{ "prometheus_port", required_argument, nullptr, ARG_PROMETHEUS_PORT },
 			{ "verbose", required_argument, nullptr, 'v' },
 			{ "mode", required_argument, nullptr, 'm' },
 			{ "knobs", required_argument, nullptr, ARG_KNOBS },
@@ -1241,6 +1250,7 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 		}
 		switch (c) {
 		case '?':
+			return -2;
 		case 'h':
 			usage();
 			return -1;
@@ -1344,6 +1354,17 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 		case ARG_SAMPLING:
 			args.sampling = atoi(optarg);
 			break;
+		case ARG_PROMETHEUS_PORT: {
+			char* end = nullptr;
+			errno = 0;
+			const auto port = std::strtol(optarg, &end, 10);
+			if (errno || end == optarg || *end != '\0' || port < 0 || port > 65535) {
+				logr.error("--prometheus_port must be between 0 and 65535");
+				return -2;
+			}
+			args.prometheus_port = static_cast<int>(port);
+			break;
+		}
 		case ARG_VERSION:
 			logr.error("Version: {}", FDB_API_VERSION);
 			_exit(0);
@@ -1610,6 +1631,10 @@ int Arguments::validate() {
 	}
 	if (mode != MODE_RUN && warmup_seconds != 0) {
 		logr.error("--warmup_seconds only supported in run mode");
+		return -1;
+	}
+	if (mode != MODE_RUN && prometheus_port != 0) {
+		logr.error("--prometheus_port is only supported in run mode");
 		return -1;
 	}
 
@@ -2263,11 +2288,45 @@ int statsProcessMain(Arguments const& args,
                      ThreadStatistics const* thread_stats,
                      ProcessStatistics const* process_stats,
                      std::atomic<double>& throttle_factor,
+                     std::atomic<int>& metrics_status,
                      std::atomic<int> const& signal,
                      std::atomic<int> const& stopcount,
                      pid_t pid_main) {
 	bool first_stats = true;
 	auto warmup_snapshot = std::optional<WarmupSnapshot>{};
+	auto metrics_server = std::unique_ptr<NativeMetricsServer>{};
+	if (args.prometheus_port != 0) {
+		const auto job = prometheusWorkloadName(std::getenv("MAKO_JOB_NAME"));
+		const auto workload = prometheusWorkloadName(std::getenv("MAKO_WORKLOAD_NAME"));
+		const auto run_start_seconds =
+		    std::chrono::duration<double>(std::chrono::system_clock::now().time_since_epoch()).count();
+		const auto num_workers = args.async_xacts > 0 ? args.async_xacts : args.num_threads;
+		try {
+			metrics_server = std::make_unique<NativeMetricsServer>(args.prometheus_port, [=, &args]() {
+				auto counters = NativeCountersSnapshot{};
+				auto latency = NativeLatencySnapshot{};
+				for (auto i = 0; i < args.num_processes * num_workers; ++i) {
+					counters.merge(*worker_stats[i].liveCounters());
+					latency.merge(*worker_stats[i].liveLatency());
+				}
+				return renderPrometheusMetrics(counters,
+				                               latency,
+				                               job,
+				                               workload,
+				                               args.key_length,
+				                               args.value_length,
+				                               args.num_processes,
+				                               args.num_threads,
+				                               args.sampling,
+				                               run_start_seconds);
+			});
+		} catch (const std::exception& error) {
+			logr.error("Mako metrics could not listen on port {}: {}", args.prometheus_port, error.what());
+			metrics_status.store(-1);
+			return -1;
+		}
+	}
+	metrics_status.store(1);
 
 	/* wait until the signal turn on */
 	while (signal.load() == SIGNAL_OFF) {
@@ -2426,7 +2485,7 @@ int main(int argc, char* argv[]) {
 	rc = parseArguments(argc, argv, args);
 	if (rc < 0) {
 		/* usage printed */
-		return 0;
+		return rc == -2 ? 1 : 0;
 	}
 
 	// set --seconds in case no ending condition has been set
@@ -2482,7 +2541,8 @@ int main(int argc, char* argv[]) {
 	const auto async_mode = args.async_xacts > 0;
 	const auto num_workers = async_mode ? args.async_xacts : args.num_threads;
 	/* allocate */
-	const auto shmsize = shared_memory::storageSize(args.num_processes, args.num_threads, num_workers);
+	const auto shmsize =
+	    shared_memory::storageSize(args.num_processes, args.num_threads, num_workers, args.prometheus_port != 0);
 
 	auto shm = std::add_pointer_t<void>{};
 	if (ftruncate(shmfd, shmsize) < 0) {
@@ -2499,7 +2559,8 @@ int main(int argc, char* argv[]) {
 	}
 	auto munmap_guard = ExitGuard([=]() { munmap(shm, shmsize); });
 
-	auto shm_access = shared_memory::Access(shm, args.num_processes, args.num_threads, num_workers);
+	auto shm_access =
+	    shared_memory::Access(shm, args.num_processes, args.num_threads, num_workers, args.prometheus_port != 0);
 
 	/* initialize the shared memory */
 	shm_access.initMemory();
@@ -2509,6 +2570,7 @@ int main(int argc, char* argv[]) {
 	shm_hdr.signal = SIGNAL_OFF;
 	shm_hdr.readycount = 0;
 	shm_hdr.stopcount = 0;
+	shm_hdr.metrics_status = 0;
 	shm_hdr.throttle_factor = 1.0;
 
 	auto proc_type = ProcKind::MAIN;
@@ -2553,29 +2615,47 @@ int main(int argc, char* argv[]) {
 	if (proc_type == ProcKind::WORKER) {
 		/* worker process */
 
-		workerProcessMain(args, process_idx, shm_access, pid_main);
+		const auto result = workerProcessMain(args, process_idx, shm_access, pid_main);
 
-		_exit(0);
+		_exit(result == 0 ? 0 : 1);
 	} else if (proc_type == ProcKind::STATS) {
 		/* stats */
 		if (args.mode == MODE_CLEAN) {
 			/* no stats needed for clean mode */
 			_exit(0);
 		}
-		statsProcessMain(args,
-		                 shm_access.workerStatsConstArray(),
-		                 shm_access.threadStatsConstArray(),
-		                 shm_access.processStatsConstArray(),
-		                 shm_hdr.throttle_factor,
-		                 shm_hdr.signal,
-		                 shm_hdr.stopcount,
-		                 pid_main);
-		_exit(0);
+		const auto result = statsProcessMain(args,
+		                                     shm_access.workerStatsConstArray(),
+		                                     shm_access.threadStatsConstArray(),
+		                                     shm_access.processStatsConstArray(),
+		                                     shm_hdr.throttle_factor,
+		                                     shm_hdr.metrics_status,
+		                                     shm_hdr.signal,
+		                                     shm_hdr.stopcount,
+		                                     pid_main);
+		_exit(result == 0 ? 0 : 1);
 	}
 
 	/* master */
 	/* wait for everyone to be ready */
-	while (shm_hdr.readycount.load() < (args.num_processes * args.num_threads)) {
+	while (shm_hdr.readycount.load() < (args.num_processes * args.num_threads) ||
+	       (args.prometheus_port != 0 && shm_hdr.metrics_status.load() == 0)) {
+		const bool exporter_failed = args.prometheus_port != 0 && shm_hdr.metrics_status.load() < 0;
+		const bool stats_exited = args.prometheus_port != 0 && shm_hdr.metrics_status.load() == 0 &&
+		                          waitpid(worker_pids[args.num_processes], nullptr, WNOHANG) > 0;
+		if (exporter_failed || stats_exited) {
+			logr.error("Mako metrics could not start");
+			for (auto p = 0; p < args.num_processes; ++p) {
+				kill(worker_pids[p], SIGTERM);
+			}
+			for (auto p = 0; p < args.num_processes; ++p) {
+				waitpid(worker_pids[p], nullptr, 0);
+			}
+			if (!stats_exited) {
+				waitpid(worker_pids[args.num_processes], nullptr, 0);
+			}
+			return -1;
+		}
 		usleep(1000);
 	}
 	shm_hdr.signal.store(SIGNAL_GREEN);
@@ -2605,12 +2685,16 @@ int main(int argc, char* argv[]) {
 	}
 
 	auto status = int{};
+	auto failed = false;
 	/* wait for worker processes to exit */
 	for (auto p = 0; p < args.num_processes; p++) {
 		logr.debug("waiting for worker process {} (PID:{}) to exit", p + 1, worker_pids[p]);
 		auto pid = waitpid(worker_pids[p], &status, 0 /* or what? */);
 		if (pid < 0) {
 			logr.error("waitpid failed for worker process PID {}", worker_pids[p]);
+			failed = true;
+		} else if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+			failed = true;
 		}
 		logr.debug("worker {} (PID:{}) exited", p + 1, worker_pids[p]);
 	}
@@ -2624,7 +2708,11 @@ int main(int argc, char* argv[]) {
 	auto pid = waitpid(worker_pids[args.num_processes], &status, 0 /* or what? */);
 	if (pid < 0) {
 		logr.error("waitpid failed for stats process PID {}", worker_pids[args.num_processes]);
+		failed = true;
+	} else if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		logr.error("stats process exited abnormally");
+		failed = true;
 	}
 
-	return 0;
+	return failed ? -1 : 0;
 }

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -1250,6 +1250,7 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 		}
 		switch (c) {
 		case '?':
+			usage();
 			return -2;
 		case 'h':
 			usage();

--- a/bindings/c/test/mako/mako.hpp
+++ b/bindings/c/test/mako/mako.hpp
@@ -57,6 +57,7 @@ enum ArgKind {
 	ARG_ASYNC,
 	ARG_COMMITGET,
 	ARG_SAMPLING,
+	ARG_PROMETHEUS_PORT,
 	ARG_VERSION,
 	ARG_KNOBS,
 	ARG_FLATBUFFERS,
@@ -169,6 +170,7 @@ struct Arguments {
 	int tpsinterval;
 	int tpschange;
 	int sampling;
+	int prometheus_port;
 	int key_length;
 	int value_length;
 	int zipf;

--- a/bindings/c/test/mako/native_latency.hpp
+++ b/bindings/c/test/mako/native_latency.hpp
@@ -1,0 +1,144 @@
+/*
+ * native_latency.hpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MAKO_NATIVE_LATENCY_HPP
+#define MAKO_NATIVE_LATENCY_HPP
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <optional>
+
+namespace mako {
+
+// Each worker owns its counters. The stats process reads them across fork, without
+// touching the worker's private DDSketch, at about 1% relative bucket resolution.
+class alignas(64) NativeLatencyHistogram {
+public:
+	static constexpr int bucketCount = 64 * 32 + 1;
+	static constexpr int operationCount = 2;
+
+	NativeLatencyHistogram() noexcept {
+		for (auto& operation : buckets) {
+			for (auto& bucket : operation) {
+				bucket.store(0, std::memory_order_relaxed);
+			}
+		}
+	}
+
+	void add(int operation, uint64_t microseconds) noexcept {
+		if (operation < 0 || operation >= operationCount) {
+			return;
+		}
+		const auto index =
+		    microseconds == 0 ? 0 : std::min(bucketCount - 1, 1 + static_cast<int>(std::log2(microseconds) * 64));
+		buckets[operation][index].fetch_add(1, std::memory_order_relaxed);
+		microseconds_total[operation].fetch_add(microseconds, std::memory_order_relaxed);
+	}
+
+	uint64_t bucket(int operation, int index) const noexcept {
+		return buckets[operation][index].load(std::memory_order_relaxed);
+	}
+	uint64_t totalMicroseconds(int operation) const noexcept {
+		return microseconds_total[operation].load(std::memory_order_relaxed);
+	}
+
+private:
+	std::array<std::array<std::atomic<uint64_t>, bucketCount>, operationCount> buckets;
+	std::array<std::atomic<uint64_t>, operationCount> microseconds_total{};
+};
+
+struct alignas(64) NativeCounters {
+	std::atomic<uint64_t> completed_transactions{};
+	std::atomic<uint64_t> attempted_transactions{};
+	std::atomic<uint64_t> reads{};
+	std::atomic<uint64_t> writes{};
+	std::atomic<uint64_t> commits{};
+	std::atomic<uint64_t> conflicts{};
+	std::atomic<uint64_t> errors{};
+	std::atomic<uint64_t> timeouts{};
+};
+
+struct NativeCountersSnapshot {
+	uint64_t completed_transactions{};
+	uint64_t attempted_transactions{};
+	uint64_t reads{};
+	uint64_t writes{};
+	uint64_t commits{};
+	uint64_t conflicts{};
+	uint64_t errors{};
+	uint64_t timeouts{};
+
+	void merge(const NativeCounters& counters) noexcept {
+		completed_transactions += counters.completed_transactions.load(std::memory_order_relaxed);
+		attempted_transactions += counters.attempted_transactions.load(std::memory_order_relaxed);
+		reads += counters.reads.load(std::memory_order_relaxed);
+		writes += counters.writes.load(std::memory_order_relaxed);
+		commits += counters.commits.load(std::memory_order_relaxed);
+		conflicts += counters.conflicts.load(std::memory_order_relaxed);
+		errors += counters.errors.load(std::memory_order_relaxed);
+		timeouts += counters.timeouts.load(std::memory_order_relaxed);
+	}
+};
+
+class NativeLatencySnapshot {
+public:
+	void merge(const NativeLatencyHistogram& histogram) noexcept {
+		for (int op = 0; op < NativeLatencyHistogram::operationCount; ++op) {
+			microseconds_total[op] += histogram.totalMicroseconds(op);
+			for (int index = 0; index < NativeLatencyHistogram::bucketCount; ++index) {
+				const auto count = histogram.bucket(op, index);
+				buckets[op][index] += count;
+				counts[op] += count;
+			}
+		}
+	}
+
+	uint64_t samples(int operation) const noexcept { return counts[operation]; }
+	uint64_t bucket(int operation, int index) const noexcept { return buckets[operation][index]; }
+	uint64_t totalMicroseconds(int operation) const noexcept { return microseconds_total[operation]; }
+
+	std::optional<uint64_t> percentile(int operation, double quantile) const noexcept {
+		if (counts[operation] == 0) {
+			return std::nullopt;
+		}
+		const auto rank = static_cast<uint64_t>(quantile * (counts[operation] - 1));
+		auto encountered = uint64_t{};
+		for (int index = 0; index < NativeLatencyHistogram::bucketCount; ++index) {
+			encountered += buckets[operation][index];
+			if (encountered > rank) {
+				return index == 0 ? 0 : static_cast<uint64_t>(std::round(std::exp2((index - 1) / 64.0)));
+			}
+		}
+		return std::nullopt;
+	}
+
+private:
+	std::array<std::array<uint64_t, NativeLatencyHistogram::bucketCount>, NativeLatencyHistogram::operationCount>
+	    buckets{};
+	std::array<uint64_t, NativeLatencyHistogram::operationCount> counts{};
+	std::array<uint64_t, NativeLatencyHistogram::operationCount> microseconds_total{};
+};
+
+} // namespace mako
+
+#endif /* MAKO_NATIVE_LATENCY_HPP */

--- a/bindings/c/test/mako/native_latency_test.cpp
+++ b/bindings/c/test/mako/native_latency_test.cpp
@@ -1,0 +1,197 @@
+/*
+ * native_latency_test.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "prometheus.hpp"
+#include "prometheus_server.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <initializer_list>
+#include <limits>
+#include <new>
+#include <sstream>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+using namespace mako;
+
+void check(bool condition, const char* message) {
+	if (!condition) {
+		std::fprintf(stderr, "%s\n", message);
+		std::abort();
+	}
+}
+
+int main() {
+	NativeLatencyHistogram edges;
+	NativeLatencySnapshot empty;
+	check(!empty.percentile(0, 0.999), "empty histogram must not report a percentile");
+	for (const auto value : { uint64_t{ 0 },
+	                          uint64_t{ 1 },
+	                          uint64_t{ 2 },
+	                          uint64_t{ 1 } << 31,
+	                          uint64_t{ 1 } << 32,
+	                          std::numeric_limits<uint64_t>::max() }) {
+		edges.add(0, value);
+	}
+	NativeLatencySnapshot edge_snapshot;
+	edge_snapshot.merge(edges);
+	check(edge_snapshot.samples(0) == 6, "all bounded histogram samples must be counted");
+	check(*edge_snapshot.percentile(0, 0) == 0, "zero latency must retain its own bucket");
+	check(*edge_snapshot.percentile(0, 1) >= (uint64_t{ 1 } << 31), "large latency must be bounded safely");
+
+	const auto size = 2 * sizeof(NativeLatencyHistogram);
+	auto* shared = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANON, -1, 0);
+	check(shared != MAP_FAILED, "could not map shared histograms");
+	auto* histograms = static_cast<NativeLatencyHistogram*>(shared);
+	new (&histograms[0]) NativeLatencyHistogram();
+	new (&histograms[1]) NativeLatencyHistogram();
+	const auto counter_size = 2 * sizeof(NativeCounters);
+	auto* counter_memory = mmap(nullptr, counter_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANON, -1, 0);
+	check(counter_memory != MAP_FAILED, "could not map shared counters");
+	auto* counters = static_cast<NativeCounters*>(counter_memory);
+	new (&counters[0]) NativeCounters();
+	new (&counters[1]) NativeCounters();
+	check(reinterpret_cast<uintptr_t>(&histograms[1]) % alignof(NativeLatencyHistogram) == 0,
+	      "adjacent worker histograms must stay aligned");
+
+	const auto child = fork();
+	check(child >= 0, "could not fork histogram writer");
+	if (child == 0) {
+		for (int i = 0; i < 3000; ++i) {
+			histograms[1].add(0, 100);
+			histograms[1].add(1, 10000);
+			counters[1].attempted_transactions.fetch_add(2);
+			counters[1].completed_transactions.fetch_add(1);
+			counters[1].reads.fetch_add(10);
+			counters[1].writes.fetch_add(1);
+			counters[1].commits.fetch_add(1);
+			counters[1].conflicts.fetch_add(1);
+		}
+		_exit(0);
+	}
+
+	auto previous = uint64_t{};
+	for (int i = 0; i < 10000; ++i) {
+		NativeLatencySnapshot current;
+		current.merge(histograms[1]);
+		check(current.samples(0) >= previous, "cross-process sample counts must not decrease");
+		previous = current.samples(0);
+		if (previous == 3000) {
+			break;
+		}
+		usleep(100);
+	}
+	int status = 0;
+	check(waitpid(child, &status, 0) == child && WIFEXITED(status) && WEXITSTATUS(status) == 0,
+	      "child writer must finish successfully");
+	NativeLatencySnapshot combined;
+	combined.merge(histograms[0]);
+	combined.merge(histograms[1]);
+	check(combined.samples(0) == 3000 && combined.samples(1) == 3000, "adjacent worker histograms must not overlap");
+	check(combined.totalMicroseconds(0) == 300000 && combined.totalMicroseconds(1) == 30000000,
+	      "sampled latency sums must be accurate");
+	NativeCountersSnapshot total;
+	total.merge(counters[0]);
+	total.merge(counters[1]);
+	check(total.completed_transactions == 3000 && total.attempted_transactions == 6000 && total.reads == 30000 &&
+	          total.writes == 3000 && total.commits == 3000 && total.conflicts == 3000,
+	      "cross-process counters must count workload operations");
+	const auto rendered = renderPrometheusMetrics(total, combined, "test-job", "benchmark-g9u1", 32, 100, 2, 4, 1, 42);
+	check(rendered.find("fdb_mako_read_operations_total{mako_job=\"test-job\",workload=\"benchmark-g9u1\"} 30000") !=
+	          std::string::npos,
+	      "read metrics must carry bounded run labels");
+	check(rendered.find("fdb_mako_write_logical_bytes_total{mako_job=\"test-job\",workload=\"benchmark-g9u1\"} "
+	                    "396000") != std::string::npos,
+	      "logical bytes must reflect the configured key and value sizes");
+	check(rendered.find("fdb_mako_conflicts_total{mako_job=\"test-job\",workload=\"benchmark-g9u1\"} 3000") !=
+	          std::string::npos,
+	      "conflicts must remain separate from errors");
+	check(rendered.find("fdb_mako_configured_worker_threads_per_process{mako_job=\"test-job\","
+	                    "workload=\"benchmark-g9u1\"} 4") != std::string::npos,
+	      "thread configuration must be exposed");
+	check(rendered.find("fdb_mako_active{mako_job=\"test-job\",workload=\"benchmark-g9u1\"} 1") != std::string::npos,
+	      "active gauge must use the same run labels");
+	check(rendered.find("fdb_mako_latency_seconds_bucket{mako_job=\"test-job\",workload=\"benchmark-g9u1\","
+	                    "operation=\"GET\",le=\"+Inf\"} 3000") != std::string::npos,
+	      "histogram +Inf count must equal samples");
+	check(rendered.find("fdb_mako_latency_seconds_sum{mako_job=\"test-job\",workload=\"benchmark-g9u1\","
+	                    "operation=\"GET\"} 0.3") != std::string::npos,
+	      "histogram sum must use seconds");
+	check(rendered.find("le=\"+Inf\"") != std::string::npos && rendered.size() < 100000,
+	      "histogram exposition must have bounded size");
+	std::istringstream histogram_lines(rendered);
+	auto line = std::string{};
+	auto bucket_count = 0;
+	auto previous_count = uint64_t{};
+	auto previous_upper = -1.0;
+	while (std::getline(histogram_lines, line)) {
+		if (line.rfind("fdb_mako_latency_seconds_bucket{mako_job=\"test-job\",workload=\"benchmark-g9u1\","
+		               "operation=\"GET\"",
+		               0) != 0) {
+			continue;
+		}
+		const auto le = line.substr(line.find("le=\"") + 4);
+		if (le.rfind("+Inf", 0) != 0) {
+			const auto upper = std::stod(le);
+			check(upper > previous_upper, "histogram bucket bounds must be increasing");
+			previous_upper = upper;
+		}
+		const auto count = std::stoull(line.substr(line.find("} ") + 2));
+		check(count >= previous_count, "cumulative histogram buckets must not decrease");
+		previous_count = count;
+		bucket_count++;
+	}
+	check(bucket_count == 253 && previous_count == 3000, "histogram needs 251 finite bins, zero, and +Inf");
+	check(prometheusWorkloadName("job;bad") == "run" && prometheusWorkloadName("job-valid_1") == "job-valid_1",
+	      "metric labels must be bounded and safe");
+	NativeMetricsServer server(0, [&rendered]() { return rendered; });
+	const auto request = [&server](const char* path) {
+		boost::asio::ip::tcp::iostream stream;
+		stream.connect("127.0.0.1", std::to_string(server.port()));
+		check(stream.good(), "could not connect to native Mako metrics endpoint");
+		stream << "GET " << path << " HTTP/1.1\r\nHost: localhost\r\n\r\n" << std::flush;
+		std::ostringstream response;
+		response << stream.rdbuf();
+		return response.str();
+	};
+	const auto http_metrics = request("/metrics");
+	check(http_metrics.find("HTTP/1.1 200 OK") != std::string::npos &&
+	          http_metrics.find("fdb_mako_latency_seconds_bucket") != std::string::npos,
+	      "native /metrics must serve histogram data over HTTP");
+	check(request("/other").find("HTTP/1.1 404 Not Found") != std::string::npos,
+	      "native metrics endpoint must reject other paths");
+	auto occupied_port_rejected = false;
+	try {
+		NativeMetricsServer duplicate(server.port(), []() { return std::string{}; });
+	} catch (const boost::system::system_error&) {
+		occupied_port_rejected = true;
+	}
+	check(occupied_port_rejected, "native metrics bind conflict must fail visibly");
+	for (const auto quantile : { 0.5, 0.9, 0.99, 0.999 }) {
+		const auto get = *combined.percentile(0, quantile);
+		const auto commit = *combined.percentile(1, quantile);
+		check(get >= 99 && get <= 101, "GET latency percentile outside histogram accuracy");
+		check(commit >= 9900 && commit <= 10100, "COMMIT latency percentile outside histogram accuracy");
+	}
+	check(munmap(shared, size) == 0, "could not unmap shared histograms");
+	check(munmap(counter_memory, counter_size) == 0, "could not unmap shared counters");
+}

--- a/bindings/c/test/mako/prometheus.hpp
+++ b/bindings/c/test/mako/prometheus.hpp
@@ -1,0 +1,145 @@
+/*
+ * prometheus.hpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MAKO_PROMETHEUS_HPP
+#define MAKO_PROMETHEUS_HPP
+
+#include "native_latency.hpp"
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+namespace mako {
+
+inline std::string prometheusWorkloadName(const char* name) {
+	if (!name) {
+		return "run";
+	}
+	const auto value = std::string_view(name);
+	if (value.empty() || value.size() > 64) {
+		return "run";
+	}
+	for (const auto character : value) {
+		if (!((character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') ||
+		      (character >= '0' && character <= '9') || character == '-' || character == '_')) {
+			return "run";
+		}
+	}
+	return std::string(value);
+}
+
+inline std::string renderPrometheusMetrics(const NativeCountersSnapshot& counters,
+                                           const NativeLatencySnapshot& latency,
+                                           std::string_view job,
+                                           std::string_view workload,
+                                           int key_length,
+                                           int value_length,
+                                           int num_processes,
+                                           int num_threads,
+                                           int sampling,
+                                           double run_start_seconds) {
+	std::ostringstream out;
+	out << std::setprecision(12);
+	const auto label = "{mako_job=\"" + std::string(job) + "\",workload=\"" + std::string(workload) + "\"}";
+	const auto emit = [&](std::string_view name, std::string_view description, std::string_view type, auto value) {
+		out << "# HELP " << name << ' ' << description << '\n';
+		out << "# TYPE " << name << ' ' << type << '\n';
+		out << name << label << ' ' << value << '\n';
+	};
+
+	emit("fdb_mako_transactions_total",
+	     "Completed Mako workload iterations",
+	     "counter",
+	     counters.completed_transactions);
+	emit("fdb_mako_attempted_transactions_total",
+	     "Started Mako workload transaction attempts, including retries",
+	     "counter",
+	     counters.attempted_transactions);
+	emit("fdb_mako_read_operations_total", "Completed GET and UPDATE API steps", "counter", counters.reads);
+	emit("fdb_mako_write_operations_total", "Completed UPDATE set API steps before commit", "counter", counters.writes);
+	emit("fdb_mako_commits_total", "Successful FDB commits", "counter", counters.commits);
+	emit("fdb_mako_conflicts_total", "FDB transaction conflicts observed by Mako", "counter", counters.conflicts);
+	emit("fdb_mako_read_logical_bytes_total",
+	     "Estimated GET and UPDATE logical value bytes",
+	     "counter",
+	     counters.reads * static_cast<uint64_t>(value_length));
+	emit("fdb_mako_write_logical_bytes_total",
+	     "Estimated UPDATE logical key and value bytes",
+	     "counter",
+	     counters.writes * static_cast<uint64_t>(key_length + value_length));
+	emit("fdb_mako_errors_total", "Mako operation errors excluding conflicts and timeouts", "counter", counters.errors);
+	emit("fdb_mako_timeouts_total", "Mako operation timeouts", "counter", counters.timeouts);
+	emit("fdb_mako_configured_worker_processes", "Configured Mako worker processes", "gauge", num_processes);
+	emit("fdb_mako_configured_worker_threads_per_process",
+	     "Configured Mako worker threads per process",
+	     "gauge",
+	     num_threads);
+	emit("fdb_mako_configured_worker_threads",
+	     "Configured Mako worker threads total",
+	     "gauge",
+	     num_processes * num_threads);
+	emit("fdb_mako_sampling_rate", "One latency observation per N completed transactions", "gauge", sampling);
+	emit("fdb_mako_run_start_time_seconds", "Mako run start UNIX timestamp", "gauge", run_start_seconds);
+	emit("fdb_mako_active", "Mako native metrics endpoint is serving this workload", "gauge", 1);
+
+	out << "# HELP fdb_mako_latency_seconds Sampled successful client-side API latency\n";
+	out << "# TYPE fdb_mako_latency_seconds histogram\n";
+	for (int op = 0; op < NativeLatencyHistogram::operationCount; ++op) {
+		const auto operation = op == 0 ? "GET" : "COMMIT";
+		const auto histogram_labels = "{mako_job=\"" + std::string(job) + "\",workload=\"" + std::string(workload) +
+		                              "\",operation=\"" + operation;
+		auto cumulative = latency.bucket(op, 0);
+		out << "fdb_mako_latency_seconds_bucket" << histogram_labels << "\",le=\"0\"} " << cumulative << '\n';
+		auto last_bucket = 0;
+		// Four internal buckets are about 4.4% wide between 100us and 1s.
+		// The coarser tails keep the exported series bounded to 250 per operation.
+		const auto emitBucket = [&](int index) {
+			for (int bucket = last_bucket + 1; bucket <= index; ++bucket) {
+				cumulative += latency.bucket(op, bucket);
+			}
+			const auto upper_seconds = std::exp2(index / 64.0) / 1'000'000;
+			out << "fdb_mako_latency_seconds_bucket" << histogram_labels << "\",le=\"" << upper_seconds << "\"} "
+			    << cumulative << '\n';
+			last_bucket = index;
+		};
+		for (int index = 32; index <= 416; index += 32) {
+			emitBucket(index);
+		}
+		for (int index = 426; index <= 1278; index += 4) {
+			emitBucket(index);
+		}
+		for (int index = 1310; index < NativeLatencyHistogram::bucketCount - 1; index += 32) {
+			emitBucket(index);
+		}
+		out << "fdb_mako_latency_seconds_bucket" << histogram_labels << "\",le=\"+Inf\"} " << latency.samples(op)
+		    << '\n';
+		out << "fdb_mako_latency_seconds_sum" << histogram_labels << "\"} "
+		    << latency.totalMicroseconds(op) / 1'000'000.0 << '\n';
+		out << "fdb_mako_latency_seconds_count" << histogram_labels << "\"} " << latency.samples(op) << '\n';
+	}
+	return out.str();
+}
+
+} // namespace mako
+
+#endif /* MAKO_PROMETHEUS_HPP */

--- a/bindings/c/test/mako/prometheus_server.hpp
+++ b/bindings/c/test/mako/prometheus_server.hpp
@@ -1,0 +1,108 @@
+/*
+ * prometheus_server.hpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MAKO_PROMETHEUS_SERVER_HPP
+#define MAKO_PROMETHEUS_SERVER_HPP
+
+#include <boost/asio.hpp>
+#include <fmt/format.h>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+
+namespace mako {
+
+class NativeMetricsServer {
+	using Tcp = boost::asio::ip::tcp;
+	struct Session : std::enable_shared_from_this<Session> {
+		Tcp::socket socket;
+		std::function<std::string()> const& render;
+		std::string request;
+		std::string response;
+
+		Session(Tcp::socket socket, std::function<std::string()> const& render)
+		  : socket(std::move(socket)), render(render) {}
+
+		void start() {
+			auto self = shared_from_this();
+			boost::asio::async_read_until(socket,
+			                              boost::asio::dynamic_buffer(request, 4096),
+			                              "\r\n\r\n",
+			                              [self](boost::system::error_code error, size_t) {
+				                              if (error) {
+					                              return;
+				                              }
+				                              const bool metrics = self->request.rfind("GET /metrics HTTP/1.", 0) == 0;
+				                              const auto body = metrics ? self->render() : std::string("Not Found\n");
+				                              self->response = fmt::format(
+				                                  "HTTP/1.1 {}\r\nContent-Type: text/plain; version=0.0.4; "
+				                                  "charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+				                                  metrics ? "200 OK" : "404 Not Found",
+				                                  body.size(),
+				                                  body);
+				                              boost::asio::async_write(self->socket,
+				                                                       boost::asio::buffer(self->response),
+				                                                       [self](boost::system::error_code, size_t) {});
+			                              });
+		}
+	};
+
+	boost::asio::io_context io;
+	Tcp::acceptor acceptor;
+	std::function<std::string()> render;
+	std::thread thread;
+
+	void accept() {
+		acceptor.async_accept([this](boost::system::error_code error, Tcp::socket socket) {
+			if (!error) {
+				std::make_shared<Session>(std::move(socket), render)->start();
+			}
+			if (acceptor.is_open()) {
+				accept();
+			}
+		});
+	}
+
+public:
+	NativeMetricsServer(uint16_t port, std::function<std::string()> render) : acceptor(io), render(std::move(render)) {
+		acceptor.open(Tcp::v4());
+		acceptor.set_option(Tcp::acceptor::reuse_address(true));
+		acceptor.bind(Tcp::endpoint(Tcp::v4(), port));
+		acceptor.listen();
+		accept();
+		thread = std::thread([this]() { io.run(); });
+	}
+
+	uint16_t port() const { return acceptor.local_endpoint().port(); }
+
+	~NativeMetricsServer() {
+		io.stop();
+		if (thread.joinable()) {
+			thread.join();
+		}
+	}
+};
+
+} // namespace mako
+
+#endif /* MAKO_PROMETHEUS_SERVER_HPP */

--- a/bindings/c/test/mako/shm.hpp
+++ b/bindings/c/test/mako/shm.hpp
@@ -39,6 +39,7 @@ struct Header {
 	std::atomic<int> readycount = ATOMIC_VAR_INIT(0);
 	std::atomic<double> throttle_factor = ATOMIC_VAR_INIT(1.0);
 	std::atomic<int> stopcount = ATOMIC_VAR_INIT(0);
+	std::atomic<int> metrics_status = ATOMIC_VAR_INIT(0);
 };
 
 struct LayoutHelper {
@@ -46,15 +47,18 @@ struct LayoutHelper {
 	WorkflowStatistics stats;
 };
 
-inline size_t storageSize(int num_processes, int num_threads, int num_workers) noexcept {
+inline size_t storageSize(int num_processes, int num_threads, int num_workers, bool native_metrics = false) noexcept {
 	assert(num_processes >= 1 && num_threads >= 1);
 	return sizeof(LayoutHelper) + sizeof(WorkflowStatistics) * ((num_processes * num_workers) - 1) +
-	       sizeof(ThreadStatistics) * (num_threads * num_processes) + sizeof(ProcessStatistics) * num_processes;
+	       sizeof(ThreadStatistics) * (num_threads * num_processes) + sizeof(ProcessStatistics) * num_processes +
+	       (native_metrics ? (sizeof(NativeLatencyHistogram) + sizeof(NativeCounters)) * num_processes * num_workers
+	                       : 0);
 }
 
 // class Access memory layout:
 // Header | WorkflowStatistics | WorkflowStatistics * (num_processes * num_workers - 1) | ThreadStatistics *
-// (num_processes * num_threads) | ProcessStatistics * (num_processes)
+// (num_processes * num_threads) | ProcessStatistics * (num_processes) | NativeLatencyHistogram *
+// (num_processes * num_workers) | NativeCounters * (num_processes * num_workers), when enabled
 // all Statistics classes have alignas(64)
 
 class Access {
@@ -62,6 +66,7 @@ class Access {
 	int num_processes;
 	int num_threads;
 	int num_workers;
+	bool native_metrics;
 
 	static inline WorkflowStatistics& workerStatsSlot(void* shm_base,
 	                                                  int num_workers,
@@ -78,7 +83,7 @@ class Access {
 	                                                int thread_idx) noexcept {
 		auto* thread_stat_base =
 		    reinterpret_cast<ThreadStatistics*>(static_cast<char*>(shm_base) + sizeof(LayoutHelper) +
-		                                        sizeof(WorkflowStatistics) * num_processes * num_workers);
+		                                        sizeof(WorkflowStatistics) * (num_processes * num_workers - 1));
 
 		return thread_stat_base[process_idx * num_threads + thread_idx];
 	}
@@ -91,28 +96,64 @@ class Access {
 
 		auto* proc_stat_base =
 		    reinterpret_cast<ProcessStatistics*>(static_cast<char*>(shm_base) + sizeof(LayoutHelper) +
-		                                         sizeof(WorkflowStatistics) * num_processes * num_workers +
+		                                         sizeof(WorkflowStatistics) * (num_processes * num_workers - 1) +
 		                                         sizeof(ThreadStatistics) * num_processes * num_threads);
 		return proc_stat_base[process_idx];
 	}
 
-public:
-	Access(void* shm, int num_processes, int num_threads, int num_workers) noexcept
-	  : base(shm), num_processes(num_processes), num_threads(num_threads), num_workers(num_workers) {}
+	static inline NativeLatencyHistogram& latencyHistogramSlot(void* shm_base,
+	                                                           int num_processes,
+	                                                           int num_threads,
+	                                                           int num_workers,
+	                                                           int process_idx,
+	                                                           int worker_idx) noexcept {
+		auto* latency_base = reinterpret_cast<NativeLatencyHistogram*>(
+		    static_cast<char*>(shm_base) + sizeof(LayoutHelper) +
+		    sizeof(WorkflowStatistics) * (num_processes * num_workers - 1) +
+		    sizeof(ThreadStatistics) * num_processes * num_threads + sizeof(ProcessStatistics) * num_processes);
+		return latency_base[process_idx * num_workers + worker_idx];
+	}
 
-	Access() noexcept : Access(nullptr, 0, 0, 0) {}
+	static inline NativeCounters& countersSlot(void* shm_base,
+	                                           int num_processes,
+	                                           int num_threads,
+	                                           int num_workers,
+	                                           int process_idx,
+	                                           int worker_idx) noexcept {
+		auto* counters_base = reinterpret_cast<NativeCounters*>(
+		    static_cast<char*>(shm_base) + sizeof(LayoutHelper) +
+		    sizeof(WorkflowStatistics) * (num_processes * num_workers - 1) +
+		    sizeof(ThreadStatistics) * num_processes * num_threads + sizeof(ProcessStatistics) * num_processes +
+		    sizeof(NativeLatencyHistogram) * num_processes * num_workers);
+		return counters_base[process_idx * num_workers + worker_idx];
+	}
+
+public:
+	Access(void* shm, int num_processes, int num_threads, int num_workers, bool native_metrics = false) noexcept
+	  : base(shm), num_processes(num_processes), num_threads(num_threads), num_workers(num_workers),
+	    native_metrics(native_metrics) {}
+
+	Access() noexcept : Access(nullptr, 0, 0, 0, false) {}
 
 	Access(const Access&) noexcept = default;
 
 	Access& operator=(const Access&) noexcept = default;
 
-	size_t size() const noexcept { return storageSize(num_processes, num_threads, num_workers); }
+	size_t size() const noexcept { return storageSize(num_processes, num_threads, num_workers, native_metrics); }
 
 	void initMemory() noexcept {
 		new (&header()) Header{};
 		for (auto i = 0; i < num_processes; i++) {
 			for (auto j = 0; j < num_workers; j++) {
-				new (&workerStatsSlot(i, j)) WorkflowStatistics();
+				NativeLatencyHistogram* latency = nullptr;
+				NativeCounters* counters = nullptr;
+				if (native_metrics) {
+					latency = &latencyHistogramSlot(base, num_processes, num_threads, num_workers, i, j);
+					counters = &countersSlot(base, num_processes, num_threads, num_workers, i, j);
+					new (latency) NativeLatencyHistogram();
+					new (counters) NativeCounters();
+				}
+				new (&workerStatsSlot(i, j)) WorkflowStatistics(latency, counters);
 			}
 		}
 		for (auto i = 0; i < num_processes; i++) {

--- a/bindings/c/test/mako/stats.hpp
+++ b/bindings/c/test/mako/stats.hpp
@@ -34,6 +34,7 @@
 #include <utility>
 #include "flow/Platform.h"
 #include "mako/mako.hpp"
+#include "native_latency.hpp"
 #include "operations.hpp"
 #include "time.hpp"
 #include "ddsketch.hpp"
@@ -100,9 +101,12 @@ class alignas(64) WorkflowStatistics {
 	std::array<uint64_t, MAX_OP> latency_samples;
 	std::array<uint64_t, MAX_OP> latency_us_total;
 	std::vector<DDSketchMako> sketches;
+	NativeLatencyHistogram* live_latency;
+	NativeCounters* live_counters;
 
 public:
-	WorkflowStatistics() noexcept {
+	WorkflowStatistics(NativeLatencyHistogram* live_latency = nullptr, NativeCounters* live_counters = nullptr) noexcept
+	  : live_latency(live_latency), live_counters(live_counters) {
 		std::fill(ops.begin(), ops.end(), 0);
 		std::fill(errors.begin(), errors.end(), 0);
 		std::fill(timeouts.begin(), timeouts.end(), 0);
@@ -137,6 +141,8 @@ public:
 	uint64_t percentile(int op, double quantile) { return sketches[op].percentile(quantile); }
 
 	uint64_t mean(int op) const noexcept { return sketches[op].mean(); }
+	NativeLatencyHistogram const* liveLatency() const noexcept { return live_latency; }
+	NativeCounters const* liveCounters() const noexcept { return live_counters; }
 
 	// with 'this' as final aggregation, factor in 'other'
 	void combine(const WorkflowStatistics& other) {
@@ -153,19 +159,57 @@ public:
 		}
 	}
 
-	void incrConflictCount() noexcept { conflicts++; }
+	void incrConflictCount() noexcept {
+		conflicts++;
+		if (live_counters) {
+			live_counters->conflicts.fetch_add(1, std::memory_order_relaxed);
+		}
+	}
 
 	// non-commit write operations aren't measured for time.
-	void incrOpCount(int op) noexcept { ops[op]++; }
+	void incrOpCount(int op) noexcept {
+		ops[op]++;
+		if (live_counters) {
+			switch (op) {
+			case OP_TRANSACTION:
+				live_counters->completed_transactions.fetch_add(1, std::memory_order_relaxed);
+				break;
+			case OP_GET:
+				live_counters->reads.fetch_add(1, std::memory_order_relaxed);
+				break;
+			case OP_UPDATE:
+				live_counters->reads.fetch_add(1, std::memory_order_relaxed);
+				live_counters->writes.fetch_add(1, std::memory_order_relaxed);
+				break;
+			case OP_COMMIT:
+				live_counters->commits.fetch_add(1, std::memory_order_relaxed);
+				break;
+			default:
+				break;
+			}
+		}
+	}
+
+	void incrTransactionAttempt() noexcept {
+		if (live_counters) {
+			live_counters->attempted_transactions.fetch_add(1, std::memory_order_relaxed);
+		}
+	}
 
 	void incrErrorCount(int op) noexcept {
 		total_errors++;
 		errors[op]++;
+		if (live_counters) {
+			live_counters->errors.fetch_add(1, std::memory_order_relaxed);
+		}
 	}
 
 	void incrTimeoutCount(int op) noexcept {
 		total_timeouts++;
 		timeouts[op]++;
+		if (live_counters) {
+			live_counters->timeouts.fetch_add(1, std::memory_order_relaxed);
+		}
 	}
 
 	void addLatency(int op, timediff_t diff) noexcept {
@@ -173,6 +217,9 @@ public:
 		latency_samples[op]++;
 		sketches[op].addSample(latency_us);
 		latency_us_total[op] += latency_us;
+		if (live_latency && (op == OP_GET || op == OP_COMMIT)) {
+			live_latency->add(op == OP_GET ? 0 : 1, latency_us);
+		}
 	}
 
 	void subtractCounters(const WorkflowStatistics& baseline) noexcept {


### PR DESCRIPTION
Mako currently reports live throughput to stdout and sampled latency only through process-private data, so a workload scraper cannot read client-side throughput and latency during a run. Add opt-in `--prometheus_port=PORT` (disabled by default) to serve `/metrics` from Mako's stats process. Per-worker shared-memory atomics expose completed and attempted transactions, GET/UPDATE client API steps, commits, conflicts, errors, timeouts, and estimated logical bytes. A bounded cumulative histogram exports successful sampled GET and COMMIT latency in seconds for Prometheus `rate` and `histogram_quantile`. The endpoint also reports configured workers, sampling, and job/workload labels; stdout interval latency JSON is removed.

The exporter allocates shared histogram/counter storage only when enabled. Roughly 250 finite latency buckets per operation provide about 4.4% width from 100 µs through 1 s; production dashboards should scope by pod and account for this series count.

Validation: focused CTest covers cross-process aggregation, cumulative histogram bounds, HTTP 200/404, and occupied-port failure; changed Mako and async translation units compile, clang-format dry-run and whitespace checks pass. 
