### PR TITLE
Avoid RocksDB WAL preallocation in simulation

### DIFF
--- a/fdbserver/kvstore/KeyValueStoreShardedRocksDB.cpp
+++ b/fdbserver/kvstore/KeyValueStoreShardedRocksDB.cpp
@@ -730,6 +730,8 @@ rocksdb::DBOptions getOptions() {
 	options.max_open_files = SERVER_KNOBS->SHARDED_ROCKSDB_MAX_OPEN_FILES;
 	options.delete_obsolete_files_period_micros = SERVER_KNOBS->ROCKSDB_DELETE_OBSOLETE_FILE_PERIOD * 1000000;
 	options.max_total_wal_size = SERVER_KNOBS->ROCKSDB_MAX_TOTAL_WAL_SIZE;
+	// Preallocating WAL space for many simulated databases can exhaust the test tmpfs before the data is written.
+	options.allow_fallocate = !g_network->isSimulated();
 	options.max_subcompactions = SERVER_KNOBS->SHARDED_ROCKSDB_MAX_SUBCOMPACTIONS;
 	options.max_background_jobs = SERVER_KNOBS->SHARDED_ROCKSDB_MAX_BACKGROUND_JOBS;
 


### PR DESCRIPTION
## Problem

Sharded RocksDB simulations can open many databases. RocksDB preallocates space for each write-ahead log even when the log is nearly empty. A simulation with many databases can exhaust a RAM-backed test directory, causing trace writes to fail with `ENOSPC` and the test to time out.

## Change

Disable RocksDB file preallocation during simulation. Non-simulation runs retain the existing behavior; simulated WALs still write their actual contents.

## Validation

An equivalent change on the 7.4 code path built successfully, and the `DataLossRecovery` simulation reproducer passed under constrained scratch space without error-level trace events.
