### PR TITLE
Keep draining storage after exhausting the clear-range budget

### DIFF
--- a/fdbserver/storageserver/storageserver.cpp
+++ b/fdbserver/storageserver/storageserver.cpp
@@ -11215,9 +11215,10 @@ Future<Void> updateStorage(StorageServer* data) {
 		++data->counters.kvCommits;
 		recentCommitStats.back().seqId = data->counters.kvCommits.getValue();
 
-		// If the mutation bytes budget was not fully used then wait some time before the next commit
-		durableDelay =
-		    (bytesLeft > 0) ? delay(SERVER_KNOBS->STORAGE_COMMIT_INTERVAL, TaskPriority::UpdateStorage) : Void();
+		// Batch only while both budgets have capacity; otherwise keep draining pending mutations.
+		durableDelay = (bytesLeft > 0 && clearRangesLeft > 0)
+		                   ? delay(SERVER_KNOBS->STORAGE_COMMIT_INTERVAL, TaskPriority::UpdateStorage)
+		                   : Void();
 
 		recentCommitStats.back().whenCommit = now();
 		try {


### PR DESCRIPTION
Storage commits stop batching when either the mutation-byte budget or the RocksDB clear-range budget is exhausted. The next-commit delay previously checked only the byte budget, so clear-heavy backlogs could incur the normal commit interval even while eligible mutations remained.

Require capacity in both budgets before applying that delay. This preserves the existing per-commit limits and whole-version batching, and lets clear-limited commits keep draining as byte-limited commits already do.

Validation:

- All 7 `fdbserver_storageserver_test` tests passed.
- `tests/slow/DDBalanceAndRemove.toml` passed with seed `1340522943`, buggify off and fault injection on.
- `tests/fast/RocksdbNondeterministicTest.toml` passed with the same seed and fault injection on, with buggify both off and on.
- A same-worker public-base/candidate comparison used identical workload files, build settings and relevant knobs. Both passed. Corresponding storage servers received within 1% of the same bytes and clear mutations, while peak queued bytes fell from approximately 177–210 MB to 42–55 MB. Sampled commits exercised the exhausted-clear/spare-byte condition. This is one simulation comparison; changing waits also changes the simulation schedule.
