### PR TITLE
Upgrade RocksDB from 8.11.4 to 8.11.5

### DIFF
--- a/cmake/RocksDBVersion.cmake
+++ b/cmake/RocksDBVersion.cmake
@@ -16,8 +16,8 @@
 # OPTION 1: RocksDB Release Number
 # If you use this option, make sure Option 2 below is commented out.
 ###############################################################################
-set(ROCKSDB_VERSION "8.11.4")
-set(ROCKSDB_VERSION_SHA256 "1b84c7d7214360fd536349917c57ebd5030d5b4fc214a343ba628b0c6e3d2711")
+set(ROCKSDB_VERSION "8.11.5")
+set(ROCKSDB_VERSION_SHA256 "2641eb63ee2d691c0e96de0a55edfcc4cab181d9b6c31fa4a33c478423062196")
 
 ###############################################################################
 # OPTION 2: RocksDB Git Commit Hash


### PR DESCRIPTION
Upgrade RocksDB from 8.11.4 to 8.11.5( which is a one-way path and cannot be downgraded)

100K simulation: (1 unrelated failure)
20260912-031925-neethuhaneeshabingi-e7a03a3d46217a05 compressed=True data_size=41742448 duration=3930882 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:29:12 sanity=False started=100000 stopped=20260912-034837 submitted=20260912-031925 timeout=5400 username=neethuhaneeshabingi


